### PR TITLE
Improve OpenEvolve launcher setup, run performance eval for speedup, and standardize task result output

### DIFF
--- a/agents/openevolve/agent_config_amd_claude.yaml
+++ b/agents/openevolve/agent_config_amd_claude.yaml
@@ -2,8 +2,9 @@
 # OpenEvolve Agent Configuration for AgentKernelArena - AMD Claude API
 # ============================================================================
 
-max_iterations: 10
+max_iterations: 5
 checkpoint_interval: 5
+max_code_length: 50000
 timeout_seconds: 600
 
 # ============================================================================
@@ -23,7 +24,7 @@ llm:
 # Database Configuration
 # ============================================================================
 database:
-  population_size: 50
+  population_size: 30
   num_islands: 2
   log_prompts: false
 
@@ -31,7 +32,7 @@ database:
 # Evaluator Configuration
 # ============================================================================
 evaluator:
-  timeout: 120
+  timeout: 600
   parallel_evaluations: 1
   cascade_evaluation: false
 

--- a/agents/openevolve/agent_setup.sh
+++ b/agents/openevolve/agent_setup.sh
@@ -1,8 +1,10 @@
 # Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
-git clone https://github.com/AMD-AGI/GEAK-agent geak-openevolve && git checkout geak-openevolve 
+git clone https://github.com/AMD-AGI/GEAK-agent geak-openevolve 
 cd geak-openevolve
+git checkout geak-openevolve
+pip install -e .
 
-git clone git@github.com:AMD-AGI/GEAK-eval.git GEAK-eval-OE
+git clone https://github.com/AMD-AGI/GEAK-eval.git GEAK-eval-OE
 cd GEAK-eval-OE 
 git checkout geak-oe 
 pip install -e . --no-deps 


### PR DESCRIPTION
# Improve OpenEvolve launcher setup, run performance eval for speedup, and standardize task result output

## What this PR changes
This PR updates the `openevolve` agent integration to make setup and evaluation behavior consistent and to emit richer task results.

1. **Adds `ensure_openevolve_setup()` in `agents/openevolve/launch_agent.py`**
   - Detects whether local `geak-openevolve` package + `GEAK-eval-OE` exist.
   - If missing, automatically runs `agents/openevolve/agent_setup.sh`.
   - Switches OpenEvolve imports to dynamic import after setup (`importlib`) to avoid import-time failures.

2. **Fixes OpenEvolve setup script in `agents/openevolve/agent_setup.sh`**
   - Uses HTTPS clone URLs.
   - Checks out required branches.
   - Installs both repos in editable mode to make modules importable in launcher execution.

3. **Executes `performance_command` during evaluator runs**
   - Previously performance command existed in task config but was not used by the OpenEvolve evaluator path.
   - Evaluator now runs performance commands after compile/correctness and captures outputs.
   - Parses perf timing from `perf/*.json` (`ms` fields) or falls back to stdout/stderr time parsing.

4. **Adds baseline/optimized timing + speedup computation**
   - Records:
     - `base_execution_time`
     - `best_optimized_execution_time`
     - `speedup`
   - Uses baseline vs current best timing and updates combined score accordingly.

5. **Updates `task_result.yaml` writing logic**
   - Writes standard fields expected by downstream flow, including:
     - `best_optimized_source_file_path`
     - `best_optimized_kernel_functions`
     - `pass_compilation`, `compilation_error_message`
     - `pass_correctness`, `correctness_error_message`
     - timing fields + `speedup_ratio`
   - Improves failure-path result writing with explicit error messages.

6. **Tunes OpenEvolve config defaults (`agent_config_amd_claude.yaml`)**
   - Adjusts iteration/population/timeouts and adds `max_code_length`.
   - Uses `agent_config_amd_claude.yaml` as launcher config source.