### PR TITLE
Timestamped reports, run-based workspace, and enhanced speedup metrics

### DIFF
--- a/compare_runs.py
+++ b/compare_runs.py
@@ -1,0 +1,358 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""
+Standalone script to compare two AgentKernelArena runs.
+
+Usage:
+    python compare_runs.py run1_path run2_path
+    python compare_runs.py workspace_MI300_cursor/run_20250115_143022 workspace_MI300_cursor/run_20250115_160530
+"""
+
+import json
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+
+def load_run_data(run_path: Path) -> Dict[str, Any]:
+    """
+    Load task_type_breakdown.json from a run directory.
+    
+    Args:
+        run_path: Path to run directory (e.g., workspace_MI300_cursor/run_20250115_143022)
+    
+    Returns:
+        Dictionary containing run data from JSON file
+    
+    Raises:
+        FileNotFoundError: If JSON file doesn't exist
+        json.JSONDecodeError: If JSON file is invalid
+    """
+    json_path = run_path / "reports" / "task_type_breakdown.json"
+    
+    if not json_path.exists():
+        raise FileNotFoundError(
+            f"task_type_breakdown.json not found in {run_path}/reports/\n"
+            f"Make sure the run directory contains a reports/ subdirectory with task_type_breakdown.json"
+        )
+    
+    with open(json_path, 'r') as f:
+        return json.load(f)
+
+
+def format_difference(value1: float, value2: float, is_percentage: bool = False) -> str:
+    """
+    Format the difference between two values.
+    
+    Args:
+        value1: First value (baseline)
+        value2: Second value (comparison)
+        is_percentage: If True, format as percentage change
+    
+    Returns:
+        Formatted string showing difference
+    """
+    diff = value2 - value1
+    if is_percentage:
+        if value1 == 0:
+            return f"{diff:+.1f}pp" if diff != 0 else "0.0pp"
+        pct_change = (diff / value1 * 100) if value1 != 0 else 0
+        return f"{diff:+.1f}pp ({pct_change:+.1f}%)"
+    else:
+        pct_change = (diff / value1 * 100) if value1 != 0 else 0
+        return f"{diff:+.3f} ({pct_change:+.1f}%)"
+
+
+def compare_overall(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> list:
+    """
+    Compare overall statistics between two runs.
+    
+    Returns:
+        List of formatted comparison lines
+    """
+    overall1 = run1_data.get('overall', {})
+    overall2 = run2_data.get('overall', {})
+    
+    lines = [
+        "=" * 80,
+        "OVERALL STATISTICS COMPARISON",
+        "=" * 80,
+        f"Run 1: {run1_data.get('run_timestamp', 'unknown')} ({run1_data.get('agent', 'unknown')})",
+        f"Run 2: {run2_data.get('run_timestamp', 'unknown')} ({run2_data.get('agent', 'unknown')})",
+        "=" * 80,
+        "",
+        f"{'Metric':<40} {'Run 1':<15} {'Run 2':<15} {'Difference':<20}",
+        "-" * 80,
+    ]
+    
+    metrics = [
+        ('Total Tasks', 'total_tasks', False),
+        ('Total Score', 'total_score', False),
+        ('Average Score', 'average_score', False),
+        ('Compilation Pass Rate', 'compilation_pass_rate', True),
+        ('Correctness Pass Rate', 'correctness_pass_rate', True),
+        ('Speedup > 1.0 Rate', 'speedup_gt_1_rate', True),
+        ('Average Speedup', 'average_speedup', False),
+    ]
+    
+    for label, key, is_percentage in metrics:
+        val1 = overall1.get(key, 0.0)
+        val2 = overall2.get(key, 0.0)
+        
+        if is_percentage:
+            fmt1 = f"{val1:.1f}%"
+            fmt2 = f"{val2:.1f}%"
+        elif key == 'total_tasks':
+            fmt1 = f"{int(val1)}"
+            fmt2 = f"{int(val2)}"
+        elif key == 'total_score':
+            fmt1 = f"{val1:.2f}"
+            fmt2 = f"{val2:.2f}"
+        else:
+            fmt1 = f"{val1:.3f}"
+            fmt2 = f"{val2:.3f}"
+        
+        diff_str = format_difference(val1, val2, is_percentage)
+        
+        # Determine if improvement (green) or regression (red) - for display purposes
+        if key in ['average_score', 'compilation_pass_rate', 'correctness_pass_rate', 
+                   'speedup_gt_1_rate', 'average_speedup']:
+            if val2 > val1:
+                indicator = "↑"
+            elif val2 < val1:
+                indicator = "↓"
+            else:
+                indicator = "="
+        else:
+            indicator = ""
+        
+        lines.append(f"{label:<40} {fmt1:<15} {fmt2:<15} {diff_str:<20} {indicator}")
+    
+    lines.append("")
+    return lines
+
+
+def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> list:
+    """
+    Compare task type breakdowns between two runs.
+    
+    Returns:
+        List of formatted comparison lines
+    """
+    types1 = run1_data.get('task_types', {})
+    types2 = run2_data.get('task_types', {})
+    
+    # Get all unique task types from both runs
+    all_types = set(types1.keys()) | set(types2.keys())
+    
+    if not all_types:
+        return ["No task type data available for comparison."]
+    
+    lines = [
+        "=" * 80,
+        "TASK TYPE BREAKDOWN COMPARISON",
+        "=" * 80,
+        "",
+    ]
+    
+    for task_type in sorted(all_types):
+        stats1 = types1.get(task_type, {})
+        stats2 = types2.get(task_type, {})
+        
+        count1 = stats1.get('count', 0)
+        count2 = stats2.get('count', 0)
+        
+        lines.append(f"{task_type.upper()} ({count1} tasks → {count2} tasks):")
+        lines.append("-" * 80)
+        
+        if count1 == 0 and count2 == 0:
+            lines.append("  No tasks in either run")
+            lines.append("")
+            continue
+        
+        # Compare key metrics
+        metrics = [
+            ('Average Speedup', 'average_speedup', False),
+            ('Compilation Pass Rate', 'compilation_pass_rate', True),
+            ('Correctness Pass Rate', 'correctness_pass_rate', True),
+            ('Speedup > 1.0 Rate', 'speedup_gt_1_rate', True),
+            ('Average Score', 'average_score', False),
+        ]
+        
+        for label, key, is_percentage in metrics:
+            val1 = stats1.get(key, 0.0)
+            val2 = stats2.get(key, 0.0)
+            
+            if count1 == 0:
+                fmt1 = "N/A"
+                diff_str = "N/A (new)"
+            elif count2 == 0:
+                fmt2 = "N/A"
+                diff_str = "N/A (removed)"
+            else:
+                if is_percentage:
+                    fmt1 = f"{val1:.1f}%"
+                    fmt2 = f"{val2:.1f}%"
+                elif key == 'average_score':
+                    fmt1 = f"{val1:.2f}"
+                    fmt2 = f"{val2:.2f}"
+                else:
+                    fmt1 = f"{val1:.3f}"
+                    fmt2 = f"{val2:.3f}"
+                
+                diff_str = format_difference(val1, val2, is_percentage)
+            
+            if count1 > 0 and count2 > 0:
+                if val2 > val1:
+                    indicator = "↑ (improved)"
+                elif val2 < val1:
+                    indicator = "↓ (regressed)"
+                else:
+                    indicator = "= (same)"
+            else:
+                indicator = ""
+            
+            if count1 == 0:
+                lines.append(f"  {label:<35} {'N/A':<15} {fmt2:<15} {diff_str:<20} {indicator}")
+            elif count2 == 0:
+                lines.append(f"  {label:<35} {fmt1:<15} {'N/A':<15} {diff_str:<20} {indicator}")
+            else:
+                lines.append(f"  {label:<35} {fmt1:<15} {fmt2:<15} {diff_str:<20} {indicator}")
+        
+        lines.append("")
+    
+    return lines
+
+
+def generate_comparison_report(run1_path: Path, run2_path: Path, output_path: Optional[Path] = None) -> str:
+    """
+    Generate a comparison report between two runs.
+    
+    Args:
+        run1_path: Path to first run directory
+        run2_path: Path to second run directory
+        output_path: Optional path to save report (if None, auto-generates in comparisons/ directory)
+    
+    Returns:
+        Comparison report as string
+    """
+    # Load data from both runs
+    try:
+        run1_data = load_run_data(run1_path)
+    except Exception as e:
+        return f"Error loading Run 1 data from {run1_path}:\n{str(e)}\n"
+    
+    try:
+        run2_data = load_run_data(run2_path)
+    except Exception as e:
+        return f"Error loading Run 2 data from {run2_path}:\n{str(e)}\n"
+    
+    # Generate comparison report
+    lines = [
+        "=" * 80,
+        "AgentKernelArena Run Comparison Report",
+        "=" * 80,
+        "",
+    ]
+    
+    lines.extend(compare_overall(run1_data, run2_data))
+    lines.extend(compare_task_types(run1_data, run2_data))
+    
+    lines.extend([
+        "=" * 80,
+        "Legend:",
+        "  ↑ = Improvement (higher is better)",
+        "  ↓ = Regression (lower is worse)",
+        "  = = No change",
+        "  pp = percentage points",
+        "=" * 80,
+    ])
+    
+    report = "\n".join(lines)
+    
+    # Determine output path
+    if output_path is None:
+        # Auto-generate path in comparisons/ directory at project root
+        # Extract run directory names (e.g., "run_20250115_143022" from full path)
+        run1_name = run1_path.name
+        run2_name = run2_path.name
+        
+        # Project root is the directory where compare_runs.py is located
+        project_root = Path(__file__).resolve().parent
+        
+        comparisons_dir = project_root / "comparisons"
+        comparisons_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Create filename: comparison_report_{run1}_{run2}.txt
+        filename = f"comparison_report_{run1_name}_{run2_name}.txt"
+        output_path = comparisons_dir / filename
+    
+    # Write to file
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w') as f:
+        f.write(report)
+    print(f"Comparison report written to: {output_path}")
+    
+    return report
+
+
+def main():
+    """Main entry point for comparison script."""
+    parser = argparse.ArgumentParser(
+        description="Compare two AgentKernelArena runs",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Compare two runs
+  python compare_runs.py workspace_MI300_cursor/run_20250115_143022 workspace_MI300_cursor/run_20250115_160530
+  
+  # Compare and save to file
+  python compare_runs.py run1 run2 --output comparison_report.txt
+        """
+    )
+    
+    parser.add_argument(
+        'run1',
+        type=str,
+        help='Path to first run directory (e.g., workspace_MI300_cursor/run_20250115_143022)'
+    )
+    
+    parser.add_argument(
+        'run2',
+        type=str,
+        help='Path to second run directory (e.g., workspace_MI300_cursor/run_20250115_160530)'
+    )
+    
+    parser.add_argument(
+        '--output', '-o',
+        type=str,
+        default=None,
+        help='Optional output file path for comparison report (if not specified, auto-generates in comparisons/ directory)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Convert to Path objects
+    run1_path = Path(args.run1).resolve()
+    run2_path = Path(args.run2).resolve()
+    
+    # Validate paths exist
+    if not run1_path.exists():
+        print(f"Error: Run 1 directory does not exist: {run1_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    if not run2_path.exists():
+        print(f"Error: Run 2 directory does not exist: {run2_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Generate and print comparison report
+    output_path = Path(args.output).resolve() if args.output else None
+    report = generate_comparison_report(run1_path, run2_path, output_path)
+    
+    # Print to stdout
+    print(report)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/compare_runs.py
+++ b/compare_runs.py
@@ -95,6 +95,9 @@ def compare_overall(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> lis
         ('Average Speedup', 'average_speedup', False),
         ('Median Speedup', 'median_speedup', False),
         ('Std Dev Speedup', 'std_dev_speedup', False),
+        ('P25 Speedup', 'p25_speedup', False),
+        ('P75 Speedup', 'p75_speedup', False),
+        ('P90 Speedup', 'p90_speedup', False),
     ]
     
     for label, key, is_percentage in metrics:
@@ -118,7 +121,8 @@ def compare_overall(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> lis
         
         # Determine if improvement (green) or regression (red) - for display purposes
         if key in ['average_score', 'compilation_pass_rate', 'correctness_pass_rate', 
-                   'speedup_gt_1_rate', 'average_speedup', 'median_speedup']:
+                   'speedup_gt_1_rate', 'average_speedup', 'median_speedup', 
+                   'p25_speedup', 'p75_speedup', 'p90_speedup']:
             if val2 > val1:
                 indicator = "↑"
             elif val2 < val1:
@@ -185,6 +189,9 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
             ('Average Speedup', 'average_speedup', False),
             ('Median Speedup', 'median_speedup', False),
             ('Std Dev Speedup', 'std_dev_speedup', False),
+            ('P25 Speedup', 'p25_speedup', False),
+            ('P75 Speedup', 'p75_speedup', False),
+            ('P90 Speedup', 'p90_speedup', False),
             ('Compilation Pass Rate', 'compilation_pass_rate', True),
             ('Correctness Pass Rate', 'correctness_pass_rate', True),
             ('Speedup > 1.0 Rate', 'speedup_gt_1_rate', True),
@@ -220,6 +227,14 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
                     if val2 < val1:
                         indicator = "↑ (improved)"
                     elif val2 > val1:
+                        indicator = "↓ (regressed)"
+                    else:
+                        indicator = "= (same)"
+                # For percentiles and other speedup metrics, higher is better
+                elif key in ['p25_speedup', 'p75_speedup', 'p90_speedup', 'average_speedup', 'median_speedup']:
+                    if val2 > val1:
+                        indicator = "↑ (improved)"
+                    elif val2 < val1:
                         indicator = "↓ (regressed)"
                     else:
                         indicator = "= (same)"

--- a/compare_runs.py
+++ b/compare_runs.py
@@ -93,6 +93,8 @@ def compare_overall(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> lis
         ('Correctness Pass Rate', 'correctness_pass_rate', True),
         ('Speedup > 1.0 Rate', 'speedup_gt_1_rate', True),
         ('Average Speedup', 'average_speedup', False),
+        ('Median Speedup', 'median_speedup', False),
+        ('Std Dev Speedup', 'std_dev_speedup', False),
     ]
     
     for label, key, is_percentage in metrics:
@@ -116,10 +118,18 @@ def compare_overall(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> lis
         
         # Determine if improvement (green) or regression (red) - for display purposes
         if key in ['average_score', 'compilation_pass_rate', 'correctness_pass_rate', 
-                   'speedup_gt_1_rate', 'average_speedup']:
+                   'speedup_gt_1_rate', 'average_speedup', 'median_speedup']:
             if val2 > val1:
                 indicator = "↑"
             elif val2 < val1:
+                indicator = "↓"
+            else:
+                indicator = "="
+        elif key == 'std_dev_speedup':
+            # Lower std dev is better (more consistent), so reverse the logic
+            if val2 < val1:
+                indicator = "↑"
+            elif val2 > val1:
                 indicator = "↓"
             else:
                 indicator = "="
@@ -173,6 +183,8 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
         # Compare key metrics
         metrics = [
             ('Average Speedup', 'average_speedup', False),
+            ('Median Speedup', 'median_speedup', False),
+            ('Std Dev Speedup', 'std_dev_speedup', False),
             ('Compilation Pass Rate', 'compilation_pass_rate', True),
             ('Correctness Pass Rate', 'correctness_pass_rate', True),
             ('Speedup > 1.0 Rate', 'speedup_gt_1_rate', True),
@@ -203,12 +215,21 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
                 diff_str = format_difference(val1, val2, is_percentage)
             
             if count1 > 0 and count2 > 0:
-                if val2 > val1:
-                    indicator = "↑ (improved)"
-                elif val2 < val1:
-                    indicator = "↓ (regressed)"
+                # For std_dev_speedup, lower is better (more consistent)
+                if key == 'std_dev_speedup':
+                    if val2 < val1:
+                        indicator = "↑ (improved)"
+                    elif val2 > val1:
+                        indicator = "↓ (regressed)"
+                    else:
+                        indicator = "= (same)"
                 else:
-                    indicator = "= (same)"
+                    if val2 > val1:
+                        indicator = "↑ (improved)"
+                    elif val2 < val1:
+                        indicator = "↓ (regressed)"
+                    else:
+                        indicator = "= (same)"
             else:
                 indicator = ""
             

--- a/compare_runs.py
+++ b/compare_runs.py
@@ -201,7 +201,18 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
         for label, key, is_percentage in metrics:
             val1 = stats1.get(key, 0.0)
             val2 = stats2.get(key, 0.0)
-            
+
+            # Format both values first, then override with N/A as needed
+            if is_percentage:
+                fmt1 = f"{val1:.1f}%"
+                fmt2 = f"{val2:.1f}%"
+            elif key == 'average_score':
+                fmt1 = f"{val1:.2f}"
+                fmt2 = f"{val2:.2f}"
+            else:
+                fmt1 = f"{val1:.3f}"
+                fmt2 = f"{val2:.3f}"
+
             if count1 == 0:
                 fmt1 = "N/A"
                 diff_str = "N/A (new)"
@@ -209,16 +220,6 @@ def compare_task_types(run1_data: Dict[str, Any], run2_data: Dict[str, Any]) -> 
                 fmt2 = "N/A"
                 diff_str = "N/A (removed)"
             else:
-                if is_percentage:
-                    fmt1 = f"{val1:.1f}%"
-                    fmt2 = f"{val2:.1f}%"
-                elif key == 'average_score':
-                    fmt1 = f"{val1:.2f}"
-                    fmt2 = f"{val2:.2f}"
-                else:
-                    fmt1 = f"{val1:.3f}"
-                    fmt2 = f"{val2:.3f}"
-                
                 diff_str = format_difference(val1, val2, is_percentage)
             
             if count1 > 0 and count2 > 0:

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@
 # - geak_ourllm_kernel2kernel
 # - task_validator 
 agent:
-  template: codex 
+  template: cursor 
 
 # Task Selection
 # Specify task names to execute (use full path from tasks/ directory)
@@ -28,45 +28,75 @@ agent:
 #   - all                               # Run ALL available tasks
 
 tasks:
-  - triton2triton/vllm/triton_pack_bitmatrix
-  - triton2triton/vllm/triton_pack_seq
-  - triton2triton/vllm/triton_paged_prefix_prefill
-  - triton2triton/vllm/triton_paged_prefix_prefill_alibi
-  - triton2triton/vllm/triton_per_token_group_quant_fp8
-  - triton2triton/vllm/triton_per_token_group_quant_fp8_colmajor
-  - triton2triton/vllm/triton_per_token_group_quant_int8
-  - triton2triton/vllm/triton_per_token_quant_int8
-  - triton2triton/vllm/triton_post_update
-  - triton2triton/vllm/triton_prepare_mrope_positions
-  - triton2triton/vllm/triton_prepare_pos_seq_lens
-  - triton2triton/vllm/triton_prepare_prefill_inputs
-  - triton2triton/vllm/triton_prompt_logprobs_token_ids
-  - triton2triton/vllm/triton_ranks
-  - triton2triton/vllm/triton_reduce_segments
-  - triton2triton/vllm/triton_rejection_greedy_sample
-  - triton2triton/vllm/triton_rejection_random_sample
-  - triton2triton/vllm/triton_reshape_and_cache_flash
+  # hip2hip: 20 tasks (18 from gpumode, 2 from others)
+  - hip2hip/gpumode/CrossEntropyLossLabelSmoothing
+  - hip2hip/gpumode/Feedforward
+  - hip2hip/gpumode/FusedLeakyReLU
+  - hip2hip/gpumode/GateGRUSelectionLayer
+  - hip2hip/gpumode/Gather
+  - hip2hip/gpumode/GELU
+  - hip2hip/gpumode/InnerProd
+  - hip2hip/gpumode/ItemQueryAttention
+  - hip2hip/gpumode/KDLoss
+  - hip2hip/gpumode/layer_normalization
+  - hip2hip/gpumode/MaskedLanguageModel
+  - hip2hip/gpumode/MLP_model
+  - hip2hip/gpumode/MultiHeadAttention
+  - hip2hip/gpumode/NormalAttention_dot
+  - hip2hip/gpumode/NormalAttention_embedded_gaussian
+  - hip2hip/gpumode/PositionEmbedder
+  - hip2hip/gpumode/Sigmoid
+  - hip2hip/gpumode/SiLU
+  - hip2hip/others/assign_score_withk
+  - hip2hip/others/ball_query
+  
+  # triton2triton/vllm: 10 tasks
+  - triton2triton/vllm/triton_awq_dequantize
+  - triton2triton/vllm/triton_awq_gemm
+  - triton2triton/vllm/triton_batched_moe
+  - triton2triton/vllm/triton_flash_prefill_attention
+  - triton2triton/vllm/triton_fused_moe
+  - triton2triton/vllm/triton_layernorm_gated
+  - triton2triton/vllm/triton_matmul_persistent
   - triton2triton/vllm/triton_rms_norm
-  - triton2triton/vllm/triton_sample_recovered_tokens
-  - triton2triton/vllm/triton_scale_swizzle
   - triton2triton/vllm/triton_scaled_mm
-  - triton2triton/vllm/triton_selective_scan_update
-  - triton2triton/vllm/triton_silu_mul_quant_fp8
-  - triton2triton/vllm/triton_solve_tril_16x16
-  - triton2triton/vllm/triton_ssd_bmm
-  - triton2triton/vllm/triton_ssd_chunk_cumsum
-  - triton2triton/vllm/triton_ssd_chunk_scan
-  - triton2triton/vllm/triton_ssd_chunk_state
-  - triton2triton/vllm/triton_ssd_chunk_state_varlen
-  - triton2triton/vllm/triton_ssd_state_passing
-  - triton2triton/vllm/triton_swiglustep_and_mul
-  - triton2triton/vllm/triton_topk_topp
-  - triton2triton/vllm/triton_unified_attention_2d
-  - triton2triton/vllm/triton_unpack_seq
-  - triton2triton/vllm/triton_w8a8_block_int8_matmul
-  - triton2triton/vllm/triton_w8a8_block_scaled_mm
-  - triton2triton/vllm/triton_write_zeros_to_output
-  - triton2triton/vllm/triton_wy_fast_recompute_wu
+  - triton2triton/vllm/triton_topk_log_softmax
+
+  # triton2triton/rocmbench: 10 tasks
+  - triton2triton/rocmbench/easy/test_add_kernel
+  - triton2triton/rocmbench/easy/test_batched_vecmat
+  - triton2triton/rocmbench/easy/test_block_copy
+  - triton2triton/rocmbench/easy/test_kernel_dot
+  - triton2triton/rocmbench/medium/layernorm
+  - triton2triton/rocmbench/medium/naive_softmax
+  - triton2triton/rocmbench/medium/rmsnorm_fwd
+  - triton2triton/rocmbench/medium/softmax
+  - triton2triton/rocmbench/hard/gemm
+  - triton2triton/rocmbench/hard/moe_gemm
+  
+  # torch2hip: 10 tasks
+  - torch2hip/gpumode/1001_NormalAttention_dot
+  - torch2hip/gpumode/10024_Feedforward
+  - torch2hip/gpumode/1003_NormalAttention_embedded_gaussian
+  - torch2hip/gpumode/10082_SoftmaxModule
+  - torch2hip/gpumode/10099_Gather
+  - torch2hip/gpumode/10190_FusedLeakyReLU
+  - torch2hip/gpumode/10456_MultiHeadAttention
+  - torch2hip/gpumode/11754_layer_normalization
+  - torch2hip/gpumode/14539_GELU
+  - torch2hip/gpumode/16636_SiLU
+  
+  # instruction2triton/rocmbench: 10 tasks
+  - instruction2triton/rocmbench/gemm
+  - instruction2triton/rocmbench/layernorm
+  - instruction2triton/rocmbench/moe_gemm
+  - instruction2triton/rocmbench/multreduce_matmul_dot_kernel
+  - instruction2triton/rocmbench/naive_softmax
+  - instruction2triton/rocmbench/rmsnorm_bwd
+  - instruction2triton/rocmbench/rmsnorm_fwd
+  - instruction2triton/rocmbench/softmax
+  - instruction2triton/rocmbench/test_flashattention_fwd
+  - instruction2triton/rocmbench/test_gemm_fusion
 
 
 target_gpu_model: MI300

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 from src.tasks import get_task_config
-from src.preprocessing import setup_workspace, setup_rocm_env
+from src.preprocessing import setup_workspace, setup_rocm_env, is_task_complete
 from src.module_registration import AgentType, load_agent_launcher, load_post_processing_handler
 from src.evaluator import measure_baseline, evaluate_kernel, write_task_result
 
@@ -13,6 +13,10 @@ from src.evaluator import measure_baseline, evaluate_kernel, write_task_result
 parser = argparse.ArgumentParser(description="arguments for AgentKernelArena")
 parser.add_argument("--config_name", type=str, default="config.yaml",help="the config of AgentKernelArena, default set to config. \
                     You can set different tasks in different config yaml file in order to run multi evaluation task in one folder.")
+parser.add_argument("--resume-run", type=str, default=None,
+                    help="Resume an existing run by specifying the run directory name (e.g., run_20250115_143022)")
+parser.add_argument("--resume-latest", action="store_true",
+                    help="Resume the most recent run in the workspace")
 
 def main() -> None:
     """Main entry point for AgentKernelArena framework."""
@@ -42,13 +46,45 @@ def main() -> None:
     project_root = Path(__file__).resolve().parent
     workspace_directory = (project_root / workspace_directory_name).resolve()
 
-    # Create log file with target_gpu_model, agent, and timestamp    
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    
-    # Create run-level directory for this execution
-    run_directory_name = f"run_{timestamp}"
-    run_directory = workspace_directory / run_directory_name
-    run_directory.mkdir(parents=True, exist_ok=True)
+    # Handle resume functionality
+    resume_mode = False
+    if args.resume_run:
+        # Resume specific run
+        run_directory_name = args.resume_run
+        run_directory = workspace_directory / run_directory_name
+        if not run_directory.exists():
+            print(f"Error: Run directory does not exist: {run_directory}")
+            return
+        resume_mode = True
+        # Extract timestamp from run directory name: run_20250115_143022 -> 20250115_143022
+        if run_directory_name.startswith("run_"):
+            timestamp = run_directory_name[4:]  # Remove "run_" prefix
+        else:
+            print(f"Error: Invalid run directory name format: {run_directory_name}. Expected format: run_YYYYMMDD_HHMMSS")
+            return
+    elif args.resume_latest:
+        # Resume latest run
+        # Find all run directories and get the most recent one
+        run_dirs = sorted([d for d in workspace_directory.iterdir() 
+                          if d.is_dir() and d.name.startswith("run_")], 
+                         key=lambda x: x.name, reverse=True)
+        if not run_dirs:
+            print(f"Error: No run directories found in {workspace_directory}")
+            return
+        run_directory = run_dirs[0]
+        run_directory_name = run_directory.name
+        resume_mode = True
+        # Extract timestamp from run directory name
+        if run_directory_name.startswith("run_"):
+            timestamp = run_directory_name[4:]
+        else:
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    else:
+        # Create new run
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        run_directory_name = f"run_{timestamp}"
+        run_directory = workspace_directory / run_directory_name
+        run_directory.mkdir(parents=True, exist_ok=True)
     log_dir = Path(log_directory)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_filename = f"{target_gpu_model}_{agent.value}_{timestamp}.log"
@@ -73,6 +109,10 @@ def main() -> None:
     logger.info(f"Target Architecture: {target_gpu_model}")
     logger.info(f"Workspace Directory: {workspace_directory}")
     logger.info(f"Run Directory: {run_directory}")
+    if resume_mode:
+        logger.info(f"RESUME MODE: Resuming existing run {run_directory_name}")
+    else:
+        logger.info(f"NEW RUN: Creating new run {run_directory_name}")
 
     # Set PYTORCH_ROCM_ARCH based on target_gpu_model before any task runs
     setup_rocm_env(target_gpu_model, logger)
@@ -92,6 +132,33 @@ def main() -> None:
         task_config_dict = {}
         for category in tasks:
             task_config_dict.update(get_task_config(category=category))
+
+    # Filter out completed tasks if resuming
+    if resume_mode:
+        original_task_count = len(task_config_dict)
+        tasks_to_run = {}
+        skipped_tasks = []
+        
+        for task_name, task_config_dir in task_config_dict.items():
+            # Get task folder name (parent directory of task_config_dir)
+            task_config_path = Path(task_config_dir)
+            task_folder = task_config_path.parent
+            task_folder_name = task_folder.name
+            
+            if is_task_complete(run_directory, task_folder_name, timestamp):
+                skipped_tasks.append(task_name)
+                logger.info(f"Skipping completed task: {task_name}")
+            else:
+                tasks_to_run[task_name] = task_config_dir
+        
+        task_config_dict = tasks_to_run
+        
+        logger.info(f"Resume mode: {len(skipped_tasks)} tasks already completed, {len(task_config_dict)} tasks remaining")
+        if skipped_tasks:
+            logger.info(f"Skipped tasks: {skipped_tasks}")
+        if len(task_config_dict) == 0:
+            logger.info("All tasks are already completed. Nothing to run.")
+            return
 
     logger.info(f"Found {len(task_config_dict)} tasks to execute")
     logger.info(f"Tasks: {list(task_config_dict.keys())}")

--- a/main.py
+++ b/main.py
@@ -44,6 +44,11 @@ def main() -> None:
 
     # Create log file with target_gpu_model, agent, and timestamp    
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    
+    # Create run-level directory for this execution
+    run_directory_name = f"run_{timestamp}"
+    run_directory = workspace_directory / run_directory_name
+    run_directory.mkdir(parents=True, exist_ok=True)
     log_dir = Path(log_directory)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_filename = f"{target_gpu_model}_{agent.value}_{timestamp}.log"
@@ -67,6 +72,7 @@ def main() -> None:
     logger.info(f"Agent: {agent.value}")
     logger.info(f"Target Architecture: {target_gpu_model}")
     logger.info(f"Workspace Directory: {workspace_directory}")
+    logger.info(f"Run Directory: {run_directory}")
 
     # Set PYTORCH_ROCM_ARCH based on target_gpu_model before any task runs
     setup_rocm_env(target_gpu_model, logger)
@@ -101,7 +107,7 @@ def main() -> None:
         
         try:
             # Setup workspace
-            workspace_path = setup_workspace(task_config_dir, workspace_directory, timestamp, logger)
+            workspace_path = setup_workspace(task_config_dir, run_directory, timestamp, logger)
             
             # Load task config for evaluation
             with open(task_config_dir, 'r') as f:

--- a/main.py
+++ b/main.py
@@ -140,12 +140,7 @@ def main() -> None:
         skipped_tasks = []
         
         for task_name, task_config_dir in task_config_dict.items():
-            # Get task folder name (parent directory of task_config_dir)
-            task_config_path = Path(task_config_dir)
-            task_folder = task_config_path.parent
-            task_folder_name = task_folder.name
-            
-            if is_task_complete(run_directory, task_folder_name, timestamp):
+            if is_task_complete(run_directory, task_name, timestamp):
                 skipped_tasks.append(task_name)
                 logger.info(f"Skipping completed task: {task_name}")
             else:
@@ -174,7 +169,7 @@ def main() -> None:
         
         try:
             # Setup workspace
-            workspace_path = setup_workspace(task_config_dir, run_directory, timestamp, logger)
+            workspace_path = setup_workspace(task_config_dir, run_directory, timestamp, logger, task_name=task_name)
             
             # Load task config for evaluation
             with open(task_config_dir, 'r') as f:

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -54,6 +54,7 @@ def _build_general_report_lines(
         f"  Average Speedup:       {aggregate_result['average_speedup']:.2f}x",
         f"  Median Speedup:       {aggregate_result.get('median_speedup', 0.0):.2f}x",
         f"  Std Dev Speedup:       {aggregate_result.get('std_dev_speedup', 0.0):.2f}x",
+        f"  P25/P75/P90 Speedup:   {aggregate_result.get('p25_speedup', 0.0):.2f}x / {aggregate_result.get('p75_speedup', 0.0):.2f}x / {aggregate_result.get('p90_speedup', 0.0):.2f}x",
         f"  Valid Speedup Count:   {aggregate_result['valid_speedup_count']}",
     ])
     
@@ -71,6 +72,7 @@ def _build_general_report_lines(
             lines.append(f"    Average Speedup:     {stats['average_speedup']:.2f}x")
             lines.append(f"    Median Speedup:      {stats.get('median_speedup', 0.0):.2f}x")
             lines.append(f"    Std Dev Speedup:     {stats.get('std_dev_speedup', 0.0):.2f}x")
+            lines.append(f"    P25/P75/P90 Speedup: {stats.get('p25_speedup', 0.0):.2f}x / {stats.get('p75_speedup', 0.0):.2f}x / {stats.get('p90_speedup', 0.0):.2f}x")
             lines.append(f"    Compilation Pass:     {stats['compilation_pass_count']}/{stats['count']}")
             lines.append(f"    Compilation Pass Rate: {stats['compilation_pass_rate']:.1f}%")
             lines.append(f"    Correctness Pass:     {stats['correctness_pass_count']}/{stats['count']}")
@@ -245,6 +247,34 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
         except statistics.StatisticsError:
             std_dev_speedup = 0.0
         
+        # Calculate percentiles (P25, P75, P90)
+        try:
+            if speedup_values and len(speedup_values) > 0:
+                sorted_speedups = sorted(speedup_values)
+                n = len(sorted_speedups)
+                if n == 1:
+                    p25_speedup = sorted_speedups[0]
+                    p75_speedup = sorted_speedups[0]
+                    p90_speedup = sorted_speedups[0]
+                else:
+                    # P25 (25th percentile)
+                    p25_idx = int(0.25 * (n - 1))
+                    p25_speedup = sorted_speedups[p25_idx] if p25_idx < n else sorted_speedups[-1]
+                    # P75 (75th percentile)
+                    p75_idx = int(0.75 * (n - 1))
+                    p75_speedup = sorted_speedups[p75_idx] if p75_idx < n else sorted_speedups[-1]
+                    # P90 (90th percentile)
+                    p90_idx = int(0.90 * (n - 1))
+                    p90_speedup = sorted_speedups[p90_idx] if p90_idx < n else sorted_speedups[-1]
+            else:
+                p25_speedup = 0.0
+                p75_speedup = 0.0
+                p90_speedup = 0.0
+        except (statistics.StatisticsError, IndexError, ValueError):
+            p25_speedup = 0.0
+            p75_speedup = 0.0
+            p90_speedup = 0.0
+        
         result[task_type] = {
             'count': count,
             'total_score': stats['total_score'],
@@ -258,6 +288,9 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
             'average_speedup': average_speedup,
             'median_speedup': median_speedup,
             'std_dev_speedup': std_dev_speedup,
+            'p25_speedup': p25_speedup,
+            'p75_speedup': p75_speedup,
+            'p90_speedup': p90_speedup,
             'valid_speedup_count': len(speedup_values)
         }
     
@@ -467,6 +500,34 @@ def general_post_processing(
         std_dev_speedup = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
     except statistics.StatisticsError:
         std_dev_speedup = 0.0
+    
+    # Calculate percentiles (P25, P75, P90)
+    try:
+        if speedup_values and len(speedup_values) > 0:
+            sorted_speedups = sorted(speedup_values)
+            n = len(sorted_speedups)
+            if n == 1:
+                p25_speedup = sorted_speedups[0]
+                p75_speedup = sorted_speedups[0]
+                p90_speedup = sorted_speedups[0]
+            else:
+                # P25 (25th percentile)
+                p25_idx = int(0.25 * (n - 1))
+                p25_speedup = sorted_speedups[p25_idx] if p25_idx < n else sorted_speedups[-1]
+                # P75 (75th percentile)
+                p75_idx = int(0.75 * (n - 1))
+                p75_speedup = sorted_speedups[p75_idx] if p75_idx < n else sorted_speedups[-1]
+                # P90 (90th percentile)
+                p90_idx = int(0.90 * (n - 1))
+                p90_speedup = sorted_speedups[p90_idx] if p90_idx < n else sorted_speedups[-1]
+        else:
+            p25_speedup = 0.0
+            p75_speedup = 0.0
+            p90_speedup = 0.0
+    except (statistics.StatisticsError, IndexError, ValueError):
+        p25_speedup = 0.0
+        p75_speedup = 0.0
+        p90_speedup = 0.0
 
     # Generate aggregate_result
     aggregate_result = {
@@ -486,6 +547,9 @@ def general_post_processing(
         'average_speedup': average_speedup,
         'median_speedup': median_speedup,
         'std_dev_speedup': std_dev_speedup,
+        'p25_speedup': p25_speedup,
+        'p75_speedup': p75_speedup,
+        'p90_speedup': p90_speedup,
         'valid_speedup_count': len(speedup_values),
 
         'task_details': task_details
@@ -528,6 +592,9 @@ def general_post_processing(
                 'average_speedup': aggregate_result['average_speedup'],
                 'median_speedup': aggregate_result.get('median_speedup', 0.0),
                 'std_dev_speedup': aggregate_result.get('std_dev_speedup', 0.0),
+                'p25_speedup': aggregate_result.get('p25_speedup', 0.0),
+                'p75_speedup': aggregate_result.get('p75_speedup', 0.0),
+                'p90_speedup': aggregate_result.get('p90_speedup', 0.0),
                 'valid_speedup_count': aggregate_result['valid_speedup_count']
             },
             'task_types': task_type_breakdown

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -15,12 +15,22 @@ except ModuleNotFoundError:
     from src.score import resolve_speedup_ratio, task_result_scoring
 
 
-def _build_general_report_lines(aggregate_result: Dict[str, Any]) -> List[str]:
+def _build_general_report_lines(aggregate_result: Dict[str, Any], run_metadata: Optional[Dict[str, str]] = None) -> List[str]:
     """Build report lines shared by logger output and fallback txt output."""
     lines = [
         "=" * 80,
         "AgentKernelArena Task Results Report",
         "=" * 80,
+    ]
+    
+    # Add run metadata if available
+    if run_metadata:
+        lines.append(f"Run: {run_metadata.get('timestamp', 'unknown')}")
+        lines.append(f"Agent: {run_metadata.get('agent', 'unknown')}")
+        lines.append(f"Target GPU: {run_metadata.get('target_gpu', 'unknown')}")
+        lines.append("=" * 80)
+    
+    lines.extend([
         "Overall Statistics:",
         f"  Total Tasks:           {aggregate_result['total_tasks']}",
         f"  Total Score:           {aggregate_result['total_score']:.2f}",
@@ -38,7 +48,7 @@ def _build_general_report_lines(aggregate_result: Dict[str, Any]) -> List[str]:
         f"  Valid Speedup Count:   {aggregate_result['valid_speedup_count']}",
         "Task Details:",
         "-" * 80,
-    ]
+    ])
 
     for task in aggregate_result["task_details"]:
         status = "PASS" if task["pass_correctness"] else ("PARTIAL" if task["pass_compilation"] else "FAIL")
@@ -52,33 +62,60 @@ def _build_general_report_lines(aggregate_result: Dict[str, Any]) -> List[str]:
     return lines
 
 
-def _write_report_txt_if_log_empty(
-    report_lines: List[str], workspace_paths: List[str], logger: logging.Logger
-) -> None:
-    """Write fallback txt report when logger file output is empty."""
+def _get_run_directory(workspace_paths: List[str]) -> Path:
+    """
+    Extract run directory from workspace paths.
+    
+    Workspace paths are task directories like:
+    workspace_MI300_cursor/run_20250115_143022/task_hip2hip_silu_20250115_143022/
+    
+    Returns the run directory: workspace_MI300_cursor/run_20250115_143022/
+    """
     if not workspace_paths:
-        return
+        raise ValueError("Cannot determine run directory: empty workspace_paths")
+    
+    # First workspace path is a task directory, its parent is the run directory
+    first_workspace = Path(workspace_paths[0]).resolve()
+    run_directory = first_workspace.parent
+    
+    # Validate that this looks like a run directory (contains task directories)
+    if not run_directory.exists():
+        raise ValueError(f"Run directory does not exist: {run_directory}")
+    
+    return run_directory
 
-    file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
-    log_is_empty = not file_handlers
 
-    for handler in file_handlers:
-        base_filename = getattr(handler, "baseFilename", None)
-        if not base_filename:
-            continue
-        log_path = Path(base_filename)
-        if log_path.exists() and log_path.stat().st_size > 0:
-            log_is_empty = False
-            break
-
-    if not log_is_empty:
-        return
-
-    workspace_root = Path(workspace_paths[0]).resolve().parent
-    txt_path = workspace_root / "task_results_report.txt"
-    with open(txt_path, "w") as f:
-        f.write("\n".join(report_lines) + "\n")
-    logger.info(f"Log was empty; wrote fallback text report: {txt_path}")
+def _extract_run_metadata(run_directory: Path) -> Dict[str, str]:
+    """
+    Extract metadata from run directory structure.
+    
+    Returns dict with: timestamp, agent, target_gpu
+    """
+    # Extract timestamp from run directory name: run_20250115_143022 -> 20250115_143022
+    run_dir_name = run_directory.name
+    if run_dir_name.startswith("run_"):
+        timestamp = run_dir_name[4:]  # Remove "run_" prefix
+    else:
+        timestamp = "unknown"
+    
+    # Extract agent and GPU from workspace directory name: workspace_MI300_cursor -> MI300, cursor
+    workspace_dir = run_directory.parent
+    workspace_name = workspace_dir.name
+    parts = workspace_name.split("_")
+    
+    # Pattern: workspace_{GPU}_{agent}
+    if len(parts) >= 3 and parts[0] == "workspace":
+        target_gpu = parts[1]
+        agent = "_".join(parts[2:])  # In case agent name has underscores
+    else:
+        target_gpu = "unknown"
+        agent = "unknown"
+    
+    return {
+        "timestamp": timestamp,
+        "agent": agent,
+        "target_gpu": target_gpu
+    }
 
 
 def _ensure_logger(logger: Optional[logging.Logger]) -> logging.Logger:
@@ -110,15 +147,16 @@ def _normalize_workspace_paths(workspace_paths: Union[str, List[str]]) -> List[s
 
 
 
-def general_log_report(aggregate_result: Dict[str, Any], logger: logging.Logger) -> None:
+def general_log_report(aggregate_result: Dict[str, Any], logger: logging.Logger, run_metadata: Optional[Dict[str, str]] = None) -> None:
     """
     Log a formatted report using the provided logger.
 
     Args:
         aggregate_result: Report dictionary from post_processing()
         logger: Logger instance to use for output
+        run_metadata: Optional dict with timestamp, agent, target_gpu
     """
-    for line in _build_general_report_lines(aggregate_result):
+    for line in _build_general_report_lines(aggregate_result, run_metadata):
         logger.info(line)
 
 
@@ -252,18 +290,42 @@ def general_post_processing(
         'task_details': task_details
     }
 
-    general_log_report(aggregate_result, logger)
-    export_task_results_csv(task_details, normalized_workspace_paths, logger)
-    _write_report_txt_if_log_empty(_build_general_report_lines(aggregate_result), normalized_workspace_paths, logger)
+    # Determine run directory and create reports subdirectory
+    try:
+        run_directory = _get_run_directory(normalized_workspace_paths)
+        run_metadata = _extract_run_metadata(run_directory)
+        
+        # Create reports subdirectory
+        reports_directory = run_directory / "reports"
+        reports_directory.mkdir(parents=True, exist_ok=True)
+        
+        # Write overall_report.txt to reports directory
+        report_lines = _build_general_report_lines(aggregate_result, run_metadata)
+        report_path = reports_directory / "overall_report.txt"
+        with open(report_path, "w") as f:
+            f.write("\n".join(report_lines) + "\n")
+        logger.info(f"Report written to: {report_path}")
+        
+    except Exception as e:
+        logger.warning(f"Could not determine run directory or create reports: {e}")
+        run_metadata = None
+        reports_directory = None
+    
+    # Log report
+    general_log_report(aggregate_result, logger, run_metadata)
+    
+    # Export CSV to reports directory
+    export_task_results_csv(task_details, normalized_workspace_paths, logger, reports_directory)
 
 
 def export_task_results_csv(
     task_details: List[Dict[str, Any]],
     workspace_paths: List[str],
-    logger: logging.Logger
+    logger: logging.Logger,
+    reports_directory: Optional[Path] = None
 ) -> None:
     """
-    Export per-task summary as CSV under the workspace root directory.
+    Export per-task summary as CSV under the reports directory.
 
     CSV columns:
       - Task Name
@@ -276,9 +338,13 @@ def export_task_results_csv(
         logger.warning("CSV export skipped: empty workspace_paths")
         return
 
-    # All task workspaces are expected to be siblings under one workspace root.
-    workspace_root = Path(workspace_paths[0]).resolve().parent
-    csv_path = workspace_root / "task_results_summary.csv"
+    # Use reports directory if provided, otherwise fall back to run directory
+    if reports_directory:
+        csv_path = reports_directory / "overall_summary.csv"
+    else:
+        # Fallback: use run directory (parent of first workspace)
+        run_directory = Path(workspace_paths[0]).resolve().parent
+        csv_path = run_directory / "task_results_summary.csv"
 
     rows: List[Dict[str, Any]] = []
     for task in task_details:

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -4,6 +4,7 @@ import logging
 import csv
 import json
 import sys
+import statistics
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Union
 from collections import defaultdict
@@ -51,6 +52,8 @@ def _build_general_report_lines(
         f"  Speedup > 1.0 Count:   {aggregate_result['speedup_gt_1_count']}/{aggregate_result['total_tasks']}",
         f"  Speedup > 1.0 Rate:    {aggregate_result['speedup_gt_1_rate']:.1f}%",
         f"  Average Speedup:       {aggregate_result['average_speedup']:.2f}x",
+        f"  Median Speedup:       {aggregate_result.get('median_speedup', 0.0):.2f}x",
+        f"  Std Dev Speedup:       {aggregate_result.get('std_dev_speedup', 0.0):.2f}x",
         f"  Valid Speedup Count:   {aggregate_result['valid_speedup_count']}",
     ])
     
@@ -66,6 +69,8 @@ def _build_general_report_lines(
             stats = task_type_breakdown[task_type]
             lines.append(f"  {task_type} ({stats['count']} tasks):")
             lines.append(f"    Average Speedup:     {stats['average_speedup']:.2f}x")
+            lines.append(f"    Median Speedup:      {stats.get('median_speedup', 0.0):.2f}x")
+            lines.append(f"    Std Dev Speedup:     {stats.get('std_dev_speedup', 0.0):.2f}x")
             lines.append(f"    Compilation Pass:     {stats['compilation_pass_count']}/{stats['count']}")
             lines.append(f"    Compilation Pass Rate: {stats['compilation_pass_rate']:.1f}%")
             lines.append(f"    Correctness Pass:     {stats['correctness_pass_count']}/{stats['count']}")
@@ -225,6 +230,21 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
     result = {}
     for task_type, stats in type_stats.items():
         count = stats['count']
+        speedup_values = stats['speedup_values']
+        
+        # Calculate speedup statistics
+        average_speedup = (sum(speedup_values) / len(speedup_values)) if speedup_values else 0.0
+        
+        try:
+            median_speedup = statistics.median(speedup_values) if speedup_values else 0.0
+        except statistics.StatisticsError:
+            median_speedup = 0.0
+        
+        try:
+            std_dev_speedup = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
+        except statistics.StatisticsError:
+            std_dev_speedup = 0.0
+        
         result[task_type] = {
             'count': count,
             'total_score': stats['total_score'],
@@ -235,8 +255,10 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
             'correctness_pass_rate': (stats['correctness_pass_count'] / count * 100) if count > 0 else 0.0,
             'speedup_gt_1_count': stats['speedup_gt_1_count'],
             'speedup_gt_1_rate': (stats['speedup_gt_1_count'] / count * 100) if count > 0 else 0.0,
-            'average_speedup': (sum(stats['speedup_values']) / len(stats['speedup_values'])) if stats['speedup_values'] else 0.0,
-            'valid_speedup_count': len(stats['speedup_values'])
+            'average_speedup': average_speedup,
+            'median_speedup': median_speedup,
+            'std_dev_speedup': std_dev_speedup,
+            'valid_speedup_count': len(speedup_values)
         }
     
     return result
@@ -434,6 +456,17 @@ def general_post_processing(
 
     # Calculate average speedup (only for valid speedups)
     average_speedup = (sum(speedup_values) / len(speedup_values)) if speedup_values else 0.0
+    
+    # Calculate median and standard deviation for speedups
+    try:
+        median_speedup = statistics.median(speedup_values) if speedup_values else 0.0
+    except statistics.StatisticsError:
+        median_speedup = 0.0
+    
+    try:
+        std_dev_speedup = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
+    except statistics.StatisticsError:
+        std_dev_speedup = 0.0
 
     # Generate aggregate_result
     aggregate_result = {
@@ -451,6 +484,8 @@ def general_post_processing(
         'speedup_gt_1_rate': speedup_gt_1_rate,
 
         'average_speedup': average_speedup,
+        'median_speedup': median_speedup,
+        'std_dev_speedup': std_dev_speedup,
         'valid_speedup_count': len(speedup_values),
 
         'task_details': task_details
@@ -491,6 +526,8 @@ def general_post_processing(
                 'speedup_gt_1_count': aggregate_result['speedup_gt_1_count'],
                 'speedup_gt_1_rate': aggregate_result['speedup_gt_1_rate'],
                 'average_speedup': aggregate_result['average_speedup'],
+                'median_speedup': aggregate_result.get('median_speedup', 0.0),
+                'std_dev_speedup': aggregate_result.get('std_dev_speedup', 0.0),
                 'valid_speedup_count': aggregate_result['valid_speedup_count']
             },
             'task_types': task_type_breakdown

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -2,9 +2,11 @@
 import yaml
 import logging
 import csv
+import json
 import sys
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Union
+from collections import defaultdict
 try:
     from src.score import resolve_speedup_ratio, task_result_scoring
 except ModuleNotFoundError:
@@ -15,7 +17,11 @@ except ModuleNotFoundError:
     from src.score import resolve_speedup_ratio, task_result_scoring
 
 
-def _build_general_report_lines(aggregate_result: Dict[str, Any], run_metadata: Optional[Dict[str, str]] = None) -> List[str]:
+def _build_general_report_lines(
+    aggregate_result: Dict[str, Any], 
+    run_metadata: Optional[Dict[str, str]] = None,
+    task_type_breakdown: Optional[Dict[str, Dict[str, Any]]] = None
+) -> List[str]:
     """Build report lines shared by logger output and fallback txt output."""
     lines = [
         "=" * 80,
@@ -31,7 +37,7 @@ def _build_general_report_lines(aggregate_result: Dict[str, Any], run_metadata: 
         lines.append("=" * 80)
     
     lines.extend([
-        "Overall Statistics:",
+        "OVERALL STATISTICS:",
         f"  Total Tasks:           {aggregate_result['total_tasks']}",
         f"  Total Score:           {aggregate_result['total_score']:.2f}",
         f"  Average Score:         {aggregate_result['average_score']:.2f}",
@@ -46,7 +52,52 @@ def _build_general_report_lines(aggregate_result: Dict[str, Any], run_metadata: 
         f"  Speedup > 1.0 Rate:    {aggregate_result['speedup_gt_1_rate']:.1f}%",
         f"  Average Speedup:       {aggregate_result['average_speedup']:.2f}x",
         f"  Valid Speedup Count:   {aggregate_result['valid_speedup_count']}",
-        "Task Details:",
+    ])
+    
+    # Add task type breakdowns if available
+    if task_type_breakdown:
+        lines.append("")
+        lines.append("TASK TYPE BREAKDOWN:")
+        lines.append("")
+        
+        # Sort task types for consistent output
+        sorted_types = sorted(task_type_breakdown.keys())
+        for task_type in sorted_types:
+            stats = task_type_breakdown[task_type]
+            lines.append(f"  {task_type} ({stats['count']} tasks):")
+            lines.append(f"    Average Speedup:     {stats['average_speedup']:.2f}x")
+            lines.append(f"    Compilation Pass:     {stats['compilation_pass_count']}/{stats['count']}")
+            lines.append(f"    Compilation Pass Rate: {stats['compilation_pass_rate']:.1f}%")
+            lines.append(f"    Correctness Pass:     {stats['correctness_pass_count']}/{stats['count']}")
+            lines.append(f"    Correctness Pass Rate: {stats['correctness_pass_rate']:.1f}%")
+            lines.append(f"    Speedup > 1.0:        {stats['speedup_gt_1_count']}/{stats['count']} ({stats['speedup_gt_1_rate']:.1f}%)")
+            lines.append(f"    Average Score:        {stats['average_score']:.2f}")
+            lines.append("")
+    
+    # Add total performance summary
+    lines.extend([
+        "TOTAL PERFORMANCE SUMMARY:",
+        f"  Overall Average Speedup:  {aggregate_result['average_speedup']:.2f}x",
+        f"  Tasks with Speedup > 1.0: {aggregate_result['speedup_gt_1_count']}/{aggregate_result['total_tasks']} ({aggregate_result['speedup_gt_1_rate']:.1f}%)",
+    ])
+    
+    # Find best and worst speedups
+    speedups = []
+    for task in aggregate_result.get('task_details', []):
+        if task.get('pass_compilation') and task.get('pass_correctness'):
+            speedup = task.get('speedup_ratio', 0.0)
+            if speedup > 0:
+                speedups.append((speedup, task.get('task_name', '')))
+    
+    if speedups:
+        best_speedup, best_task = max(speedups, key=lambda x: x[0])
+        worst_speedup, worst_task = min(speedups, key=lambda x: x[0])
+        lines.append(f"  Best Speedup:            {best_speedup:.2f}x (task: {best_task})")
+        lines.append(f"  Worst Speedup:           {worst_speedup:.2f}x (task: {worst_task})")
+    
+    lines.extend([
+        "",
+        "TASK DETAILS:",
         "-" * 80,
     ])
 
@@ -118,6 +169,79 @@ def _extract_run_metadata(run_directory: Path) -> Dict[str, str]:
     }
 
 
+def _extract_task_type(task_name: str) -> str:
+    """
+    Extract task type from task name.
+    
+    Task names are like: hip2hip/silu, triton2triton/vllm/xxx, etc.
+    Returns the first part before the first slash, or empty string if no slash.
+    """
+    if isinstance(task_name, str) and "/" in task_name:
+        return task_name.split("/", 1)[0]
+    return ""
+
+
+def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """
+    Aggregate statistics by task type.
+    
+    Returns a dictionary mapping task_type -> statistics dict.
+    """
+    type_stats = defaultdict(lambda: {
+        'count': 0,
+        'total_score': 0.0,
+        'compilation_pass_count': 0,
+        'correctness_pass_count': 0,
+        'speedup_gt_1_count': 0,
+        'speedup_values': [],
+        'task_names': []
+    })
+    
+    for task in task_details:
+        task_type = _extract_task_type(task.get('task_name', ''))
+        if not task_type:
+            task_type = 'unknown'
+        
+        stats = type_stats[task_type]
+        stats['count'] += 1
+        stats['total_score'] += task.get('score', 0.0)
+        stats['task_names'].append(task.get('task_name', ''))
+        
+        if task.get('pass_compilation', False):
+            stats['compilation_pass_count'] += 1
+        
+        if task.get('pass_correctness', False):
+            stats['correctness_pass_count'] += 1
+        
+        # Check speedup (only if both compilation and correctness passed)
+        if task.get('pass_compilation', False) and task.get('pass_correctness', False):
+            speedup = task.get('speedup_ratio', 0.0)
+            if speedup > 1.0:
+                stats['speedup_gt_1_count'] += 1
+            if speedup > 0:  # Only include valid speedups
+                stats['speedup_values'].append(speedup)
+    
+    # Calculate derived statistics for each task type
+    result = {}
+    for task_type, stats in type_stats.items():
+        count = stats['count']
+        result[task_type] = {
+            'count': count,
+            'total_score': stats['total_score'],
+            'average_score': stats['total_score'] / count if count > 0 else 0.0,
+            'compilation_pass_count': stats['compilation_pass_count'],
+            'compilation_pass_rate': (stats['compilation_pass_count'] / count * 100) if count > 0 else 0.0,
+            'correctness_pass_count': stats['correctness_pass_count'],
+            'correctness_pass_rate': (stats['correctness_pass_count'] / count * 100) if count > 0 else 0.0,
+            'speedup_gt_1_count': stats['speedup_gt_1_count'],
+            'speedup_gt_1_rate': (stats['speedup_gt_1_count'] / count * 100) if count > 0 else 0.0,
+            'average_speedup': (sum(stats['speedup_values']) / len(stats['speedup_values'])) if stats['speedup_values'] else 0.0,
+            'valid_speedup_count': len(stats['speedup_values'])
+        }
+    
+    return result
+
+
 def _ensure_logger(logger: Optional[logging.Logger]) -> logging.Logger:
     """Return a usable logger when caller passes None."""
     if logger is not None:
@@ -147,7 +271,12 @@ def _normalize_workspace_paths(workspace_paths: Union[str, List[str]]) -> List[s
 
 
 
-def general_log_report(aggregate_result: Dict[str, Any], logger: logging.Logger, run_metadata: Optional[Dict[str, str]] = None) -> None:
+def general_log_report(
+    aggregate_result: Dict[str, Any], 
+    logger: logging.Logger, 
+    run_metadata: Optional[Dict[str, str]] = None,
+    task_type_breakdown: Optional[Dict[str, Dict[str, Any]]] = None
+) -> None:
     """
     Log a formatted report using the provided logger.
 
@@ -155,8 +284,9 @@ def general_log_report(aggregate_result: Dict[str, Any], logger: logging.Logger,
         aggregate_result: Report dictionary from post_processing()
         logger: Logger instance to use for output
         run_metadata: Optional dict with timestamp, agent, target_gpu
+        task_type_breakdown: Optional dict with task type statistics
     """
-    for line in _build_general_report_lines(aggregate_result, run_metadata):
+    for line in _build_general_report_lines(aggregate_result, run_metadata, task_type_breakdown):
         logger.info(line)
 
 
@@ -290,6 +420,9 @@ def general_post_processing(
         'task_details': task_details
     }
 
+    # Aggregate statistics by task type
+    task_type_breakdown = _aggregate_by_task_type(task_details)
+
     # Determine run directory and create reports subdirectory
     try:
         run_directory = _get_run_directory(normalized_workspace_paths)
@@ -300,19 +433,45 @@ def general_post_processing(
         reports_directory.mkdir(parents=True, exist_ok=True)
         
         # Write overall_report.txt to reports directory
-        report_lines = _build_general_report_lines(aggregate_result, run_metadata)
+        report_lines = _build_general_report_lines(aggregate_result, run_metadata, task_type_breakdown)
         report_path = reports_directory / "overall_report.txt"
         with open(report_path, "w") as f:
             f.write("\n".join(report_lines) + "\n")
         logger.info(f"Report written to: {report_path}")
         
+        # Write task_type_breakdown.json
+        json_data = {
+            'run_timestamp': run_metadata.get('timestamp', 'unknown'),
+            'agent': run_metadata.get('agent', 'unknown'),
+            'target_gpu': run_metadata.get('target_gpu', 'unknown'),
+            'overall': {
+                'total_tasks': aggregate_result['total_tasks'],
+                'total_score': aggregate_result['total_score'],
+                'average_score': aggregate_result['average_score'],
+                'compilation_pass_count': aggregate_result['compilation_pass_count'],
+                'compilation_pass_rate': aggregate_result['compilation_pass_rate'],
+                'correctness_pass_count': aggregate_result['correctness_pass_count'],
+                'correctness_pass_rate': aggregate_result['correctness_pass_rate'],
+                'speedup_gt_1_count': aggregate_result['speedup_gt_1_count'],
+                'speedup_gt_1_rate': aggregate_result['speedup_gt_1_rate'],
+                'average_speedup': aggregate_result['average_speedup'],
+                'valid_speedup_count': aggregate_result['valid_speedup_count']
+            },
+            'task_types': task_type_breakdown
+        }
+        json_path = reports_directory / "task_type_breakdown.json"
+        with open(json_path, "w") as f:
+            json.dump(json_data, f, indent=2)
+        logger.info(f"Task type breakdown JSON written to: {json_path}")
+        
     except Exception as e:
         logger.warning(f"Could not determine run directory or create reports: {e}")
         run_metadata = None
         reports_directory = None
+        task_type_breakdown = None
     
     # Log report
-    general_log_report(aggregate_result, logger, run_metadata)
+    general_log_report(aggregate_result, logger, run_metadata, task_type_breakdown)
     
     # Export CSV to reports directory
     export_task_results_csv(task_details, normalized_workspace_paths, logger, reports_directory)

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -290,6 +290,29 @@ def general_log_report(
         logger.info(line)
 
 
+def _collect_all_tasks_from_run(run_directory: Path) -> List[str]:
+    """
+    Collect all task directories from a run directory that have task_result.yaml.
+    
+    Args:
+        run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
+    
+    Returns:
+        List of task directory paths (as strings) that have task_result.yaml
+    """
+    task_paths = []
+    if not run_directory.exists():
+        return task_paths
+    
+    for item in run_directory.iterdir():
+        if item.is_dir():
+            result_file = item / "task_result.yaml"
+            if result_file.exists():
+                task_paths.append(str(item))
+    
+    return sorted(task_paths)
+
+
 def general_post_processing(
     workspace_paths: Union[str, List[str]], logger: Optional[logging.Logger]
 ) -> None:
@@ -314,6 +337,19 @@ def general_post_processing(
     """
     logger = _ensure_logger(logger)
     normalized_workspace_paths = _normalize_workspace_paths(workspace_paths)
+    
+    # If we have workspace paths, try to detect the run directory and collect ALL tasks
+    # This ensures that when resuming, we include previously completed tasks in the report
+    if normalized_workspace_paths:
+        try:
+            run_directory = _get_run_directory(normalized_workspace_paths)
+            # Collect all tasks from the run directory (including previously completed ones)
+            all_task_paths = _collect_all_tasks_from_run(run_directory)
+            if all_task_paths:
+                logger.info(f"Collected {len(all_task_paths)} total tasks from run directory (including previously completed)")
+                normalized_workspace_paths = all_task_paths
+        except Exception as e:
+            logger.warning(f"Could not collect all tasks from run directory: {e}. Using provided workspace paths only.")
     total_tasks = len(normalized_workspace_paths)
     total_score = 0.0
     compilation_pass_count = 0

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -52,7 +52,7 @@ def _build_general_report_lines(
         f"  Speedup > 1.0 Count:   {aggregate_result['speedup_gt_1_count']}/{aggregate_result['total_tasks']}",
         f"  Speedup > 1.0 Rate:    {aggregate_result['speedup_gt_1_rate']:.1f}%",
         f"  Average Speedup:       {aggregate_result['average_speedup']:.2f}x",
-        f"  Median Speedup:       {aggregate_result.get('median_speedup', 0.0):.2f}x",
+        f"  Median Speedup:        {aggregate_result.get('median_speedup', 0.0):.2f}x",
         f"  Std Dev Speedup:       {aggregate_result.get('std_dev_speedup', 0.0):.2f}x",
         f"  P25/P75/P90 Speedup:   {aggregate_result.get('p25_speedup', 0.0):.2f}x / {aggregate_result.get('p75_speedup', 0.0):.2f}x / {aggregate_result.get('p90_speedup', 0.0):.2f}x",
         f"  Valid Speedup Count:   {aggregate_result['valid_speedup_count']}",
@@ -176,6 +176,61 @@ def _extract_run_metadata(run_directory: Path) -> Dict[str, str]:
     }
 
 
+def _compute_speedup_stats(speedup_values: List[float]) -> Dict[str, float]:
+    """
+    Compute speedup statistics: average, median, std dev, and percentiles (P25, P75, P90).
+
+    Args:
+        speedup_values: List of valid speedup ratios (> 0).
+
+    Returns:
+        Dict with keys: average_speedup, median_speedup, std_dev_speedup,
+        p25_speedup, p75_speedup, p90_speedup.
+    """
+    if not speedup_values:
+        return {
+            'average_speedup': 0.0,
+            'median_speedup': 0.0,
+            'std_dev_speedup': 0.0,
+            'p25_speedup': 0.0,
+            'p75_speedup': 0.0,
+            'p90_speedup': 0.0,
+        }
+
+    average = sum(speedup_values) / len(speedup_values)
+
+    try:
+        median = statistics.median(speedup_values)
+    except statistics.StatisticsError:
+        median = 0.0
+
+    try:
+        std_dev = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
+    except statistics.StatisticsError:
+        std_dev = 0.0
+
+    if len(speedup_values) == 1:
+        p25 = p75 = p90 = speedup_values[0]
+    else:
+        try:
+            # statistics.quantiles with n=100 gives 99 cut points; index 24 = P25, etc.
+            quantile_cuts = statistics.quantiles(speedup_values, n=100)
+            p25 = quantile_cuts[24]
+            p75 = quantile_cuts[74]
+            p90 = quantile_cuts[89]
+        except (statistics.StatisticsError, IndexError, ValueError):
+            p25 = p75 = p90 = 0.0
+
+    return {
+        'average_speedup': average,
+        'median_speedup': median,
+        'std_dev_speedup': std_dev,
+        'p25_speedup': p25,
+        'p75_speedup': p75,
+        'p90_speedup': p90,
+    }
+
+
 def _extract_task_type(task_name: str) -> str:
     """
     Extract task type from task name.
@@ -233,48 +288,8 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
     for task_type, stats in type_stats.items():
         count = stats['count']
         speedup_values = stats['speedup_values']
-        
-        # Calculate speedup statistics
-        average_speedup = (sum(speedup_values) / len(speedup_values)) if speedup_values else 0.0
-        
-        try:
-            median_speedup = statistics.median(speedup_values) if speedup_values else 0.0
-        except statistics.StatisticsError:
-            median_speedup = 0.0
-        
-        try:
-            std_dev_speedup = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
-        except statistics.StatisticsError:
-            std_dev_speedup = 0.0
-        
-        # Calculate percentiles (P25, P75, P90)
-        try:
-            if speedup_values and len(speedup_values) > 0:
-                sorted_speedups = sorted(speedup_values)
-                n = len(sorted_speedups)
-                if n == 1:
-                    p25_speedup = sorted_speedups[0]
-                    p75_speedup = sorted_speedups[0]
-                    p90_speedup = sorted_speedups[0]
-                else:
-                    # P25 (25th percentile)
-                    p25_idx = int(0.25 * (n - 1))
-                    p25_speedup = sorted_speedups[p25_idx] if p25_idx < n else sorted_speedups[-1]
-                    # P75 (75th percentile)
-                    p75_idx = int(0.75 * (n - 1))
-                    p75_speedup = sorted_speedups[p75_idx] if p75_idx < n else sorted_speedups[-1]
-                    # P90 (90th percentile)
-                    p90_idx = int(0.90 * (n - 1))
-                    p90_speedup = sorted_speedups[p90_idx] if p90_idx < n else sorted_speedups[-1]
-            else:
-                p25_speedup = 0.0
-                p75_speedup = 0.0
-                p90_speedup = 0.0
-        except (statistics.StatisticsError, IndexError, ValueError):
-            p25_speedup = 0.0
-            p75_speedup = 0.0
-            p90_speedup = 0.0
-        
+        speed_stats = _compute_speedup_stats(speedup_values)
+
         result[task_type] = {
             'count': count,
             'total_score': stats['total_score'],
@@ -285,12 +300,7 @@ def _aggregate_by_task_type(task_details: List[Dict[str, Any]]) -> Dict[str, Dic
             'correctness_pass_rate': (stats['correctness_pass_count'] / count * 100) if count > 0 else 0.0,
             'speedup_gt_1_count': stats['speedup_gt_1_count'],
             'speedup_gt_1_rate': (stats['speedup_gt_1_count'] / count * 100) if count > 0 else 0.0,
-            'average_speedup': average_speedup,
-            'median_speedup': median_speedup,
-            'std_dev_speedup': std_dev_speedup,
-            'p25_speedup': p25_speedup,
-            'p75_speedup': p75_speedup,
-            'p90_speedup': p90_speedup,
+            **speed_stats,
             'valid_speedup_count': len(speedup_values)
         }
     
@@ -487,47 +497,8 @@ def general_post_processing(
     correctness_pass_rate = (correctness_pass_count / total_tasks * 100) if total_tasks > 0 else 0.0
     speedup_gt_1_rate = (speedup_gt_1_count / total_tasks * 100) if total_tasks > 0 else 0.0
 
-    # Calculate average speedup (only for valid speedups)
-    average_speedup = (sum(speedup_values) / len(speedup_values)) if speedup_values else 0.0
-    
-    # Calculate median and standard deviation for speedups
-    try:
-        median_speedup = statistics.median(speedup_values) if speedup_values else 0.0
-    except statistics.StatisticsError:
-        median_speedup = 0.0
-    
-    try:
-        std_dev_speedup = statistics.stdev(speedup_values) if len(speedup_values) > 1 else 0.0
-    except statistics.StatisticsError:
-        std_dev_speedup = 0.0
-    
-    # Calculate percentiles (P25, P75, P90)
-    try:
-        if speedup_values and len(speedup_values) > 0:
-            sorted_speedups = sorted(speedup_values)
-            n = len(sorted_speedups)
-            if n == 1:
-                p25_speedup = sorted_speedups[0]
-                p75_speedup = sorted_speedups[0]
-                p90_speedup = sorted_speedups[0]
-            else:
-                # P25 (25th percentile)
-                p25_idx = int(0.25 * (n - 1))
-                p25_speedup = sorted_speedups[p25_idx] if p25_idx < n else sorted_speedups[-1]
-                # P75 (75th percentile)
-                p75_idx = int(0.75 * (n - 1))
-                p75_speedup = sorted_speedups[p75_idx] if p75_idx < n else sorted_speedups[-1]
-                # P90 (90th percentile)
-                p90_idx = int(0.90 * (n - 1))
-                p90_speedup = sorted_speedups[p90_idx] if p90_idx < n else sorted_speedups[-1]
-        else:
-            p25_speedup = 0.0
-            p75_speedup = 0.0
-            p90_speedup = 0.0
-    except (statistics.StatisticsError, IndexError, ValueError):
-        p25_speedup = 0.0
-        p75_speedup = 0.0
-        p90_speedup = 0.0
+    # Calculate speedup statistics using shared helper
+    speed_stats = _compute_speedup_stats(speedup_values)
 
     # Generate aggregate_result
     aggregate_result = {
@@ -544,12 +515,7 @@ def general_post_processing(
         'speedup_gt_1_count': speedup_gt_1_count,
         'speedup_gt_1_rate': speedup_gt_1_rate,
 
-        'average_speedup': average_speedup,
-        'median_speedup': median_speedup,
-        'std_dev_speedup': std_dev_speedup,
-        'p25_speedup': p25_speedup,
-        'p75_speedup': p75_speedup,
-        'p90_speedup': p90_speedup,
+        **speed_stats,
         'valid_speedup_count': len(speedup_values),
 
         'task_details': task_details

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -64,6 +64,23 @@ def check_environment() -> None:
     pass
 
 
+def is_task_complete(run_directory: Path, task_folder_name: str, timestamp: str) -> bool:
+    """
+    Check if a task is already completed.
+    
+    Args:
+        run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
+        task_folder_name: Name of the task folder (e.g., "hip2hip/silu" -> "silu")
+        timestamp: Timestamp string used in task directory name
+    
+    Returns:
+        True if task directory exists and task_result.yaml exists, False otherwise
+    """
+    task_dir = run_directory / f"{task_folder_name}_{timestamp}"
+    result_file = task_dir / "task_result.yaml"
+    return result_file.exists()
+
+
 def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, logger: logging.Logger) -> Path:
     """
     Setup workspace for agent execution by duplicating task directory.

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -64,24 +64,31 @@ def check_environment() -> None:
     pass
 
 
-def is_task_complete(run_directory: Path, task_folder_name: str, timestamp: str) -> bool:
+def _sanitize_task_name(task_name: str) -> str:
+    """Convert a task name like 'hip2hip/gpumode/SiLU' to 'hip2hip_gpumode_SiLU' for use in directory names."""
+    return task_name.replace("/", "_")
+
+
+def is_task_complete(run_directory: Path, task_name: str, timestamp: str) -> bool:
     """
     Check if a task is already completed.
-    
+
     Args:
         run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
-        task_folder_name: Name of the task folder (e.g., "hip2hip/silu" -> "silu")
+        task_name: Full task name (e.g., "hip2hip/gpumode/SiLU")
         timestamp: Timestamp string used in task directory name
-    
+
     Returns:
         True if task directory exists and task_result.yaml exists, False otherwise
     """
-    task_dir = run_directory / f"{task_folder_name}_{timestamp}"
+    sanitized = _sanitize_task_name(task_name)
+    task_dir = run_directory / f"{sanitized}_{timestamp}"
     result_file = task_dir / "task_result.yaml"
     return result_file.exists()
 
 
-def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, logger: logging.Logger) -> Path:
+def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, logger: logging.Logger,
+                    task_name: str = "") -> Path:
     """
     Setup workspace for agent execution by duplicating task directory.
 
@@ -90,6 +97,7 @@ def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, l
         run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
         timestamp: Timestamp string for unique workspace naming
         logger: Logger instance
+        task_name: Full task name (e.g., "hip2hip/gpumode/SiLU") for unique directory naming
 
     Returns:
         Path to the created workspace directory
@@ -97,10 +105,13 @@ def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, l
     # 1. Get task_folder name (parent directory of task_config_dir)
     task_config_path = Path(task_config_dir)
     task_folder = task_config_path.parent
-    task_folder_name = task_folder.name
 
     # 2. Create new directory with timestamp suffix under run_directory
-    new_folder_name = f"{task_folder_name}_{timestamp}"
+    # Use sanitized full task_name to avoid collisions between tasks with the same leaf name
+    if task_name:
+        new_folder_name = f"{_sanitize_task_name(task_name)}_{timestamp}"
+    else:
+        new_folder_name = f"{task_folder.name}_{timestamp}"
     workspace_path = run_directory / new_folder_name
     workspace_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -64,13 +64,13 @@ def check_environment() -> None:
     pass
 
 
-def setup_workspace(task_config_dir: str, workspace_directory: str, timestamp: str, logger: logging.Logger) -> Path:
+def setup_workspace(task_config_dir: str, run_directory: Path, timestamp: str, logger: logging.Logger) -> Path:
     """
     Setup workspace for agent execution by duplicating task directory.
 
     Args:
         task_config_dir: Path to task's config.yaml
-        workspace_directory: Base workspace directory
+        run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
         timestamp: Timestamp string for unique workspace naming
         logger: Logger instance
 
@@ -82,9 +82,9 @@ def setup_workspace(task_config_dir: str, workspace_directory: str, timestamp: s
     task_folder = task_config_path.parent
     task_folder_name = task_folder.name
 
-    # 2. Create new directory with timestamp suffix under workspace_dir
+    # 2. Create new directory with timestamp suffix under run_directory
     new_folder_name = f"{task_folder_name}_{timestamp}"
-    workspace_path = Path(workspace_directory) / new_folder_name
+    workspace_path = run_directory / new_folder_name
     workspace_path.mkdir(parents=True, exist_ok=True)
 
     logger.info(f"Created workspace directory: {workspace_path}")


### PR DESCRIPTION
## Summary

This PR adds a run-based workspace layout with timestamped reports so each run is isolated and comparable. It includes: restructured workspace directories, timestamped report files (overall report, CSV summary, task-type breakdown JSON), a comparison script for two runs, resume support to extend an existing run, and richer speedup stats (median, std dev, percentiles). The default config is updated to 60 representative tasks for benchmarking.

## Changes (8 commits)

### 1. Restructure workspace directory creation
- **Commit**: `e2e4475`
- Each run gets a top-level directory `run_{timestamp}/` (timestamp format `YYYYMMDD_HHMMSS`). All task subdirectories for that run live inside it. This avoids overwriting previous results and keeps runs separate.

### 2. Update post-processing for timestamped reports
- **Commit**: `7384981`
- Post-processing writes into `run_{timestamp}/reports/` instead of the workspace root. It generates: `overall_report.txt`, `overall_summary.csv`, and structured report data. The old single `task_results_report.txt` at workspace root is no longer used.

### 3. Add task type breakdown functionality
- **Commit**: `07ce786`
- Reports aggregate by task type (e.g. hip2hip, triton2triton, torch2hip, instruction2triton). Each type gets counts, pass rates, and speedup stats. A `task_type_breakdown.json` is written under `reports/` for automation and comparison.

### 4. Create comparison script
- **Commit**: `798be14`
- Adds `compare_runs.py` at repo root. It loads the JSON breakdowns from two runs, computes differences (e.g. pass rates, speedups), and prints a comparison report. Usage: `python compare_runs.py <run1_path> <run2_path>`.

### 5. Add resume functionality
- **Commit**: `6ed34ae`
- Adds `--resume-run run_YYYYMMDD_HHMMSS` and `--resume-latest` to continue an existing run. Completed tasks (directory exists and contains `task_result.yaml`) are skipped. New tasks use the original run timestamp and are added to the same run directory and reports.

### 6. Add median and std calculation to speedup
- **Commit**: `da222ac`
- Speedup evaluation now computes **median speedup** and **standard deviation** (over tasks with valid speedups), in addition to average. These are included in overall and per–task-type stats in the report and in `task_type_breakdown.json`.

### 7. Add percentiles reporting to speedup evaluation
- **Commit**: `7b710b3`
- Adds **P25, P75, and P90** speedup percentiles for overall and per–task-type breakdowns. They appear in the text report, in the JSON/CSV outputs, and in `compare_runs.py` when comparing two runs.

### 8. Update config with 60 representative tasks for benchmarking
- **Commit**: `3d3dd50`
- `config.yaml` is updated to 60 representative tasks so benchmark runs are smaller and more focused while still covering a variety of task types and workloads.

## Output layout

After a run:
- `workspace_<target>/run_YYYYMMDD_HHMMSS/` — one directory per run
  - Task dirs: `task_<name>_YYYYMMDD_HHMMSS/`
  - `reports/`
    - `overall_report.txt` — human-readable report (overall + task-type breakdowns, median/std/percentiles)
    - `overall_summary.csv` — all tasks in CSV form
    - `task_type_breakdown.json` — structured stats for automation and `compare_runs.py`

## Testing

- ✅ Run the pipeline: results should appear under `run_{timestamp}/reports/` with the new metrics.
- ✅ Run `compare_runs.py` on two run directories to confirm comparison output includes the new speedup metrics.
- ✅ Use `--resume-run` or `--resume-latest` to add tasks to an existing run and confirm completed tasks are skipped and reports stay consistent.
