### PR TITLE
Fix instruction2triton/rocmbench: Remove dependency on tb_eval and add performance_utils_pytest.py files

### DIFF
--- a/tasks/instruction2triton/rocmbench/gemm/config.yaml
+++ b/tasks/instruction2triton/rocmbench/gemm/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 gemm.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -116,7 +116,6 @@ prompt:
     \ tl.cdiv(N, BLOCK_SIZE_N)`.\n                                Used for PID remapping\
     \ across XCDs.\n    \"\"\"\n    # Your code here.\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_kernel

--- a/tasks/instruction2triton/rocmbench/gemm/gemm.py
+++ b/tasks/instruction2triton/rocmbench/gemm/gemm.py
@@ -662,9 +662,11 @@ def test_performance(M, N, K, col_a, col_b, in_dtype_a_str, in_dtype_b_str, out_
         "triton_scale_mode": current_scale_a8_b8, "activation": current_activation
     }
 
+    baseline_callable = lambda: torch.matmul(a, b)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_gemm_gbps,
-                              tflops_calculator=calculate_gemm_tflops)
+                              tflops_calculator=calculate_gemm_tflops,
+                              baseline_callable=baseline_callable)
   
 def get_type(provider):  
     res = re.findall(r'\(.*?\)', provider)  

--- a/tasks/instruction2triton/rocmbench/gemm/gemm.py
+++ b/tasks/instruction2triton/rocmbench/gemm/gemm.py
@@ -286,7 +286,11 @@ import sys
 import argparse  
 import pytest  
 import re  
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict  
 ######################################## HELPERS for Eval ######################################## 
 import numpy as np
@@ -589,15 +593,19 @@ def test_correctness(M, N, K, col_a, col_b, in_dtype_a, in_dtype_b, out_dtype, r
         sanitized_key_name = test_case_name.replace("::", "_").replace("[", "_").replace("]", "").replace("-", "_")
         result_gold[sanitized_key_name] = c.to(torch.float32).clone().detach().cpu()
         ###################################################################
-        # torch.testing.assert_close(c.to(torch.float32),  
-        #                            torch_output.to(torch.int8).to(torch.float32), atol=1e-3, rtol=1e-2)  
+        torch.testing.assert_close(
+            c.to(torch.float32),
+            torch_output.to(torch.int8).to(torch.float32),
+            atol=1e-3,
+            rtol=1e-2,
+        )
     else:  
         ################### save c in result_gold ###################
         test_case_name = request.node.name
         sanitized_key_name = test_case_name.replace("::", "_").replace("[", "_").replace("]", "").replace("-", "_")
         result_gold[sanitized_key_name] = c.clone().detach().cpu()
         ###################################################################
-        # torch.testing.assert_close(c, torch_output.to(torch_out_dtype), atol=5e-3, rtol=1e-2)  
+        torch.testing.assert_close(c, torch_output.to(torch_out_dtype), atol=5e-3, rtol=1e-2)
   
 OP_NAME_FOR_BENCHMARK = "gemm_triton_perf"
 

--- a/tasks/instruction2triton/rocmbench/gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/gemm/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/layernorm/config.yaml
+++ b/tasks/instruction2triton/rocmbench/layernorm/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 layernorm.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -72,7 +72,6 @@ prompt:
     \ This influences how data is  \n                                 loaded and processed\
     \ in parallel within a row.  \n  \"\"\"  \n    # Your code here.\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - layernorm_kernel

--- a/tasks/instruction2triton/rocmbench/layernorm/layernorm.py
+++ b/tasks/instruction2triton/rocmbench/layernorm/layernorm.py
@@ -455,9 +455,11 @@ def test_performance(M, N, dtype_str, request):
         "M": M, "N": N, "eps": eps, "dtype_str": dtype_str
     }
 
+    baseline_callable = lambda: torch.nn.functional.layer_norm(x, normalized_shape_arg, w, b, eps)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_layernorm_gbps,
-                              tflops_calculator=calculate_layernorm_tflops)
+                              tflops_calculator=calculate_layernorm_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/layernorm/layernorm.py
+++ b/tasks/instruction2triton/rocmbench/layernorm/layernorm.py
@@ -122,7 +122,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -252,7 +256,7 @@ class LayerNorm(torch.autograd.Function):
         # heuristics for number of warps  
         num_warps = min(max(BLOCK_SIZE // 256, 1), 8)  
         # layernorm_kernel[(M, )](x, y, weight, bias, mean, rstd, x.stride(0), y.stride(0), M, N, eps, BLOCK_SIZE)  
-        grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE']), triton.cdiv(N, meta['BLOCK_SIZE']))  
+        grid = (M,)
         layernorm_wrapper_fn(grid, x, y, weight, bias, mean, rstd,  
                              x.stride(0), y.stride(0), M, N, M, N, eps, BLOCK_SIZE)  
         # Save tensors for backward pass
@@ -349,6 +353,13 @@ def test_layernorm(M, N, request, eps=1e-5):
   
     #backward pass (torch)  
     y_ref.backward(dy, retain_graph=True)
+    dx_ref, dw_ref, db_ref = [_.grad.clone() for _ in [x, w, b]]
+
+    # Validate both forward and backward numerics.
+    torch.testing.assert_close(y_triton, y_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dx_tri, dx_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dw_tri, dw_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(db_tri, db_ref, atol=1e-2, rtol=1e-2)
 
 
 # --- Define TFLOPS and GB/s calculators for LayerNorm Forward ---
@@ -405,7 +416,7 @@ OP_NAME_FOR_BENCHMARK = "layernorm_triton_fwd_perf"
 LAYERNORM_SHAPES_FOR_PERF = [
     (1823, 781), (2048, 2048), (8192, 8192), # Some medium to large
     (4096, 10240), # LLM typical
-    (1, 131072), (1, 89999), # Long sequence, batch 1
+    (1, 131072), # Long sequence, batch 1
     (128, 2048), (512, 4096)
 ]
 # Dtypes to test for performance
@@ -435,7 +446,7 @@ def test_performance(M, N, dtype_str, request):
     # --- Benchmarking ---
     # Autotuned kernels might benefit from fewer reps if tuning takes time,
     # but do_bench needs enough reps for stable measurement AFTER tuning.
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/layernorm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/layernorm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/layernorm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/layernorm/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/moe_gemm/config.yaml
+++ b/tasks/instruction2triton/rocmbench/moe_gemm/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 moe_gemm.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -45,7 +45,6 @@ prompt:
     \ to maintain consistency in block matrix  \n    multiplication across different\
     \ blocks processed by the same expert.  \n    \"\"\"  \n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - moe_gemm_kernel

--- a/tasks/instruction2triton/rocmbench/moe_gemm/moe_gemm.py
+++ b/tasks/instruction2triton/rocmbench/moe_gemm/moe_gemm.py
@@ -1,6 +1,7 @@
 # Copyright(C) [2025] Advanced Micro Devices, Inc. All rights reserved.
 import triton  
 import triton.language as tl  
+import torch
 
 
 class MetaData():  
@@ -219,7 +220,11 @@ import sys
 import triton.language as tl # Required for tl.constexpr in quantize_input and other places  
 
 
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 ######################################## HELPERS for Eval ######################################## 
 import numpy as np
@@ -890,7 +895,7 @@ def test_performance(M_orig, N, K, top_k, E, routed_weight, dtype_str, request):
     op_lambda = lambda: moe_gemm(a, b, c_for_kernel, metadata)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=10, repetition=50) # MoE can be slower
+    bench_config = do_bench_config(warm_up=10, repetition=100) # MoE can be slower
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/moe_gemm/moe_gemm.py
+++ b/tasks/instruction2triton/rocmbench/moe_gemm/moe_gemm.py
@@ -910,9 +910,13 @@ def test_performance(M_orig, N, K, top_k, E, routed_weight, dtype_str, request):
         "GROUP_SIZE_M": metadata.config['GROUP_SIZE_M'],
     }
 
+    # MoE dense baseline (b_indexed = b[topk_ids]) OOMs for large M (224+ GB).
+    # Sparse routing is the entire point of MoE, so no PyTorch baseline is applicable.
+    baseline_callable = None
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_moe_gemm_gbps,
-                              tflops_calculator=calculate_moe_gemm_tflops)
+                              tflops_calculator=calculate_moe_gemm_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/moe_gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/moe_gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/moe_gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/moe_gemm/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/config.yaml
+++ b/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/config.yaml
@@ -7,7 +7,7 @@ performance_command:
 - pytest -vv -x --maxfail=1 multreduce_matmul_dot_kernel.py -k "test_performance or
   test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -65,7 +65,6 @@ prompt:
     \       allowing for potentially more efficient, unmasked loads along the K dimension.\n\
     \"\"\"\n# Your code here.\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - triton_dot_matmul_kernel

--- a/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/multreduce_matmul_dot_kernel.py
+++ b/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/multreduce_matmul_dot_kernel.py
@@ -155,7 +155,11 @@ import torch
 from torch import Tensor  
 import triton  
 import triton.language as tl  
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -400,7 +404,7 @@ def test_performance(M: int, N: int, K: int, use_bias: bool, dtype_str: str, req
     op_lambda = lambda: triton_matmul("triton-dot", a, b, bias)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/multreduce_matmul_dot_kernel.py
+++ b/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/multreduce_matmul_dot_kernel.py
@@ -414,9 +414,11 @@ def test_performance(M: int, N: int, K: int, use_bias: bool, dtype_str: str, req
         "provider": "triton-dot"
     }
 
+    baseline_callable = lambda: torch_matmul(a, b, bias)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_gemm_gbps,
-                              tflops_calculator=calculate_gemm_tflops)
+                              tflops_calculator=calculate_gemm_tflops,
+                              baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/multreduce_matmul_dot_kernel/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/naive_softmax/config.yaml
+++ b/tasks/instruction2triton/rocmbench/naive_softmax/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 naive_softmax.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -57,7 +57,6 @@ prompt:
     \ + row_idx * row_stride\n    output_ptrs = output_row_start_ptr + col_offsets\n\
     \    tl.store(output_ptrs, softmax_output, mask=mask)\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - softmax_kernel_naive

--- a/tasks/instruction2triton/rocmbench/naive_softmax/naive_softmax.py
+++ b/tasks/instruction2triton/rocmbench/naive_softmax/naive_softmax.py
@@ -318,9 +318,11 @@ def test_performance(M, N, dtype_str, request): # Renamed from test_softmax
         "LOGGED_BLOCK_SIZE_heuristic": BLOCK_SIZE_log # Log the heuristic block size
     }
 
+    baseline_callable = lambda: torch.softmax(x, dim=1)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_softmax_fwd_gbps,
-                              tflops_calculator=calculate_softmax_fwd_tflops)
+                              tflops_calculator=calculate_softmax_fwd_tflops,
+                              baseline_callable=baseline_callable)
 
 
 def model_benchmark_configs(args):

--- a/tasks/instruction2triton/rocmbench/naive_softmax/naive_softmax.py
+++ b/tasks/instruction2triton/rocmbench/naive_softmax/naive_softmax.py
@@ -43,7 +43,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -296,7 +300,7 @@ def test_performance(M, N, dtype_str, request): # Renamed from test_softmax
     op_lambda = lambda: softmax(x)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/naive_softmax/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/naive_softmax/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/naive_softmax/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/naive_softmax/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/rmsnorm_bwd/config.yaml
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_bwd/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 rmsnorm_bwd.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -82,7 +82,6 @@ prompt:
     \    further processed by `_rmsnorm_bwd_dg_reduce` to sum contributions across\n\
     \    all rows to get the final dL/dg.\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - rms_bwd_kernel

--- a/tasks/instruction2triton/rocmbench/rmsnorm_bwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_bwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/rmsnorm_bwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_bwd/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/rmsnorm_bwd/rmsnorm_bwd.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_bwd/rmsnorm_bwd.py
@@ -157,7 +157,11 @@ import argparse
 import sys
 import pytest
 from itertools import product
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 import triton
@@ -721,7 +725,7 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, dtype_str, request):
     )
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/rmsnorm_fwd/config.yaml
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_fwd/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 rmsnorm_fwd.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -76,7 +76,6 @@ prompt:
     \          program instances. For example, program `pid` handles rows `pid, pid\
     \ + NUM_PRGMS, ...`.\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - rms_kernel

--- a/tasks/instruction2triton/rocmbench/rmsnorm_fwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_fwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/rmsnorm_fwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_fwd/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/rmsnorm_fwd/rmsnorm_fwd.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_fwd/rmsnorm_fwd.py
@@ -159,7 +159,11 @@ from itertools import product
 import triton
 import triton.language as tl
 
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 ######################################## HELPERS for Eval ######################################## 
@@ -483,7 +487,7 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, in_dtype_str, out_dtype_str, req
     )
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/rmsnorm_fwd/rmsnorm_fwd.py
+++ b/tasks/instruction2triton/rocmbench/rmsnorm_fwd/rmsnorm_fwd.py
@@ -499,9 +499,11 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, in_dtype_str, out_dtype_str, req
         "blk_size_fwd": blk_size_fwd, "USE_BLOCKED_fwd": USE_BLOCKED_fwd, "NUM_PRGMS_fwd": NUM_PRGMS_fwd
     }
 
+    baseline_callable = lambda: torch_rmsnorm_fwd(x, g, ZERO_CENTERED_GAMMA, current_dtype, eps)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_rmsnorm_fwd_gbps,
-                              tflops_calculator=calculate_rmsnorm_fwd_tflops)
+                              tflops_calculator=calculate_rmsnorm_fwd_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/softmax/config.yaml
+++ b/tasks/instruction2triton/rocmbench/softmax/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 softmax.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -73,7 +73,6 @@ prompt:
     \ constant and should ideally be a\n        power of 2 for efficiency (e.g., 1024,\
     \ 2048).\n    \"\"\"\n    # Your code here.\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - softmax_kernel_online

--- a/tasks/instruction2triton/rocmbench/softmax/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/softmax/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/softmax/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/softmax/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/softmax/softmax.py
+++ b/tasks/instruction2triton/rocmbench/softmax/softmax.py
@@ -96,7 +96,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -351,7 +355,7 @@ def test_performance(M, N, dtype_str, request): # Renamed from test_softmax
     op_lambda = lambda: softmax(x)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/softmax/softmax.py
+++ b/tasks/instruction2triton/rocmbench/softmax/softmax.py
@@ -373,9 +373,11 @@ def test_performance(M, N, dtype_str, request): # Renamed from test_softmax
         "LOGGED_BLOCK_SIZE_heuristic": BLOCK_SIZE_log # Log the heuristic block size
     }
 
+    baseline_callable = lambda: torch.softmax(x, dim=1)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_softmax_fwd_gbps,
-                              tflops_calculator=calculate_softmax_fwd_tflops)
+                              tflops_calculator=calculate_softmax_fwd_tflops,
+                              baseline_callable=baseline_callable)
 
 
 def model_benchmark_configs(args):

--- a/tasks/instruction2triton/rocmbench/test_add_kernel/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_add_kernel/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_add_kernel.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -43,7 +43,6 @@ prompt:
     \ in the Triton kernel. It should typically be a power of two.\n    \"\"\"\n \
     \   # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - add_kernel

--- a/tasks/instruction2triton/rocmbench/test_add_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_add_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_add_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_add_kernel/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_add_kernel/test_add_kernel.py
+++ b/tasks/instruction2triton/rocmbench/test_add_kernel/test_add_kernel.py
@@ -183,9 +183,14 @@ def test_performance(SIZE, BLOCK_SIZE_ARG, dtype_str, request): # Function accep
     # current_params_for_calculators = {"SIZE": SIZE, "BLOCK_SIZE": BLOCK_SIZE_ARG, "dtype_str": dtype_str}
 
 
+    # PyTorch baseline: element-wise addition
+    output_baseline = torch.empty_like(output)
+    baseline_callable = lambda: torch.add(x, y, out=output_baseline)
+
     benchmarker.run_benchmark(current_params_dict=current_params_for_calculators,
                               gbps_calculator=calculate_add_gbps,
-                              tflops_calculator=calculate_add_tflops)
+                              tflops_calculator=calculate_add_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_add_kernel/test_add_kernel.py
+++ b/tasks/instruction2triton/rocmbench/test_add_kernel/test_add_kernel.py
@@ -45,7 +45,11 @@ import os
 from numpy.random import RandomState
 import pytest
 from torch.testing import assert_close
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 import triton
@@ -166,7 +170,7 @@ def test_performance(SIZE, BLOCK_SIZE_ARG, dtype_str, request): # Function accep
     # The op_lambda passes BLOCK_SIZE_ARG (runtime value) as the kernel's `BLOCK_SIZE` (constexpr name)
     op_lambda = lambda: add_kernel[grid](*kernel_args, BLOCK_SIZE=BLOCK_SIZE_ARG)
 
-    bench_config = do_bench_config(warm_up=25, repetition=100) # Smaller for faster debug
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Smaller for faster debug
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_batched_vecmat/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_batched_vecmat/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_batched_vecmat.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -47,7 +47,6 @@ prompt:
     \ n dimension.\n    block_k\n        tl.constexpr: Tiling size for the k dimension\
     \ (reduction dimension).\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - batched_vecmat

--- a/tasks/instruction2triton/rocmbench/test_batched_vecmat/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_batched_vecmat/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_batched_vecmat/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_batched_vecmat/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_batched_vecmat/test_batched_vecmat.py
+++ b/tasks/instruction2triton/rocmbench/test_batched_vecmat/test_batched_vecmat.py
@@ -323,9 +323,11 @@ def test_performance(M, N, K, block_m, block_n, block_k, dtype_str, request):
         "dtype_str": dtype_str
     }
 
+    baseline_callable = lambda: torch.sum(A_tri[:, None, :] * B_tri, dim=2)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_batched_vecmat_gbps,
-                              tflops_calculator=calculate_batched_vecmat_tflops)
+                              tflops_calculator=calculate_batched_vecmat_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_batched_vecmat/test_batched_vecmat.py
+++ b/tasks/instruction2triton/rocmbench/test_batched_vecmat/test_batched_vecmat.py
@@ -57,7 +57,11 @@ import os
 import pytest
 from numpy.random import RandomState
 
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -308,7 +312,7 @@ def test_performance(M, N, K, block_m, block_n, block_k, dtype_str, request):
     op_lambda = lambda: batched_vecmat_triton_wrapper(A_tri, B_tri, block_m, block_n, block_k)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_block_copy/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_block_copy/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_block_copy.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -49,7 +49,6 @@ prompt:
     \ a block from a_ptr (with potential padding)\n    # and store it to b_ptr.\n\n\
     \    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - block_copy_kernel

--- a/tasks/instruction2triton/rocmbench/test_block_copy/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_block_copy/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_block_copy/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_block_copy/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_block_copy/test_block_copy.py
+++ b/tasks/instruction2triton/rocmbench/test_block_copy/test_block_copy.py
@@ -233,9 +233,14 @@ def test_performance(dtypes_str_tuple, n, padding_option, request, device='cuda'
         "BLOCK_SIZE": FIXED_BLOCK_SIZE_FOR_PERF # Log the fixed block size
     }
 
+    # PyTorch baseline: tensor copy
+    dst_baseline = torch.empty_like(a)
+    baseline_callable = lambda: dst_baseline.copy_(a)
+
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_block_copy_gbps,
-                              tflops_calculator=None) # TFLOPS not relevant
+                              tflops_calculator=None, # TFLOPS not relevant
+                              baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_block_copy/test_block_copy.py
+++ b/tasks/instruction2triton/rocmbench/test_block_copy/test_block_copy.py
@@ -30,7 +30,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -218,7 +222,7 @@ def test_performance(dtypes_str_tuple, n, padding_option, request, device='cuda'
     )
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=50, repetition=200) # Copy is fast
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Copy is fast
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_block_pointer_matmul.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -60,7 +60,6 @@ prompt:
     \ tl.constexpr\n        The depth of the tiles (common dimension K) processed\
     \ from A and B for the dot product.\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_no_scf_with_advance_kernel

--- a/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/test_block_pointer_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/test_block_pointer_matmul.py
@@ -41,7 +41,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -174,7 +178,7 @@ BPM_SHAPES_FOR_PERF = [
     (256, 64,  128),
     (128, 256, 64),
 ]
-BPM_DTYPES_FOR_PERF = ['fp16', 'fp32'] # Add bf16 if relevant
+BPM_DTYPES_FOR_PERF = ['fp16'] # fp32 can exceed shared-memory limits for some block shapes
 # num_warps is passed to launch but not a JIT param for this kernel.
 # It can influence scheduling. Let's fix it for perf or parametrize.
 BPM_NUM_WARPS_FOR_PERF = [4, 8]
@@ -206,7 +210,7 @@ def test_performance(shape, num_warps_arg, dtype_str, request, device='cuda'): #
     op_lambda = lambda: block_pointer_matmul_triton_wrapper(a, b, c, num_warps_arg)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/test_block_pointer_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_block_pointer_matmul/test_block_pointer_matmul.py
@@ -220,9 +220,11 @@ def test_performance(shape, num_warps_arg, dtype_str, request, device='cuda'): #
         "num_warps": num_warps_arg, "dtype_str": dtype_str
     }
 
+    baseline_callable = lambda: torch.matmul(a, b)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_block_matmul_gbps,
-                              tflops_calculator=calculate_block_matmul_tflops)
+                              tflops_calculator=calculate_block_matmul_tflops,
+                              baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_cast_matmul/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_cast_matmul/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_cast_matmul.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -59,7 +59,6 @@ prompt:
     \ to\n    potentially improve L2 cache locality.\n    \"\"\"\n    # Your code\
     \ here\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_kernel

--- a/tasks/instruction2triton/rocmbench/test_cast_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_cast_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_cast_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_cast_matmul/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_cast_matmul/test_cast_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_cast_matmul/test_cast_matmul.py
@@ -73,7 +73,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -281,7 +285,7 @@ def test_performance(M, K, N, a_dtype_str, b_dtype_str, c_dtype_str, dot_acc_tl_
     )
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_cast_matmul/test_cast_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_cast_matmul/test_cast_matmul.py
@@ -298,9 +298,11 @@ def test_performance(M, K, N, a_dtype_str, b_dtype_str, c_dtype_str, dot_acc_tl_
         "BLOCK_K": FIXED_BLOCK_K, "GROUP_M": FIXED_GROUP_M
     }
 
+    baseline_callable = lambda: torch.matmul(a.to(c_torch_dtype), b.to(c_torch_dtype))
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_cast_matmul_gbps,
-                              tflops_calculator=calculate_cast_matmul_tflops)
+                              tflops_calculator=calculate_cast_matmul_tflops,
+                              baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_chained_dot_fp8.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -80,7 +80,6 @@ prompt:
     \   Boolean flag indicating whether to use FP8 E4M3 precision and apply scaling.\
     \ Compile-time constant.\n    \"\"\"\n    # Your code here\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - _chained_dot

--- a/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/test_chained_dot_fp8.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/test_chained_dot_fp8.py
@@ -349,9 +349,11 @@ def test_performance(test_config, request):
         "BATCH": BATCH, "M_seqlen": M_seqlen, "N_kv_seqlen": N_kv_seqlen, "D_head": D_head,
         "dtype_str": dtype_str, "msize_arg": msize_arg
     }
+    baseline_callable = lambda: torch.matmul(torch.matmul(q_host, k_host.transpose(1, 2)), v_host_for_call.transpose(1, 2))
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_chained_dot_gbps,
-                              tflops_calculator=calculate_chained_dot_tflops)
+                              tflops_calculator=calculate_chained_dot_tflops,
+                              baseline_callable=baseline_callable)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/test_chained_dot_fp8.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_dot_fp8/test_chained_dot_fp8.py
@@ -97,7 +97,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 ########################## HELPER utils ##########################
 TORCH_HAS_FP8E4 = hasattr(torch, 'float8_e4m3fnuz')
@@ -336,7 +340,7 @@ def test_performance(test_config, request):
     )
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=10, repetition=50) # Adjust reps as needed
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Adjust reps as needed
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_chained_matmul/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_chained_matmul/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_chained_matmul.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -74,7 +74,6 @@ prompt:
     \   - Storing the resulting tile to the output tensor `out`\n\n    \"\"\"\n  \
     \  # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - chained_matmul_kernel

--- a/tasks/instruction2triton/rocmbench/test_chained_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_chained_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_matmul/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_chained_matmul/test_chained_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_matmul/test_chained_matmul.py
@@ -302,9 +302,11 @@ def test_performance(test_params_dict, dtype_str, request):
         "dtype_str": dtype_str
     }
 
+    baseline_callable = lambda: torch.matmul(torch.matmul(a, b.T), c_mat)
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                               gbps_calculator=calculate_chained_matmul_gbps,
-                              tflops_calculator=calculate_chained_matmul_tflops)
+                              tflops_calculator=calculate_chained_matmul_tflops,
+                              baseline_callable=baseline_callable)
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  
 def test_save_results():  

--- a/tasks/instruction2triton/rocmbench/test_chained_matmul/test_chained_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_chained_matmul/test_chained_matmul.py
@@ -55,7 +55,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -287,7 +291,7 @@ def test_performance(test_params_dict, dtype_str, request):
         block_m, block_n
     )
 
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_flashattention_fwd/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_flashattention_fwd/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_flashattention_fwd.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -80,7 +80,6 @@ prompt:
     \ the key/value sequence length dimension (N). Keys and values are loaded and\
     \ processed in blocks of this size.\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - flash_fwd_kernel

--- a/tasks/instruction2triton/rocmbench/test_flashattention_fwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_flashattention_fwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_flashattention_fwd/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_flashattention_fwd/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_flashattention_fwd/test_flashattention_fwd.py
+++ b/tasks/instruction2triton/rocmbench/test_flashattention_fwd/test_flashattention_fwd.py
@@ -144,7 +144,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -322,7 +326,7 @@ def test_performance(Z, H, N_CTX, D_HEAD, dtype_str, request):
 
     op_lambda = lambda: attention(q, k, v, sm_scale)
 
-    bench_config = do_bench_config(warm_up=10, repetition=50) 
+    bench_config = do_bench_config(warm_up=10, repetition=100) 
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_gemm_fusion/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_gemm_fusion/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_gemm_fusion.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -67,7 +67,6 @@ prompt:
     \   for the common dimension in A@B^T and the output column dimension\n      \
     \             for C and E.\n    \"\"\"\n    # Your code here\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - gemm_fusion_kernel

--- a/tasks/instruction2triton/rocmbench/test_gemm_fusion/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_fusion/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_gemm_fusion/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_fusion/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_gemm_fusion/test_gemm_fusion.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_fusion/test_gemm_fusion.py
@@ -270,9 +270,11 @@ def test_performance(test_params_dict, dtype_str, request):
         "dtype_str": dtype_str, "num_warps": num_warps_launch
     }
     
+    baseline_callable = lambda: torch.matmul(torch.matmul(A, B.T), C_mat)
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_gemm_fusion_gbps,
-                                            tflops_calculator=calculate_gemm_fusion_tflops)
+                                            tflops_calculator=calculate_gemm_fusion_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 

--- a/tasks/instruction2triton/rocmbench/test_gemm_fusion/test_gemm_fusion.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_fusion/test_gemm_fusion.py
@@ -67,7 +67,11 @@ import numpy as np
 import random
 import torch 
 import os
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -256,7 +260,7 @@ def test_performance(test_params_dict, dtype_str, request):
         block_m, block_n, num_warps_launch
     )
 
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_gemm_no_scf/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_gemm_no_scf/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_gemm_no_scf.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -69,7 +69,6 @@ prompt:
     \ traditional epilogue by\n        calculating destination pointers manually with\
     \ `tl.arange` and `tl.store`.\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_no_scf_kernel

--- a/tasks/instruction2triton/rocmbench/test_gemm_no_scf/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_no_scf/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_gemm_no_scf/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_no_scf/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_gemm_no_scf/test_gemm_no_scf.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_no_scf/test_gemm_no_scf.py
@@ -90,7 +90,11 @@ import itertools
 import re
 
 from torch.testing import assert_close
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 import triton
 import triton.language as tl
@@ -317,7 +321,7 @@ def test_performance(M, N, K, NUM_CTAS, NUM_WARPS, TRANS_A, TRANS_B, OUTPUT_TYPE
         NUM_WARPS, (OUTPUT_TYPE == "float16"), USE_TMA_EPILOGUE
     )
 
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_gemm_no_scf/test_gemm_no_scf.py
+++ b/tasks/instruction2triton/rocmbench/test_gemm_no_scf/test_gemm_no_scf.py
@@ -332,9 +332,11 @@ def test_performance(M, N, K, NUM_CTAS, NUM_WARPS, TRANS_A, TRANS_B, OUTPUT_TYPE
         "input_dtype_str": "fp16" # Hardcoded based on original test's a,b creation
     }
     
+    baseline_callable = lambda: torch.matmul(a_host, b_host)
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_gemm_no_scf_gbps,
-                                            tflops_calculator=calculate_gemm_no_scf_tflops)
+                                            tflops_calculator=calculate_gemm_no_scf_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_iv_dependent_matmul.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -64,7 +64,6 @@ prompt:
     \ advanced to prefetch/prepare for three iterations ahead.\n    \"\"\"\n    #\
     \ Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - iv_dependent_matmul

--- a/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/test_iv_dependent_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/test_iv_dependent_matmul.py
@@ -285,9 +285,11 @@ def test_performance(m_n_k_shape, block_config, kernel_type_str, input_dtype_str
         "num_stages": num_stages_launch, "num_warps": num_warps_launch
     }
     
+    baseline_callable = lambda: torch.matmul(a, b)
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_gemm_gbps,
-                                            tflops_calculator=calculate_gemm_tflops)
+                                            tflops_calculator=calculate_gemm_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/test_iv_dependent_matmul.py
+++ b/tasks/instruction2triton/rocmbench/test_iv_dependent_matmul/test_iv_dependent_matmul.py
@@ -81,7 +81,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -270,7 +274,7 @@ def test_performance(m_n_k_shape, block_config, kernel_type_str, input_dtype_str
         kernel_type_str, num_stages_launch, num_warps_launch
     )
 
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_kernel_dot/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_kernel_dot/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_kernel_dot.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -33,7 +33,6 @@ prompt:
     \ location in Z.\n        This tensor serves as both input and output.\n    \"\
     \"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - kernel_dot

--- a/tasks/instruction2triton/rocmbench/test_kernel_dot/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_dot/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_kernel_dot/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_dot/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_kernel_dot/test_kernel_dot.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_dot/test_kernel_dot.py
@@ -230,9 +230,14 @@ def test_performance(dtype_str, num_warps_launch, request):
         "num_warps": num_warps_launch
     }
     
+    # PyTorch baseline: matrix multiplication (matching correctness ref: torch.matmul(z_in, z_in))
+    Z_baseline = Z_tensor.clone()
+    baseline_callable = lambda: torch.matmul(Z_baseline, Z_baseline)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_kernel_dot_gbps,
-                                            tflops_calculator=calculate_kernel_dot_tflops)
+                                            tflops_calculator=calculate_kernel_dot_tflops,
+                                            baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_kernel_dot/test_kernel_dot.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_dot/test_kernel_dot.py
@@ -8,7 +8,6 @@ import pytest
 
 import triton
 import triton.language as tl
-from triton.backends.compiler import AttrsDescriptor
 from triton.compiler import ASTSource
 ######################################## Imports ########################################
 
@@ -33,11 +32,14 @@ import shutil
 import tempfile
 import os
 import pytest
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 import triton
 import triton.language as tl
-from triton.backends.compiler import AttrsDescriptor
 from triton.compiler import ASTSource
 
 result_gold = {}
@@ -93,14 +95,13 @@ except Exception:
 skip_if_no_target = pytest.mark.skipif(not TARGET_AVAILABLE, reason="Triton target not available (e.g., no GPU or CUDA/ROCm setup)")
 
 @skip_if_no_target
-def compile_kernel_dot_for_test(attrs): # Renamed to be specific
+def compile_kernel_dot_for_test(): # Renamed to be specific
     # kernel_dot is defined globally above
-    src = ASTSource(fn=kernel_dot, signature={'Z': "*fp32"}, attrs=attrs, constants={})
+    src = ASTSource(fn=kernel_dot, signature={'Z': "*fp32"}, constexprs={})
     triton.compile(src=src, target=target)
 
 @skip_if_no_target
 def test_compile_kernel_dot_in_forked_subproc(fresh_triton_cache, request) -> None: # Test name updated for clarity
-    config = AttrsDescriptor.from_hints({0: 16})
     current_start_method = multiprocessing.get_start_method(allow_none=True)
     if current_start_method is None:
         try:
@@ -110,7 +111,7 @@ def test_compile_kernel_dot_in_forked_subproc(fresh_triton_cache, request) -> No
     if multiprocessing.get_start_method(allow_none=True) != 'fork':
         pytest.skip("Test requires 'fork' multiprocessing start method.")
 
-    proc = multiprocessing.Process(target=compile_kernel_dot_for_test, args=(config, ))
+    proc = multiprocessing.Process(target=compile_kernel_dot_for_test)
     proc.start()
     proc.join(timeout=60)
     if proc.is_alive():
@@ -139,6 +140,28 @@ def kernel_dot_triton_wrapper(Z_tensor, num_warps_launch):
     grid = (1,)
     kernel_dot[grid](Z_tensor, num_warps=num_warps_launch) # Z_tensor is modified in-place
     return Z_tensor # Return for consistency, though modified in-place
+
+
+@skip_if_no_target
+@pytest.mark.parametrize("dtype_str", ["fp32", "fp16"])
+def test_kernel_dot_numerical_correctness(dtype_str, request):
+    set_seed()
+    if dtype_str == "fp32":
+        current_dtype = torch.float32
+    else:
+        current_dtype = torch.float16
+
+    z = torch.randn((FIXED_DIM_FOR_KERNEL_DOT, FIXED_DIM_FOR_KERNEL_DOT), device="cuda", dtype=current_dtype)
+    z_in = z.clone()
+    out = kernel_dot_triton_wrapper(z, num_warps_launch=1)
+    ref = torch.matmul(z_in, z_in)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2, check_dtype=False)
+
+    result_gold["_CALL_SUCCESS_"] = torch.tensor([[1.0]])
+    test_case_name = request.node.name
+    sanitized_key_name = test_case_name.replace("::", "_").replace("[", "_").replace("]", "").replace("-", "_")
+    result_gold[sanitized_key_name] = out.clone().detach().cpu()
+
 
 # --- Define TFLOPS and GB/s calculators for the 16x16 dot product ---
 FIXED_DIM_FOR_KERNEL_DOT = 16
@@ -196,7 +219,7 @@ def test_performance(dtype_str, num_warps_launch, request):
     op_lambda = lambda: kernel_dot_triton_wrapper(Z_tensor, num_warps_launch)
 
     # --- Benchmarking ---
-    bench_config = do_bench_config(warm_up=100, repetition=1000) # Kernel is tiny, need more reps
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Kernel is tiny, need more reps
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_kernel_sub/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_kernel_sub/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_kernel_sub.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -37,7 +37,6 @@ prompt:
     \   to the block size or a dimension of the tensors.\n    \"\"\"\n    # Your code\
     \ here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - kernel_sub

--- a/tasks/instruction2triton/rocmbench/test_kernel_sub/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_sub/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_kernel_sub/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_sub/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_kernel_sub/test_kernel_sub.py
+++ b/tasks/instruction2triton/rocmbench/test_kernel_sub/test_kernel_sub.py
@@ -239,9 +239,14 @@ def test_performance(N_val, dtype_str, num_warps_launch, request):
         "num_warps": num_warps_launch
     }
     
+    # PyTorch baseline: element-wise subtraction (matching correctness ref: a - b * 777)
+    output_baseline = torch.empty_like(o_buffer)
+    baseline_callable = lambda: torch.sub(a, b * 777, out=output_baseline)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_kernel_sub_gbps,
-                                            tflops_calculator=calculate_kernel_sub_tflops)
+                                            tflops_calculator=calculate_kernel_sub_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_load_reduce/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_load_reduce/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_load_reduce.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -53,7 +53,6 @@ prompt:
     \   and it's the dimension over which the reduction (max) is performed.\n    \"\
     \"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - load_reduce_kernel

--- a/tasks/instruction2triton/rocmbench/test_load_reduce/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_load_reduce/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_load_reduce/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_load_reduce/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_load_reduce/test_load_reduce.py
+++ b/tasks/instruction2triton/rocmbench/test_load_reduce/test_load_reduce.py
@@ -45,7 +45,11 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -194,7 +198,7 @@ def test_performance(block_m_const, block_n_const, dtype_str, request): # Added 
         # , num_warps_launch # if num_warps is added to wrapper
     )
 
-    bench_config = do_bench_config(warm_up=50, repetition=200) # Reduction can be fast
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Reduction can be fast
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_load_reduce/test_load_reduce.py
+++ b/tasks/instruction2triton/rocmbench/test_load_reduce/test_load_reduce.py
@@ -208,9 +208,13 @@ def test_performance(block_m_const, block_n_const, dtype_str, request): # Added 
         # "num_warps": num_warps_launch # if parametrized
     }
     
+    # PyTorch baseline: max reduction along dim=1 (matching correctness ref: x.max(dim=1)[0])
+    baseline_callable = lambda: x.max(dim=1)[0]
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_load_reduce_gbps,
-                                            tflops_calculator=calculate_load_reduce_tflops)
+                                            tflops_calculator=calculate_load_reduce_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_matmul_MXFP/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_matmul_MXFP/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_matmul_MXFP.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -86,7 +86,6 @@ prompt:
     \        This is used to tile the processing of the output tensor.\n    \"\"\"\
     \n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_kernel,mxfp_to_bf16_kernel

--- a/tasks/instruction2triton/rocmbench/test_matmul_MXFP/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_matmul_MXFP/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_matmul_MXFP/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_matmul_MXFP/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_matmul_MXFP/test_matmul_MXFP.py
+++ b/tasks/instruction2triton/rocmbench/test_matmul_MXFP/test_matmul_MXFP.py
@@ -503,9 +503,11 @@ def test_performance(test_cfg_dict, request):
         "NUM_STAGES": num_stages_const, "num_warps": num_warps_launch
     }
     
+    baseline_callable = (lambda: torch.matmul(a_tensor.to(torch.float16), b_tensor.to(torch.float16))) if not is_scaled_mode else None
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_mxfp_matmul_gbps,
-                                            tflops_calculator=calculate_mxfp_matmul_tflops)
+                                            tflops_calculator=calculate_mxfp_matmul_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 

--- a/tasks/instruction2triton/rocmbench/test_matmul_MXFP/test_matmul_MXFP.py
+++ b/tasks/instruction2triton/rocmbench/test_matmul_MXFP/test_matmul_MXFP.py
@@ -4,7 +4,6 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-import triton.tools.experimental_descriptor
 ######################################## Imports ######################################## 
 
 
@@ -146,7 +145,11 @@ import pytest
 from numpy.random import RandomState
 
 result_gold = {}
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 ######################################## HELPERS for Eval ######################################## 
@@ -481,7 +484,7 @@ def test_performance(test_cfg_dict, request):
         num_warps_launch
     )
 
-    bench_config = do_bench_config(warm_up=10, repetition=50)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_randn/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_randn/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_randn.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -47,7 +47,6 @@ prompt:
     \ indexing/calculations (compile-time constant, e.g., tl.int32).\n    \"\"\"\n\
     \    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - randn_kernel_runtime_seed,randn_kernel_const_seed

--- a/tasks/instruction2triton/rocmbench/test_randn/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_randn/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_randn/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_randn/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_randn/test_randn.py
+++ b/tasks/instruction2triton/rocmbench/test_randn/test_randn.py
@@ -296,9 +296,13 @@ def test_performance(size_val, seed_val, offset_tl_dtype_str, const_seed_bool, r
         "num_warps": 4 # Log the fixed num_warps
     }
     
+    # PyTorch baseline: generate random uniform values [0, 1)
+    baseline_callable = lambda: torch.rand(size_val, dtype=torch.float32, device=device)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_randn_gbps,
-                                            tflops_calculator=calculate_randn_tflops)
+                                            tflops_calculator=calculate_randn_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_random_int/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_random_int/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_random_int.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -55,7 +55,6 @@ prompt:
     \                                to initialize its state.\n    \"\"\"\n    # Your\
     \ code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - randint_kernel_runtime_seed,randint_kernel_const_seed

--- a/tasks/instruction2triton/rocmbench/test_random_int/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_random_int/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_random_int/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_random_int/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_random_int/test_random_int.py
+++ b/tasks/instruction2triton/rocmbench/test_random_int/test_random_int.py
@@ -312,9 +312,13 @@ def test_performance(size_val, seed_val, output_dtype_str, const_seed_bool, requ
         "num_warps": 4 
     }
     
+    # PyTorch baseline: generate random integers
+    baseline_callable = lambda: torch.randint(0, 2**31, (size_val,), dtype=current_out_dtype, device=device)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_randint_gbps,
-                                            tflops_calculator=calculate_randint_tflops)
+                                            tflops_calculator=calculate_randint_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/test_reverse_range/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_reverse_range/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_reverse_range.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -44,7 +44,6 @@ prompt:
     \       receives the value from `in_ptr + 512`.\n    \"\"\"\n    # Your code here\n\
     \n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - reverse_range

--- a/tasks/instruction2triton/rocmbench/test_reverse_range/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_reverse_range/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_reverse_range/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_reverse_range/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_reverse_range/test_reverse_range.py
+++ b/tasks/instruction2triton/rocmbench/test_reverse_range/test_reverse_range.py
@@ -160,9 +160,13 @@ def test_performance(dtype_str, num_warps_launch, request, device='cuda'):
         "num_warps": num_warps_launch
     }
     
+    # PyTorch baseline: reverse 1D tensor (matching correctness ref: torch.flip(data[1:513], [0]))
+    baseline_callable = lambda: torch.flip(data_perf[1:KERNEL_FIXED_SIZE+1], [0])
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_reverse_range_gbps,
-                                            tflops_calculator=calculate_reverse_range_tflops)
+                                            tflops_calculator=calculate_reverse_range_tflops,
+                                            baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_reverse_range/test_reverse_range.py
+++ b/tasks/instruction2triton/rocmbench/test_reverse_range/test_reverse_range.py
@@ -23,7 +23,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -146,7 +150,7 @@ def test_performance(dtype_str, num_warps_launch, request, device='cuda'):
         data_perf, res_perf_buffer, num_warps_launch
     )
 
-    bench_config = do_bench_config(warm_up=100, repetition=1000) # Simple kernel, more reps
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Simple kernel, more reps
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_tma_store_gemm/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_tma_store_gemm/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_tma_store_gemm.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -76,7 +76,6 @@ prompt:
     \ it is stored\n                                   in the accumulation data type\
     \ (typically `tl.float32`).\n    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - matmul_tma_load_store

--- a/tasks/instruction2triton/rocmbench/test_tma_store_gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_tma_store_gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_tma_store_gemm/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_tma_store_gemm/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_tma_store_gemm/test_tma_store_gemm.py
+++ b/tasks/instruction2triton/rocmbench/test_tma_store_gemm/test_tma_store_gemm.py
@@ -263,9 +263,11 @@ def test_performance(M, N, K, NUM_CTAS_param, NUM_WARPS_param, TRANS_A, TRANS_B,
         "input_dtype_str": "fp16" # For the calculator
     }
     
+    baseline_callable = lambda: torch.matmul(a, b)
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_tma_gemm_gbps,
-                                            tflops_calculator=calculate_tma_gemm_tflops)
+                                            tflops_calculator=calculate_tma_gemm_tflops,
+                                            baseline_callable=baseline_callable)
 
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/instruction2triton/rocmbench/test_tma_store_gemm/test_tma_store_gemm.py
+++ b/tasks/instruction2triton/rocmbench/test_tma_store_gemm/test_tma_store_gemm.py
@@ -67,7 +67,11 @@ import torch
 import os
 import pytest
 from torch.testing import assert_close
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -247,7 +251,7 @@ def test_performance(M, N, K, NUM_CTAS_param, NUM_WARPS_param, TRANS_A, TRANS_B,
         OUTPUT_F16_param, NUM_WARPS_param
     )
 
-    bench_config = do_bench_config(warm_up=25, repetition=100)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_triton_flip/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_triton_flip/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_triton_flip.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -41,7 +41,6 @@ prompt:
     \ kernel instance.\n        The flip operation occurs along this dimension.\n\
     \    \"\"\"\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - flip_kernel

--- a/tasks/instruction2triton/rocmbench/test_triton_flip/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_flip/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_triton_flip/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_flip/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_triton_flip/test_triton_flip.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_flip/test_triton_flip.py
@@ -25,7 +25,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -189,7 +193,7 @@ def test_performance(N_const, M_const, dtype_str, num_warps_launch, request, dev
         x_perf_tensor, z_perf_buffer, N_const, M_const, num_warps_launch
     )
 
-    bench_config = do_bench_config(warm_up=100, repetition=1000) # Simple kernel
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Simple kernel
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_triton_sort/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_triton_sort/config.yaml
@@ -5,7 +5,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_triton_sort.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -42,7 +42,6 @@ prompt:
     \        If False, each row is sorted in ascending order.\n    \"\"\"\n\n    #\
     \ Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - sort_kernel

--- a/tasks/instruction2triton/rocmbench/test_triton_sort/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_sort/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_triton_sort/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_sort/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_triton_sort/test_triton_sort.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_sort/test_triton_sort.py
@@ -231,9 +231,13 @@ def test_performance(N_tile_rows, M_tile_cols, descending_val, dtype_str, reques
         "num_warps": 4 # Log the fixed num_warps
     }
     
+    # PyTorch baseline: sort along dim=1
+    baseline_callable = lambda: torch.sort(x_perf_tensor, dim=1, descending=descending_val)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_sort_gbps,
-                                            tflops_calculator=calculate_sort_tflops)
+                                            tflops_calculator=calculate_sort_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 

--- a/tasks/instruction2triton/rocmbench/test_triton_sort/test_triton_sort.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_sort/test_triton_sort.py
@@ -24,7 +24,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 
@@ -178,7 +182,7 @@ OP_NAME_FOR_BENCHMARK = "triton_sort_perf"
 # Kernel's N and M are constexpr, defining the tile size it processes.
 SORT_TILE_SHAPES_FOR_PERF = [
     # N_tile_rows, M_tile_cols (for the single tile processed by kernel)
-    (1, 1024), (1, 4096), (1, 8192), (1, 16384), # Sorting long single rows
+    (1, 1024), (1, 4096), (1, 8192), # Sorting long single rows
     (8, 512), (8, 1024), (8, 2048),             # Sorting a few medium rows
     (64, 128), (64, 256),            # Sorting more, shorter rows
     (256, 64), (256, 128), (256, 256)
@@ -215,7 +219,7 @@ def test_performance(N_tile_rows, M_tile_cols, descending_val, dtype_str, reques
         num_warps_launch=4 # Example, can be parametrized
     )
 
-    bench_config = do_bench_config(warm_up=50, repetition=200) # Sorting can vary
+    bench_config = do_bench_config(warm_up=10, repetition=100) # Sorting can vary
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/config.yaml
+++ b/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/config.yaml
@@ -6,7 +6,7 @@ correctness_command:
 performance_command:
 - pytest -vv -x --maxfail=1 test_triton_swizzle2d.py -k "test_performance or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -41,7 +41,6 @@ prompt:
     \ one dimension are\n            interleaved with elements from other groups.\
     \ Typically a power of 2.\n    \"\"\"\n    pass\n\n    # Your code here\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - swizzle2d_kernel

--- a/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/test_triton_swizzle2d.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/test_triton_swizzle2d.py
@@ -22,7 +22,11 @@ import torch
 import os
 import pytest
 from numpy.random import RandomState
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -167,7 +171,7 @@ def test_performance(size_i_k, size_j_k, size_g_k, output_dtype_str, request, de
     )
 
     # This kernel is very fast for small sizes, might need many reps.
-    bench_config = do_bench_config(warm_up=100, repetition=1000 if size_i_k*size_j_k < 256*256 else 200) 
+    bench_config = do_bench_config(warm_up=10, repetition=100) 
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/test_triton_swizzle2d.py
+++ b/tasks/instruction2triton/rocmbench/test_triton_swizzle2d/test_triton_swizzle2d.py
@@ -183,9 +183,15 @@ def test_performance(size_i_k, size_j_k, size_g_k, output_dtype_str, request, de
         "num_warps": 4 
     }
     
+    # PyTorch baseline: generate the expected swizzle2d output using arange + reshape
+    # The correctness test compares against a hardcoded expected_order tensor.
+    # The baseline generates a sequential index tensor (the input to swizzle mapping).
+    baseline_callable = lambda: torch.arange(size_i_k * size_j_k, dtype=current_out_dtype, device=device).reshape(size_i_k, size_j_k)
+
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_swizzle2d_gbps,
-                                            tflops_calculator=calculate_swizzle2d_tflops)
+                                            tflops_calculator=calculate_swizzle2d_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 ######################################## HELPERS for Eval ########################################     

--- a/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/config.yaml
+++ b/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/config.yaml
@@ -7,7 +7,7 @@ performance_command:
 - pytest -vv -x --maxfail=1 triton_multreduce_matmul_kernel.py -k "test_performance
   or test_save_performance_results"
 task_type: instruction2triton
-task_result_template: null
+task_result_template: task_result_template.yaml
 prompt:
   cheatsheet: null
   instructions: "\nYou are an expert in triton programming language. You will be given\
@@ -74,7 +74,6 @@ prompt:
     \ by BLOCK_SIZE_K,  \n                               allowing for unmasked loads\
     \ in the K loop.  \n    \"\"\"\n    # Your code here.\n\n\n"
   source_code: null
-source_file_path:
-- null
+source_file_path: []
 target_kernel_functions:
 - triton_multreduce_matmul_kernel

--- a/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/performance_utils_pytest.py
+++ b/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/performance_utils_pytest.py
@@ -1,0 +1,98 @@
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+@dataclass
+class BenchConfig:
+    warm_up: int = 10
+    repetition: int = 100
+
+
+def do_bench_config(warm_up: int = 10, repetition: int = 100) -> BenchConfig:
+    """Create a benchmark configuration object compatible with existing task code."""
+    return BenchConfig(warm_up=max(0, int(warm_up)), repetition=max(1, int(repetition)))
+
+
+_BENCHMARK_RESULTS: list[dict[str, Any]] = []
+
+
+def _sync_if_needed() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class PytestBenchmarker:
+    """Simple benchmark helper used by rocmbench pytest performance tests."""
+
+    def __init__(self, op_callable: Callable[[], Any], op_name: str, config: BenchConfig) -> None:
+        self.op_callable = op_callable
+        self.op_name = op_name
+        self.config = config
+
+    def run_benchmark(
+        self,
+        current_params_dict: dict[str, Any],
+        gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+    ) -> dict[str, Any]:
+        # Warmup first to avoid measuring one-time initialization effects.
+        for _ in range(self.config.warm_up):
+            self.op_callable()
+        _sync_if_needed()
+
+        times_ms: list[float] = []
+        for _ in range(self.config.repetition):
+            _sync_if_needed()
+            start = time.perf_counter()
+            self.op_callable()
+            _sync_if_needed()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+
+        times_ms_sorted = sorted(times_ms)
+        n = len(times_ms_sorted)
+        median_ms = times_ms_sorted[n // 2]
+        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
+        mean_ms = sum(times_ms_sorted) / n
+
+        result: dict[str, Any] = {
+            "op_name": self.op_name,
+            "params": current_params_dict,
+            "timing_ms": {
+                "mean": mean_ms,
+                "median": median_ms,
+                "p90": p90_ms,
+                "min": times_ms_sorted[0],
+                "max": times_ms_sorted[-1],
+                "repetition": self.config.repetition,
+                "warm_up": self.config.warm_up,
+            },
+        }
+
+        if gbps_calculator is not None:
+            try:
+                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["gbps_error"] = str(exc)
+        if tflops_calculator is not None:
+            try:
+                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+            except Exception as exc:
+                result["tflops_error"] = str(exc)
+
+        _BENCHMARK_RESULTS.append(result)
+        return result
+
+
+def save_all_benchmark_results(output_directory: str) -> None:
+    """Persist collected benchmark entries to a single JSON file."""
+    out_dir = Path(output_directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "benchmark_results.json"
+    out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
+

--- a/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
+++ b/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
@@ -156,7 +156,11 @@ import torch
 from torch import Tensor  
 import triton  
 import triton.language as tl  
-from tb_eval.perf.ROCm.performance_utils_pytest import PytestBenchmarker, do_bench_config, save_all_benchmark_results
+from performance_utils_pytest import (
+    PytestBenchmarker,
+    do_bench_config,
+    save_all_benchmark_results,
+)
 from typing import Dict
 
 result_gold = {}
@@ -496,7 +500,7 @@ def test_performance(m_n_k_shape, block_config, use_bias_flag, dtype_str,
         use_bias_flag, num_warps_val, num_stages_val
     )
 
-    bench_config = do_bench_config(warm_up=10, repetition=50)
+    bench_config = do_bench_config(warm_up=10, repetition=100)
     benchmarker = PytestBenchmarker(op_callable=op_lambda,
                                     op_name=OP_NAME_FOR_BENCHMARK,
                                     config=bench_config)

--- a/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
+++ b/tasks/instruction2triton/rocmbench/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
@@ -512,9 +512,11 @@ def test_performance(m_n_k_shape, block_config, use_bias_flag, dtype_str,
         "USE_DOT": False 
     }
     
+    baseline_callable = lambda: torch_matmul(a, b, bias)
     perf_result = benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
                                             gbps_calculator=calculate_gemm_gbps,
-                                            tflops_calculator=calculate_gemm_tflops)
+                                            tflops_calculator=calculate_gemm_tflops,
+                                            baseline_callable=baseline_callable)
 
 
 

--- a/tasks/triton2triton/rocmbench/easy/test_add_kernel/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_add_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_batched_vecmat/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_batched_vecmat/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_block_copy/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_block_copy/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_kernel_dot/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_kernel_dot/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_kernel_sub/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_kernel_sub/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_load_reduce/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_load_reduce/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_randn/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_randn/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_random_int/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_random_int/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_reverse_range/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_reverse_range/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/easy/test_triton_flip/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/easy/test_triton_flip/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/gemm/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/moe_gemm/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/moe_gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/multreduce_matmul_dot_kernel/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/multreduce_matmul_dot_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/rmsnorm_bwd/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/rmsnorm_bwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_block_pointer_matmul/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_block_pointer_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_chained_dot_fp8/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_chained_dot_fp8/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_flashattention_fwd/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_flashattention_fwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_gemm_fusion/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_gemm_fusion/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_matmul_MXFP/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_matmul_MXFP/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/test_tma_store_gemm/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/test_tma_store_gemm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/hard/triton_multreduce_matmul_kernel/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/hard/triton_multreduce_matmul_kernel/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/layernorm/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/layernorm/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/naive_softmax/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/naive_softmax/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/rmsnorm_fwd/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/rmsnorm_fwd/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/softmax/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/softmax/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_cast_matmul/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_cast_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_chained_matmul/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_chained_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_gemm_no_scf/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_gemm_no_scf/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_iv_dependent_matmul/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_iv_dependent_matmul/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_triton_sort/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_triton_sort/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-

--- a/tasks/triton2triton/rocmbench/medium/test_triton_swizzle2d/performance_utils_pytest.py
+++ b/tasks/triton2triton/rocmbench/medium/test_triton_swizzle2d/performance_utils_pytest.py
@@ -26,6 +26,38 @@ def _sync_if_needed() -> None:
         torch.cuda.synchronize()
 
 
+def _measure_times(callable_fn: Callable[[], Any], config: BenchConfig) -> list[float]:
+    """Run warmup + measured iterations and return list of times in ms."""
+    for _ in range(config.warm_up):
+        callable_fn()
+    _sync_if_needed()
+
+    times_ms: list[float] = []
+    for _ in range(config.repetition):
+        _sync_if_needed()
+        start = time.perf_counter()
+        callable_fn()
+        _sync_if_needed()
+        end = time.perf_counter()
+        times_ms.append((end - start) * 1000.0)
+    return times_ms
+
+
+def _compute_timing_stats(times_ms: list[float], config: BenchConfig) -> dict[str, Any]:
+    """Compute mean, median, p90, min, max from a list of times."""
+    times_sorted = sorted(times_ms)
+    n = len(times_sorted)
+    return {
+        "mean": sum(times_sorted) / n,
+        "median": times_sorted[n // 2],
+        "p90": times_sorted[min(n - 1, int(round(0.9 * (n - 1))))],
+        "min": times_sorted[0],
+        "max": times_sorted[-1],
+        "repetition": config.repetition,
+        "warm_up": config.warm_up,
+    }
+
+
 class PytestBenchmarker:
     """Simple benchmark helper used by rocmbench pytest performance tests."""
 
@@ -39,51 +71,40 @@ class PytestBenchmarker:
         current_params_dict: dict[str, Any],
         gbps_calculator: Callable[[dict[str, Any], float], float] | None = None,
         tflops_calculator: Callable[[dict[str, Any], float], float] | None = None,
+        baseline_callable: Callable[[], Any] | None = None,
     ) -> dict[str, Any]:
-        # Warmup first to avoid measuring one-time initialization effects.
-        for _ in range(self.config.warm_up):
-            self.op_callable()
-        _sync_if_needed()
-
-        times_ms: list[float] = []
-        for _ in range(self.config.repetition):
-            _sync_if_needed()
-            start = time.perf_counter()
-            self.op_callable()
-            _sync_if_needed()
-            end = time.perf_counter()
-            times_ms.append((end - start) * 1000.0)
-
-        times_ms_sorted = sorted(times_ms)
-        n = len(times_ms_sorted)
-        median_ms = times_ms_sorted[n // 2]
-        p90_ms = times_ms_sorted[min(n - 1, int(round(0.9 * (n - 1))))]
-        mean_ms = sum(times_ms_sorted) / n
+        # Measure the main (optimized/triton) operation.
+        times_ms = _measure_times(self.op_callable, self.config)
+        timing_stats = _compute_timing_stats(times_ms, self.config)
+        mean_ms = timing_stats["mean"]
 
         result: dict[str, Any] = {
             "op_name": self.op_name,
             "params": current_params_dict,
-            "timing_ms": {
-                "mean": mean_ms,
-                "median": median_ms,
-                "p90": p90_ms,
-                "min": times_ms_sorted[0],
-                "max": times_ms_sorted[-1],
-                "repetition": self.config.repetition,
-                "warm_up": self.config.warm_up,
-            },
+            "timing_ms": timing_stats,
         }
 
         if gbps_calculator is not None:
             try:
-                result["gbps"] = float(gbps_calculator(current_params_dict, median_ms))
+                result["gbps"] = float(gbps_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["gbps_error"] = str(exc)
         if tflops_calculator is not None:
             try:
-                result["tflops"] = float(tflops_calculator(current_params_dict, median_ms))
+                result["tflops"] = float(tflops_calculator(current_params_dict, mean_ms))
             except Exception as exc:
                 result["tflops_error"] = str(exc)
+
+        # Measure baseline (e.g. PyTorch reference) if provided.
+        if baseline_callable is not None:
+            baseline_times = _measure_times(baseline_callable, self.config)
+            baseline_stats = _compute_timing_stats(baseline_times, self.config)
+            result["baseline_timing_ms"] = baseline_stats
+            baseline_mean = baseline_stats["mean"]
+            if mean_ms > 0:
+                result["speedup_ratio"] = baseline_mean / mean_ms
+            else:
+                result["speedup_ratio"] = 1.0
 
         _BENCHMARK_RESULTS.append(result)
         return result
@@ -95,4 +116,3 @@ def save_all_benchmark_results(output_directory: str) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "benchmark_results.json"
     out_path.write_text(json.dumps(_BENCHMARK_RESULTS, indent=2, sort_keys=True), encoding="utf-8")
-


### PR DESCRIPTION
### Summary
This PR fixes instruction2triton/rocmbench issues based on task_validator.
## What changed

- Removed import from tb_eval and added standalone performance_utils_pytest.py files.
- Fixed correctness/perfromance evaluation issues based on task_evaluator feedback.