### PR TITLE
Add a visualization dashboard for AgentKernelArena run reports

### DIFF
--- a/visualization/.gitignore
+++ b/visualization/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+__pycache__/
+*.pyc
+*.pyo
+
+# Generated dashboard payloads
+frontend/dashboard/data.js
+frontend/dashboard/data.json
+
+# Local runtime artifacts
+*.log
+*.pid

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -1,0 +1,86 @@
+# AgentKernelArena Visualization
+
+Static dashboard for comparing run reports produced by AgentKernelArena.
+
+The app lives under `visualization/`, but it scans the parent AgentKernelArena
+repository for report directories that contain:
+
+- `overall_summary.csv`
+- `task_type_breakdown.json`
+- `overall_report.txt`
+
+In the standard AgentKernelArena layout, those files are usually located at:
+
+```text
+workspace_<gpu>_<agent>/run_<timestamp>/reports/
+```
+
+## Structure
+
+```text
+visualization/
+├── backend/
+│   ├── server.py
+│   └── scripts/
+│       └── build_dashboard_data.py
+├── frontend/
+│   ├── index.html
+│   └── dashboard/
+│       ├── app.js
+│       ├── styles.css
+│       ├── data.js
+│       └── data.json
+├── .gitignore
+├── README.md
+└── setup.sh
+```
+
+`frontend/dashboard/data.js` and `frontend/dashboard/data.json` are generated files.
+
+## Usage
+
+From the `visualization/` directory:
+
+```bash
+python backend/scripts/build_dashboard_data.py
+python backend/server.py --host 127.0.0.1 --port 8080
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8080
+```
+
+## Serve on Port 80
+
+Port `80` usually requires elevated privileges:
+
+```bash
+sudo python backend/server.py --host 0.0.0.0 --port 80
+```
+
+Or use the helper script:
+
+```bash
+bash setup.sh
+```
+
+`setup.sh` rebuilds the dashboard data first, then starts the HTTP service on port `80`.
+
+## Rebuild After New Runs
+
+Whenever AgentKernelArena produces new run reports, rebuild the dashboard payload:
+
+```bash
+python backend/scripts/build_dashboard_data.py
+```
+
+The dashboard will automatically pick up newly discovered report directories on the next refresh.
+
+## Notes
+
+- The HTTP service serves the dashboard UI from `frontend/`.
+- Source-file links inside the dashboard are exposed through an `/artifacts/...` route.
+- `/artifacts/...` only allows `.csv`, `.json`, and `.txt` files.
+- If no reports are found yet, the dashboard still builds and shows an empty state.

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -15,6 +15,16 @@ In the standard AgentKernelArena layout, those files are usually located at:
 workspace_<gpu>_<agent>/run_<timestamp>/reports/
 ```
 
+It also supports local visualization-specific report bundles stored as:
+
+```text
+visualization/reports/<report_name>/
+```
+
+By default, the dashboard scans only `visualization/reports/<report_name>/`.
+
+Workspace-run scanning is available, but it is opt-in and must be enabled explicitly.
+
 ## Structure
 
 ```text
@@ -76,7 +86,25 @@ Whenever AgentKernelArena produces new run reports, rebuild the dashboard payloa
 python backend/scripts/build_dashboard_data.py
 ```
 
-The dashboard will automatically pick up newly discovered report directories on the next refresh.
+This default mode only scans:
+
+```text
+visualization/reports/<report_name>/
+```
+
+To also scan workspace runs, enable the explicit flag:
+
+```bash
+python backend/scripts/build_dashboard_data.py --include-workspace-runs
+```
+
+Or via the helper script:
+
+```bash
+bash setup.sh --include-workspace-runs
+```
+
+The dashboard will pick up newly discovered report directories on the next refresh.
 
 ## Notes
 

--- a/visualization/backend/scripts/build_dashboard_data.py
+++ b/visualization/backend/scripts/build_dashboard_data.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import csv
 import json
 import re
@@ -57,37 +58,93 @@ def artifact_path(path: Path) -> str:
     return "artifacts/" + path.relative_to(PROJECT_ROOT).as_posix()
 
 
-def discover_report_directories() -> list[Path]:
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build dashboard data for AgentKernelArena visualization."
+    )
+    parser.add_argument(
+        "--include-workspace-runs",
+        action="store_true",
+        help="Also scan workspace_*/run_*/reports outside visualization/reports.",
+    )
+    return parser.parse_args()
+
+
+def is_local_visualization_report_directory(report_dir: Path) -> bool:
+    try:
+        relative = report_dir.relative_to(PROJECT_ROOT)
+    except ValueError:
+        return False
+
+    return (
+        len(relative.parts) == 3
+        and relative.parts[0] == "visualization"
+        and relative.parts[1] == "reports"
+    )
+
+
+def is_workspace_run_report_directory(report_dir: Path) -> bool:
+    try:
+        relative = report_dir.relative_to(PROJECT_ROOT)
+    except ValueError:
+        return False
+
+    return (
+        len(relative.parts) == 3
+        and relative.parts[0].startswith("workspace_")
+        and relative.parts[1].startswith("run_")
+        and relative.parts[2] == "reports"
+    )
+
+
+def has_required_report_files(report_dir: Path) -> bool:
+    return all(
+        (report_dir / filename).exists()
+        for filename in ("overall_summary.csv", "task_type_breakdown.json", "overall_report.txt")
+    )
+
+
+def discover_report_directories(include_workspace_runs: bool = False) -> list[Path]:
     report_dirs: list[Path] = []
     seen: set[Path] = set()
 
-    for json_path in PROJECT_ROOT.rglob("task_type_breakdown.json"):
-        report_dir = json_path.parent.resolve()
-        if report_dir in seen:
-            continue
+    visualization_reports_root = VISUALIZATION_ROOT / "reports"
+    if visualization_reports_root.exists():
+        for report_dir in sorted(p for p in visualization_reports_root.iterdir() if p.is_dir()):
+            report_dir = report_dir.resolve()
+            if report_dir in seen or not is_local_visualization_report_directory(report_dir):
+                continue
+            if not has_required_report_files(report_dir):
+                continue
+            seen.add(report_dir)
+            report_dirs.append(report_dir)
 
-        try:
-            relative = report_dir.relative_to(PROJECT_ROOT)
-        except ValueError:
-            continue
-
-        if relative.parts and relative.parts[0] == "visualization":
-            continue
-
-        summary_csv = report_dir / "overall_summary.csv"
-        detail_report = report_dir / "overall_report.txt"
-        if not summary_csv.exists() or not detail_report.exists():
-            continue
-
-        seen.add(report_dir)
-        report_dirs.append(report_dir)
+    if include_workspace_runs:
+        for workspace_dir in sorted(
+            p for p in PROJECT_ROOT.iterdir() if p.is_dir() and p.name.startswith("workspace_")
+        ):
+            for run_dir in sorted(
+                p for p in workspace_dir.iterdir() if p.is_dir() and p.name.startswith("run_")
+            ):
+                report_dir = (run_dir / "reports").resolve()
+                if report_dir in seen or not report_dir.is_dir():
+                    continue
+                if not is_workspace_run_report_directory(report_dir):
+                    continue
+                if not has_required_report_files(report_dir):
+                    continue
+                seen.add(report_dir)
+                report_dirs.append(report_dir)
 
     return sorted(report_dirs, key=lambda path: path.relative_to(PROJECT_ROOT).as_posix())
 
 
 def report_identity(report_dir: Path) -> dict[str, str]:
     relative = report_dir.relative_to(PROJECT_ROOT)
-    base_path = relative.parent if relative.name == "reports" else relative
+    if is_local_visualization_report_directory(report_dir):
+        base_path = relative
+    else:
+        base_path = relative.parent if relative.name == "reports" else relative
     label = base_path.as_posix() if base_path.parts else relative.as_posix()
     return {
         "id": label.replace("/", "__"),
@@ -96,13 +153,15 @@ def report_identity(report_dir: Path) -> dict[str, str]:
     }
 
 
-def build_dataset() -> dict[str, Any]:
+def build_dataset(include_workspace_runs: bool = False) -> dict[str, Any]:
     warnings: list[str] = []
     reports: list[dict[str, Any]] = []
     task_catalog: dict[str, dict[str, Any]] = {}
     all_statuses: set[str] = set()
     all_gpus: set[str] = set()
-    discovered_report_dirs = discover_report_directories()
+    discovered_report_dirs = discover_report_directories(
+        include_workspace_runs=include_workspace_runs
+    )
 
     for report_dir in discovered_report_dirs:
         report_meta = report_identity(report_dir)
@@ -230,6 +289,7 @@ def build_dataset() -> dict[str, Any]:
             "statuses": sorted(all_statuses),
             "targetGpus": sorted(all_gpus),
             "scanRoot": PROJECT_ROOT.as_posix(),
+            "includeWorkspaceRuns": include_workspace_runs,
             "discoveredReportDirectories": [
                 path.relative_to(PROJECT_ROOT).as_posix() for path in discovered_report_dirs
             ],
@@ -243,8 +303,9 @@ def build_dataset() -> dict[str, Any]:
 
 
 def main() -> None:
+    args = parse_args()
     DASHBOARD_DIR.mkdir(parents=True, exist_ok=True)
-    dataset = build_dataset()
+    dataset = build_dataset(include_workspace_runs=args.include_workspace_runs)
     OUTPUT_JSON.write_text(json.dumps(dataset, indent=2))
     OUTPUT_JS.write_text(
         "window.ARENA_REPORT_DATA = " + json.dumps(dataset, indent=2) + ";\n"
@@ -252,7 +313,10 @@ def main() -> None:
 
     print(f"Wrote {OUTPUT_JSON.relative_to(VISUALIZATION_ROOT)}")
     print(f"Wrote {OUTPUT_JS.relative_to(VISUALIZATION_ROOT)}")
-    print(f"Discovered {len(dataset['reports'])} report directories under {PROJECT_ROOT}")
+    print(
+        f"Discovered {len(dataset['reports'])} report directories under {PROJECT_ROOT} "
+        f"(include_workspace_runs={args.include_workspace_runs})"
+    )
     warnings = dataset["meta"]["warnings"]
     if warnings:
         print(f"Warnings: {len(warnings)}")

--- a/visualization/backend/scripts/build_dashboard_data.py
+++ b/visualization/backend/scripts/build_dashboard_data.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Build a browser-friendly data bundle for the Arena report dashboard."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+VISUALIZATION_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = VISUALIZATION_ROOT.parent
+DASHBOARD_DIR = VISUALIZATION_ROOT / "frontend" / "dashboard"
+OUTPUT_JSON = DASHBOARD_DIR / "data.json"
+OUTPUT_JS = DASHBOARD_DIR / "data.js"
+
+STATUS_PATTERN = re.compile(
+    r"^(PASS|FAIL|PARTIAL)\s+(\S+)\s+Score:\s*([0-9.]+)\s+Speedup:\s*([0-9.]+)x\s*$"
+)
+
+
+def format_run_timestamp(raw: str) -> str:
+    try:
+        dt = datetime.strptime(raw, "%Y%m%d_%H%M%S")
+    except ValueError:
+        return raw
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def load_status_map(report_path: Path) -> dict[str, dict[str, Any]]:
+    status_map: dict[str, dict[str, Any]] = {}
+    for line in report_path.read_text().splitlines():
+        match = STATUS_PATTERN.match(line.strip())
+        if not match:
+            continue
+        status, task_name, score, speedup = match.groups()
+        status_map[task_name] = {
+            "status": status,
+            "score_from_report": float(score),
+            "speedup_from_report": float(speedup),
+        }
+    return status_map
+
+
+def as_float(value: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def artifact_path(path: Path) -> str:
+    return "artifacts/" + path.relative_to(PROJECT_ROOT).as_posix()
+
+
+def discover_report_directories() -> list[Path]:
+    report_dirs: list[Path] = []
+    seen: set[Path] = set()
+
+    for json_path in PROJECT_ROOT.rglob("task_type_breakdown.json"):
+        report_dir = json_path.parent.resolve()
+        if report_dir in seen:
+            continue
+
+        try:
+            relative = report_dir.relative_to(PROJECT_ROOT)
+        except ValueError:
+            continue
+
+        if relative.parts and relative.parts[0] == "visualization":
+            continue
+
+        summary_csv = report_dir / "overall_summary.csv"
+        detail_report = report_dir / "overall_report.txt"
+        if not summary_csv.exists() or not detail_report.exists():
+            continue
+
+        seen.add(report_dir)
+        report_dirs.append(report_dir)
+
+    return sorted(report_dirs, key=lambda path: path.relative_to(PROJECT_ROOT).as_posix())
+
+
+def report_identity(report_dir: Path) -> dict[str, str]:
+    relative = report_dir.relative_to(PROJECT_ROOT)
+    base_path = relative.parent if relative.name == "reports" else relative
+    label = base_path.as_posix() if base_path.parts else relative.as_posix()
+    return {
+        "id": label.replace("/", "__"),
+        "label": label,
+        "reportPath": relative.as_posix(),
+    }
+
+
+def build_dataset() -> dict[str, Any]:
+    warnings: list[str] = []
+    reports: list[dict[str, Any]] = []
+    task_catalog: dict[str, dict[str, Any]] = {}
+    all_statuses: set[str] = set()
+    all_gpus: set[str] = set()
+    discovered_report_dirs = discover_report_directories()
+
+    for report_dir in discovered_report_dirs:
+        report_meta = report_identity(report_dir)
+        summary_csv = report_dir / "overall_summary.csv"
+        breakdown_json = report_dir / "task_type_breakdown.json"
+        detail_report = report_dir / "overall_report.txt"
+
+        missing = [p.name for p in (summary_csv, breakdown_json, detail_report) if not p.exists()]
+        if missing:
+            warnings.append(
+                f"Skipped {report_dir.name}: missing {', '.join(sorted(missing))}"
+            )
+            continue
+
+        breakdown = json.loads(breakdown_json.read_text())
+        status_map = load_status_map(detail_report)
+        tasks: list[dict[str, Any]] = []
+
+        with summary_csv.open(newline="") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                task_name = row["Task Name"].strip()
+                task_type = row["Task Type"].strip()
+                status = status_map.get(task_name, {}).get("status", "UNKNOWN")
+                task = {
+                    "taskName": task_name,
+                    "taskType": task_type,
+                    "status": status,
+                    "score": as_float(row["Score"]),
+                    "speedup": as_float(row["Speedup"]),
+                    "optimizationSummary": row["Optimization_summary"].strip(),
+                }
+                tasks.append(task)
+                all_statuses.add(status)
+
+                catalog_entry = task_catalog.setdefault(
+                    task_name,
+                    {
+                        "taskName": task_name,
+                        "taskType": task_type,
+                        "presentInReports": [],
+                    },
+                )
+                if catalog_entry["taskType"] != task_type:
+                    warnings.append(
+                        f"Task type mismatch for {task_name}: "
+                        f"{catalog_entry['taskType']} vs {task_type} in {report_meta['label']}"
+                    )
+                catalog_entry["presentInReports"].append(report_meta["id"])
+
+        missing_in_csv = set(status_map) - {task["taskName"] for task in tasks}
+        for task_name in sorted(missing_in_csv):
+            status_info = status_map[task_name]
+            inferred_task_type = task_name.split("/", 1)[0] if "/" in task_name else "unknown"
+            task = {
+                "taskName": task_name,
+                "taskType": inferred_task_type,
+                "status": status_info["status"],
+                "score": status_info["score_from_report"],
+                "speedup": status_info["speedup_from_report"],
+                "optimizationSummary": "Recovered from overall_report.txt",
+            }
+            tasks.append(task)
+            all_statuses.add(task["status"])
+            task_catalog.setdefault(
+                task_name,
+                {
+                    "taskName": task_name,
+                    "taskType": inferred_task_type,
+                    "presentInReports": [],
+                },
+            )["presentInReports"].append(report_meta["id"])
+            warnings.append(
+                f"{report_meta['label']}: recovered {task_name} from overall_report.txt only"
+            )
+
+        overall = breakdown.get("overall", {})
+        task_types = breakdown.get("task_types", {})
+        all_gpus.add(str(breakdown.get("target_gpu", "unknown")))
+
+        reports.append(
+            {
+                "id": report_meta["id"],
+                "label": report_meta["label"],
+                "agent": breakdown.get("agent", "unknown"),
+                "runTimestamp": breakdown.get("run_timestamp", ""),
+                "runTimestampFormatted": format_run_timestamp(
+                    breakdown.get("run_timestamp", "")
+                ),
+                "targetGpu": breakdown.get("target_gpu", "unknown"),
+                "reportPath": report_meta["reportPath"],
+                "overall": overall,
+                "taskTypes": task_types,
+                "tasks": sorted(tasks, key=lambda item: item["taskName"]),
+                "sourceFiles": {
+                    "summaryCsv": artifact_path(summary_csv),
+                    "breakdownJson": artifact_path(breakdown_json),
+                    "overallReport": artifact_path(detail_report),
+                },
+            }
+        )
+
+    reports.sort(
+        key=lambda report: report.get("overall", {}).get("total_score", 0.0), reverse=True
+    )
+
+    timestamps = [
+        report["runTimestamp"]
+        for report in reports
+        if report.get("runTimestamp")
+    ]
+    latest_run = max(timestamps) if timestamps else ""
+    task_type_totals: dict[str, int] = defaultdict(int)
+    for item in task_catalog.values():
+        task_type_totals[item["taskType"]] += 1
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    dataset = {
+        "meta": {
+            "generatedAt": generated_at,
+            "latestRunTimestamp": latest_run,
+            "latestRunTimestampFormatted": format_run_timestamp(latest_run) if latest_run else "",
+            "reportCount": len(reports),
+            "taskCount": len(task_catalog),
+            "statuses": sorted(all_statuses),
+            "targetGpus": sorted(all_gpus),
+            "scanRoot": PROJECT_ROOT.as_posix(),
+            "discoveredReportDirectories": [
+                path.relative_to(PROJECT_ROOT).as_posix() for path in discovered_report_dirs
+            ],
+            "warnings": warnings,
+        },
+        "reports": reports,
+        "taskCatalog": sorted(task_catalog.values(), key=lambda item: item["taskName"]),
+        "taskTypeTotals": dict(sorted(task_type_totals.items())),
+    }
+    return dataset
+
+
+def main() -> None:
+    DASHBOARD_DIR.mkdir(parents=True, exist_ok=True)
+    dataset = build_dataset()
+    OUTPUT_JSON.write_text(json.dumps(dataset, indent=2))
+    OUTPUT_JS.write_text(
+        "window.ARENA_REPORT_DATA = " + json.dumps(dataset, indent=2) + ";\n"
+    )
+
+    print(f"Wrote {OUTPUT_JSON.relative_to(VISUALIZATION_ROOT)}")
+    print(f"Wrote {OUTPUT_JS.relative_to(VISUALIZATION_ROOT)}")
+    print(f"Discovered {len(dataset['reports'])} report directories under {PROJECT_ROOT}")
+    warnings = dataset["meta"]["warnings"]
+    if warnings:
+        print(f"Warnings: {len(warnings)}")
+        for warning in warnings:
+            print(f"  - {warning}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/backend/server.py
+++ b/visualization/backend/server.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Small static HTTP service for the Arena dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import mimetypes
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+VISUALIZATION_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = VISUALIZATION_ROOT.parent
+FRONTEND_ROOT = VISUALIZATION_ROOT / "frontend"
+INDEX_FILE = FRONTEND_ROOT / "index.html"
+ROUTE_ROOTS = {
+    "dashboard": FRONTEND_ROOT / "dashboard",
+    "artifacts": PROJECT_ROOT,
+}
+ARTIFACT_EXTENSIONS = {".csv", ".json", ".txt"}
+
+
+class DashboardHandler(SimpleHTTPRequestHandler):
+    """Serve only the dashboard assets needed by the static UI."""
+
+    server_version = "ArenaDashboardHTTP/1.0"
+
+    def translate_path(self, path: str) -> str:
+        normalized = self._normalize_request_path(path)
+        if normalized is None:
+            return str(VISUALIZATION_ROOT / "__forbidden__")
+        return str(normalized)
+
+    def do_GET(self) -> None:
+        if self._normalize_request_path(self.path) is None:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return
+        super().do_GET()
+
+    def do_HEAD(self) -> None:
+        if self._normalize_request_path(self.path) is None:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return
+        super().do_HEAD()
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def list_directory(self, path: str):  # type: ignore[override]
+        self.send_error(HTTPStatus.NOT_FOUND, "Directory listing is disabled")
+        return None
+
+    def guess_type(self, path: str) -> str:
+        if path.endswith(".csv"):
+            return "text/csv; charset=utf-8"
+        if path.endswith(".json"):
+            return "application/json; charset=utf-8"
+        if path.endswith(".txt"):
+            return "text/plain; charset=utf-8"
+        return mimetypes.guess_type(path)[0] or "application/octet-stream"
+
+    def _normalize_request_path(self, raw_path: str) -> Path | None:
+        path = raw_path.split("?", 1)[0].split("#", 1)[0]
+        if path in ("", "/"):
+            return INDEX_FILE
+
+        if path == "/index.html":
+            return INDEX_FILE
+
+        clean = path.lstrip("/")
+        if not clean:
+            return INDEX_FILE
+
+        if clean.startswith(".") or "/." in clean:
+            return None
+
+        candidate = Path(clean)
+        if candidate.is_absolute():
+            return None
+
+        if not candidate.parts:
+            return None
+
+        route_name = candidate.parts[0]
+        route_root = ROUTE_ROOTS.get(route_name)
+        if route_root is None:
+            return None
+
+        resolved = (route_root / Path(*candidate.parts[1:])).resolve()
+        try:
+            resolved.relative_to(route_root.resolve())
+        except ValueError:
+            return None
+
+        if route_name == "artifacts" and resolved.is_file() and resolved.suffix not in ARTIFACT_EXTENSIONS:
+            return None
+
+        if clean == route_name:
+            return route_root
+
+        return resolved
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Serve the Arena dashboard over HTTP.")
+    parser.add_argument("--host", default="0.0.0.0", help="Host interface to bind. Default: 0.0.0.0")
+    parser.add_argument("--port", type=int, default=80, help="TCP port to bind. Default: 80")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        with ThreadingHTTPServer((args.host, args.port), DashboardHandler) as httpd:
+            print(f"Serving {FRONTEND_ROOT} at http://{args.host}:{args.port}")
+            httpd.serve_forever()
+    except KeyboardInterrupt:
+        raise SystemExit("Server stopped.")
+    except PermissionError:
+        raise SystemExit(
+            f"Permission denied binding to {args.host}:{args.port}. "
+            "Port 80 usually requires elevated privileges."
+        )
+    except OSError as exc:
+        raise SystemExit(f"Failed to bind {args.host}:{args.port}: {exc.strerror or exc}") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/frontend/dashboard/app.js
+++ b/visualization/frontend/dashboard/app.js
@@ -1,0 +1,671 @@
+(function () {
+  const dataset = window.ARENA_REPORT_DATA;
+
+  const elements = {
+    errorBanner: document.getElementById("error-banner"),
+    metaPill: document.getElementById("meta-pill"),
+    sourceNote: document.getElementById("source-note"),
+    summaryCards: document.getElementById("summary-cards"),
+    leaderboardBody: document.getElementById("leaderboard-body"),
+    heatmapHead: document.getElementById("heatmap-head"),
+    heatmapBody: document.getElementById("heatmap-body"),
+    heatmapCaption: document.getElementById("heatmap-caption"),
+    spotlightGrid: document.getElementById("spotlight-grid"),
+    taskTableHead: document.getElementById("task-table-head"),
+    taskTableBody: document.getElementById("task-table-body"),
+    taskTableCaption: document.getElementById("task-table-caption"),
+    reportChips: document.getElementById("report-chips"),
+    taskTypeChips: document.getElementById("task-type-chips"),
+    statusChips: document.getElementById("status-chips"),
+    taskSearch: document.getElementById("task-search"),
+    heatmapMetric: document.getElementById("heatmap-metric"),
+    taskSort: document.getElementById("task-sort"),
+  };
+
+  if (!dataset || !Array.isArray(dataset.reports)) {
+    showFatal(
+      "Dashboard data not found. Run `python backend/scripts/build_dashboard_data.py` to generate `frontend/dashboard/data.js` first."
+    );
+    return;
+  }
+
+  const reports = dataset.reports.slice();
+  const taskCatalog = Array.isArray(dataset.taskCatalog) ? dataset.taskCatalog.slice() : [];
+  const taskTypeOrder = Object.keys(dataset.taskTypeTotals || {}).sort(
+    (left, right) => (dataset.taskTypeTotals[right] || 0) - (dataset.taskTypeTotals[left] || 0)
+  );
+  const allTaskTypes = taskTypeOrder.length
+    ? taskTypeOrder
+    : Array.from(new Set(taskCatalog.map((item) => item.taskType))).sort();
+  const allStatuses = Array.from(
+    new Set([...(dataset.meta?.statuses || []), "PASS", "PARTIAL", "FAIL", "UNKNOWN"])
+  ).sort((left, right) => statusRank(left) - statusRank(right));
+
+  const reportContexts = new Map(
+    reports.map((report) => [
+      report.id,
+      {
+        report,
+        tasksByName: new Map((report.tasks || []).map((task) => [task.taskName, task])),
+      },
+    ])
+  );
+
+  const state = {
+    selectedReports: new Set(reports.map((report) => report.id)),
+    selectedTaskTypes: new Set(allTaskTypes),
+    selectedStatuses: new Set(allStatuses),
+    search: "",
+    heatmapMetric: elements.heatmapMetric.value,
+    taskSort: elements.taskSort.value,
+  };
+
+  bindEvents();
+  render();
+
+  function bindEvents() {
+    elements.taskSearch.addEventListener("input", (event) => {
+      state.search = event.target.value.trim().toLowerCase();
+      render();
+    });
+
+    elements.heatmapMetric.addEventListener("change", (event) => {
+      state.heatmapMetric = event.target.value;
+      render();
+    });
+
+    elements.taskSort.addEventListener("change", (event) => {
+      state.taskSort = event.target.value;
+      render();
+    });
+
+    document.querySelectorAll("[data-filter-action]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const action = button.dataset.filterAction;
+        if (action === "toggle-reports") {
+          toggleAll(state.selectedReports, reports.map((report) => report.id));
+        } else if (action === "toggle-task-types") {
+          toggleAll(state.selectedTaskTypes, allTaskTypes);
+        } else if (action === "toggle-statuses") {
+          toggleAll(state.selectedStatuses, allStatuses);
+        }
+        render();
+      });
+    });
+  }
+
+  function toggleAll(targetSet, allItems) {
+    if (targetSet.size === allItems.length) {
+      targetSet.clear();
+      return;
+    }
+    targetSet.clear();
+    allItems.forEach((item) => targetSet.add(item));
+  }
+
+  function render() {
+    renderMeta();
+    renderWarnings();
+    renderChips(elements.reportChips, reports, state.selectedReports, "report", (report) => ({
+      key: report.id,
+      label: report.label,
+      title: report.runTimestampFormatted || report.runTimestamp || report.label,
+    }));
+    renderChips(
+      elements.taskTypeChips,
+      allTaskTypes,
+      state.selectedTaskTypes,
+      "task-type",
+      (taskType) => ({ key: taskType, label: taskType })
+    );
+    renderChips(elements.statusChips, allStatuses, state.selectedStatuses, "status", (status) => ({
+      key: status,
+      label: status,
+    }));
+
+    const visibleReports = getVisibleReports();
+    const taskRows = buildTaskRows(visibleReports);
+
+    renderSummaryCards(visibleReports);
+    renderLeaderboard(visibleReports);
+    renderHeatmap(visibleReports);
+    renderSpotlights(visibleReports, taskRows);
+    renderTaskTable(visibleReports, taskRows);
+  }
+
+  function renderMeta() {
+    const latestRun = dataset.meta?.latestRunTimestampFormatted || "n/a";
+    elements.metaPill.textContent = `${reports.length} reports • latest run ${latestRun}`;
+    const gpuLabel = (dataset.meta?.targetGpus || []).join(", ") || "n/a";
+    elements.sourceNote.textContent = [
+      `Generated ${dataset.meta?.generatedAt || "unknown"}`,
+      `Tasks ${dataset.meta?.taskCount || 0}`,
+      `GPU ${gpuLabel}`,
+      `Scan root ${dataset.meta?.scanRoot || "unknown"}`,
+    ].join(" • ");
+  }
+
+  function renderWarnings() {
+    const warnings = dataset.meta?.warnings || [];
+    if (!warnings.length) {
+      elements.errorBanner.classList.add("hidden");
+      elements.errorBanner.textContent = "";
+      return;
+    }
+
+    const preview = warnings.slice(0, 4).join(" | ");
+    elements.errorBanner.textContent =
+      warnings.length > 4 ? `${preview} | +${warnings.length - 4} more` : preview;
+    elements.errorBanner.classList.remove("hidden");
+  }
+
+  function renderChips(container, items, selectedSet, group, toChip) {
+    container.innerHTML = "";
+    items.forEach((item) => {
+      const chipData = toChip(item);
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `chip${selectedSet.has(chipData.key) ? " active" : ""}`;
+      button.textContent = chipData.label;
+      if (chipData.title) {
+        button.title = chipData.title;
+      }
+      button.addEventListener("click", () => {
+        if (selectedSet.has(chipData.key)) {
+          selectedSet.delete(chipData.key);
+        } else {
+          selectedSet.add(chipData.key);
+        }
+        render();
+      });
+      button.dataset.group = group;
+      button.dataset.key = chipData.key;
+      container.appendChild(button);
+    });
+  }
+
+  function getVisibleReports() {
+    return reports.filter((report) => state.selectedReports.has(report.id));
+  }
+
+  function buildTaskRows(visibleReports) {
+    return taskCatalog
+      .map((catalogItem) => {
+        const cells = visibleReports.map((report) => {
+          const entry = reportContexts.get(report.id);
+          return entry?.tasksByName.get(catalogItem.taskName) || null;
+        });
+        const populatedCells = cells.filter(Boolean);
+        const matchesSearch =
+          !state.search || catalogItem.taskName.toLowerCase().includes(state.search);
+        const matchesTaskType = state.selectedTaskTypes.has(catalogItem.taskType);
+        const matchesStatus = populatedCells.some((cell) =>
+          state.selectedStatuses.has((cell.status || "UNKNOWN").toUpperCase())
+        );
+
+        const maxSpeedup = populatedCells.length
+          ? Math.max(...populatedCells.map((cell) => Number(cell.speedup) || 0))
+          : -1;
+        const avgScore = populatedCells.length
+          ? populatedCells.reduce((sum, cell) => sum + (Number(cell.score) || 0), 0) /
+            populatedCells.length
+          : -1;
+
+        return {
+          taskName: catalogItem.taskName,
+          taskType: catalogItem.taskType,
+          cells,
+          populatedCells,
+          maxSpeedup,
+          avgScore,
+          include: matchesSearch && matchesTaskType && matchesStatus,
+        };
+      })
+      .filter((row) => row.include)
+      .sort(sortTaskRows);
+  }
+
+  function sortTaskRows(left, right) {
+    if (state.taskSort === "avg_score_desc") {
+      return sortNumberDesc(left.avgScore, right.avgScore) || left.taskName.localeCompare(right.taskName);
+    }
+
+    if (state.taskSort === "task_name_asc") {
+      return left.taskName.localeCompare(right.taskName);
+    }
+
+    if (state.taskSort === "task_type_asc") {
+      return left.taskType.localeCompare(right.taskType) || left.taskName.localeCompare(right.taskName);
+    }
+
+    return sortNumberDesc(left.maxSpeedup, right.maxSpeedup) || sortNumberDesc(left.avgScore, right.avgScore) || left.taskName.localeCompare(right.taskName);
+  }
+
+  function renderSummaryCards(visibleReports) {
+    if (!visibleReports.length) {
+      elements.summaryCards.innerHTML = `<div class="empty-state">No reports selected.</div>`;
+      return;
+    }
+
+    const bestScore = maxBy(visibleReports, (report) => report.overall?.total_score || 0);
+    const bestMedian = maxBy(visibleReports, (report) => report.overall?.median_speedup || 0);
+    const bestCorrect = maxBy(
+      visibleReports,
+      (report) => report.overall?.correctness_pass_rate || 0
+    );
+    const longTail = maxBy(visibleReports, (report) => {
+      const average = report.overall?.average_speedup || 0;
+      const median = report.overall?.median_speedup || 0;
+      return median > 0 ? average / median : average;
+    });
+
+    const cards = [
+      {
+        label: "Active reports",
+        value: `${visibleReports.length}/${reports.length}`,
+        detail: `Current scope • ${dataset.meta?.taskCount || 0} tasks • latest ${
+          dataset.meta?.latestRunTimestampFormatted || "n/a"
+        }`,
+      },
+      {
+        label: "Highest total score",
+        value: formatScore(bestScore.overall?.total_score || 0),
+        detail: `${bestScore.label} • avg speedup ${formatSpeedup(bestScore.overall?.average_speedup || 0)}`,
+      },
+      {
+        label: "Best median speedup",
+        value: formatSpeedup(bestMedian.overall?.median_speedup || 0),
+        detail: `${bestMedian.label} • avg ${formatSpeedup(bestMedian.overall?.average_speedup || 0)}`,
+      },
+      {
+        label: "Best correctness rate",
+        value: formatPercent(bestCorrect.overall?.correctness_pass_rate || 0),
+        detail: `${bestCorrect.label} • compile ${formatPercent(bestCorrect.overall?.compilation_pass_rate || 0)}`,
+      },
+      {
+        label: "Largest avg / median gap",
+        value: formatRatio(
+          (longTail.overall?.average_speedup || 0) / Math.max(longTail.overall?.median_speedup || 1, 1e-9)
+        ),
+        detail: `${longTail.label} • avg ${formatSpeedup(longTail.overall?.average_speedup || 0)} vs median ${formatSpeedup(longTail.overall?.median_speedup || 0)}`,
+      },
+    ];
+
+    elements.summaryCards.innerHTML = cards
+      .map(
+        (card) => `
+          <article class="summary-card">
+            <div class="summary-card-label">${escapeHtml(card.label)}</div>
+            <div class="summary-card-value">${escapeHtml(card.value)}</div>
+            <div class="summary-card-detail">${escapeHtml(card.detail)}</div>
+          </article>
+        `
+      )
+      .join("");
+  }
+
+  function renderLeaderboard(visibleReports) {
+    if (!visibleReports.length) {
+      elements.leaderboardBody.innerHTML =
+        '<tr><td colspan="8"><div class="empty-state">No reports selected.</div></td></tr>';
+      return;
+    }
+
+    const rows = visibleReports
+      .slice()
+      .sort((left, right) =>
+        sortNumberDesc(left.overall?.total_score || 0, right.overall?.total_score || 0)
+      )
+      .map((report) => {
+        const overall = report.overall || {};
+        return `
+          <tr>
+            <td class="leaderboard-report">
+              <div class="report-name">${escapeHtml(report.label)}</div>
+              <div class="report-meta">${escapeHtml(report.agent || "unknown")} • ${escapeHtml(
+          report.runTimestampFormatted || report.runTimestamp || "n/a"
+        )}</div>
+            </td>
+            <td>${formatScore(overall.total_score || 0)}</td>
+            <td>${formatSpeedup(overall.average_speedup || 0)}</td>
+            <td>${formatSpeedup(overall.median_speedup || 0)}</td>
+            <td><span class="metric-pill">${formatPercent(overall.compilation_pass_rate || 0)}</span></td>
+            <td><span class="metric-pill">${formatPercent(overall.correctness_pass_rate || 0)}</span></td>
+            <td><span class="metric-pill">${formatPercent(overall.speedup_gt_1_rate || 0)}</span></td>
+            <td>
+              <div class="source-links">
+                ${renderSourceLink(report.sourceFiles?.summaryCsv, "CSV")}
+                ${renderSourceLink(report.sourceFiles?.breakdownJson, "JSON")}
+                ${renderSourceLink(report.sourceFiles?.overallReport, "TXT")}
+              </div>
+            </td>
+          </tr>
+        `;
+      });
+
+    elements.leaderboardBody.innerHTML = rows.join("");
+  }
+
+  function renderHeatmap(visibleReports) {
+    const metric = state.heatmapMetric;
+    const metricLabel = metricToLabel(metric);
+    elements.heatmapCaption.textContent = `${metricLabel} by task type across ${
+      visibleReports.length
+    } selected reports.`;
+
+    if (!visibleReports.length) {
+      elements.heatmapHead.innerHTML = "";
+      elements.heatmapBody.innerHTML = `<tr><td><div class="empty-state">No reports selected.</div></td></tr>`;
+      return;
+    }
+
+    elements.heatmapHead.innerHTML = `
+      <tr>
+        <th class="heatmap-rowhead">Task type</th>
+        ${visibleReports
+          .map(
+            (report) => `<th>${escapeHtml(report.label)}</th>`
+          )
+          .join("")}
+      </tr>
+    `;
+
+    const values = [];
+    allTaskTypes.forEach((taskType) => {
+      visibleReports.forEach((report) => {
+        const taskTypeData = report.taskTypes?.[taskType];
+        if (taskTypeData && Number.isFinite(taskTypeData[metric])) {
+          values.push(Number(taskTypeData[metric]));
+        }
+      });
+    });
+
+    const minValue = values.length ? Math.min(...values) : 0;
+    const maxValue = values.length ? Math.max(...values) : 0;
+
+    elements.heatmapBody.innerHTML = allTaskTypes
+      .map((taskType) => {
+        const count = dataset.taskTypeTotals?.[taskType] || 0;
+        const cells = visibleReports
+          .map((report) => {
+            const taskTypeData = report.taskTypes?.[taskType];
+            if (!taskTypeData) {
+              return `<td><div class="heatmap-cell" style="background: rgba(31, 37, 33, 0.06); color: #5f665f;">n/a</div></td>`;
+            }
+
+            const value = Number(taskTypeData[metric]) || 0;
+            const normalized = normalizeMetric(metric, value, minValue, maxValue);
+            const bgColor = heatColor(normalized);
+            return `
+              <td>
+                <div class="heatmap-cell" style="background: ${bgColor}">
+                  <div class="heatmap-value">${escapeHtml(formatMetric(metric, value))}</div>
+                  <div class="heatmap-subvalue">${escapeHtml(
+                    `${taskTypeData.count || 0} tasks`
+                  )}</div>
+                </div>
+              </td>
+            `;
+          })
+          .join("");
+
+        return `
+          <tr>
+            <th class="heatmap-rowhead">${escapeHtml(taskType)}<div class="report-meta">${count} task records</div></th>
+            ${cells}
+          </tr>
+        `;
+      })
+      .join("");
+  }
+
+  function renderSpotlights(visibleReports, taskRows) {
+    if (!taskRows.length) {
+      elements.spotlightGrid.innerHTML =
+        '<div class="empty-state">No tasks match the current filters.</div>';
+      return;
+    }
+
+    const spotlightRows = taskRows
+      .slice()
+      .sort((left, right) => sortNumberDesc(left.maxSpeedup, right.maxSpeedup))
+      .slice(0, 6);
+
+    elements.spotlightGrid.innerHTML = spotlightRows
+      .map((row) => {
+        const winners = bestTaskCells(visibleReports, row);
+        const winner = winners[0];
+        if (!winner) {
+          return "";
+        }
+        const report = visibleReports.find((item) => item.id === winner.reportId);
+        const runnerUp = row.populatedCells
+          .filter((cell) => cell !== winner.task)
+          .sort((left, right) => sortNumberDesc(left.speedup || 0, right.speedup || 0))[0];
+        const runnerText = runnerUp
+          ? `runner-up ${formatSpeedup(runnerUp.speedup || 0)}`
+          : "single report";
+
+        return `
+          <article class="spotlight-card">
+            <div class="spotlight-type">${escapeHtml(row.taskType)}</div>
+            <div class="spotlight-task">${escapeHtml(row.taskName)}</div>
+            <div class="spotlight-score">${escapeHtml(formatSpeedup(winner.task.speedup || 0))}</div>
+            <div class="spotlight-caption">
+              ${escapeHtml(report?.label || winner.reportId)} • ${escapeHtml(
+          winner.task.status || "UNKNOWN"
+        )} • score ${escapeHtml(formatScore(winner.task.score || 0))}<br />
+              ${escapeHtml(runnerText)}
+            </div>
+          </article>
+        `;
+      })
+      .join("");
+  }
+
+  function renderTaskTable(visibleReports, taskRows) {
+    elements.taskTableCaption.textContent = `${taskRows.length} tasks after filters • ${
+      visibleReports.length
+    } visible reports`;
+
+    if (!visibleReports.length) {
+      elements.taskTableHead.innerHTML = "";
+      elements.taskTableBody.innerHTML =
+        '<tr><td><div class="empty-state">No reports selected.</div></td></tr>';
+      return;
+    }
+
+    elements.taskTableHead.innerHTML = `
+      <tr>
+        <th>Task</th>
+        <th>Type</th>
+        ${visibleReports
+          .map(
+            (report) =>
+              `<th>${escapeHtml(report.label)}<div class="report-meta">${escapeHtml(
+                report.runTimestampFormatted || report.runTimestamp || "n/a"
+              )}</div></th>`
+          )
+          .join("")}
+      </tr>
+    `;
+
+    if (!taskRows.length) {
+      elements.taskTableBody.innerHTML =
+        `<tr><td colspan="${2 + visibleReports.length}"><div class="empty-state">No tasks match the current filters.</div></td></tr>`;
+      return;
+    }
+
+    elements.taskTableBody.innerHTML = taskRows
+      .map((row) => {
+        const bestCells = bestTaskCells(visibleReports, row);
+        return `
+          <tr>
+            <td class="task-name">${escapeHtml(row.taskName)}</td>
+            <td>${escapeHtml(row.taskType)}</td>
+            ${visibleReports
+              .map((report, index) => {
+                const task = row.cells[index];
+                if (!task) {
+                  return `<td class="task-cell"><div class="task-cell-inner"><span class="status-pill status-unknown">N/A</span><div class="task-submetric">missing in report</div></div></td>`;
+                }
+
+                const isBest = bestCells.some((cell) => cell.reportId === report.id);
+                const status = (task.status || "UNKNOWN").toUpperCase();
+                return `
+                  <td class="task-cell${isBest ? " best" : ""}">
+                    <div class="task-cell-inner" title="${escapeHtml(
+                      task.optimizationSummary || "No optimization summary"
+                    )}">
+                      <span class="status-pill ${statusClass(status)}">${escapeHtml(status)}</span>
+                      <div class="task-metric">${escapeHtml(formatSpeedup(task.speedup || 0))}</div>
+                      <div class="task-submetric">score ${escapeHtml(formatScore(task.score || 0))}</div>
+                    </div>
+                  </td>
+                `;
+              })
+              .join("")}
+          </tr>
+        `;
+      })
+      .join("");
+  }
+
+  function bestTaskCells(visibleReports, row) {
+    const cells = row.cells
+      .map((task, index) => ({ task, reportId: visibleReports[index]?.id }))
+      .filter((item) => item.task && item.reportId);
+
+    if (!cells.length) {
+      return [];
+    }
+
+    const bestSpeedup = Math.max(...cells.map((item) => Number(item.task.speedup) || 0));
+    return cells.filter((item) => (Number(item.task.speedup) || 0) === bestSpeedup);
+  }
+
+  function renderSourceLink(path, label) {
+    if (!path) {
+      return "";
+    }
+    return `<a class="source-link" href="./${escapeHtml(path)}" target="_blank" rel="noreferrer">${escapeHtml(
+      label
+    )}</a>`;
+  }
+
+  function metricToLabel(metric) {
+    const labels = {
+      average_speedup: "Average speedup",
+      median_speedup: "Median speedup",
+      average_score: "Average score",
+      correctness_pass_rate: "Correctness pass rate",
+      compilation_pass_rate: "Compilation pass rate",
+      speedup_gt_1_rate: "Speedup > 1 rate",
+    };
+    return labels[metric] || metric;
+  }
+
+  function formatMetric(metric, value) {
+    if (metric.includes("speedup")) {
+      return formatSpeedup(value);
+    }
+    if (metric.includes("rate")) {
+      return formatPercent(value);
+    }
+    return formatScore(value);
+  }
+
+  function normalizeMetric(metric, value, minValue, maxValue) {
+    if (metric.includes("rate")) {
+      return clamp(value / 100, 0, 1);
+    }
+
+    const normalizer = metric === "average_score" ? Math.log1p : Math.log1p;
+    const low = normalizer(Math.max(minValue, 0));
+    const high = normalizer(Math.max(maxValue, 0));
+    if (high === low) {
+      return 0.5;
+    }
+    return clamp((normalizer(Math.max(value, 0)) - low) / (high - low), 0, 1);
+  }
+
+  function heatColor(normalized) {
+    const hue = 20 + normalized * 145;
+    const saturation = 58 + normalized * 16;
+    const lightness = 92 - normalized * 34;
+    return `hsl(${hue} ${saturation}% ${lightness}%)`;
+  }
+
+  function showFatal(message) {
+    elements.errorBanner.textContent = message;
+    elements.errorBanner.classList.remove("hidden");
+  }
+
+  function formatSpeedup(value) {
+    return `${Number(value || 0).toFixed(2)}x`;
+  }
+
+  function formatPercent(value) {
+    return `${Number(value || 0).toFixed(1)}%`;
+  }
+
+  function formatScore(value) {
+    return Number(value || 0).toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+  }
+
+  function formatRatio(value) {
+    return `${Number(value || 0).toFixed(2)}x`;
+  }
+
+  function sortNumberDesc(left, right) {
+    return (right || 0) - (left || 0);
+  }
+
+  function maxBy(items, metric) {
+    return items.reduce((best, item) => (metric(item) > metric(best) ? item : best), items[0]);
+  }
+
+  function escapeHtml(value) {
+    const lookup = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    };
+    return String(value).replace(/[&<>"']/g, (char) => lookup[char] || char);
+  }
+
+  function statusClass(status) {
+    if (status === "PASS") {
+      return "status-pass";
+    }
+    if (status === "PARTIAL") {
+      return "status-partial";
+    }
+    if (status === "FAIL") {
+      return "status-fail";
+    }
+    return "status-unknown";
+  }
+
+  function statusRank(status) {
+    if (status === "PASS") {
+      return 0;
+    }
+    if (status === "PARTIAL") {
+      return 1;
+    }
+    if (status === "FAIL") {
+      return 2;
+    }
+    return 3;
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+})();

--- a/visualization/frontend/dashboard/app.js
+++ b/visualization/frontend/dashboard/app.js
@@ -141,6 +141,7 @@
       `Generated ${dataset.meta?.generatedAt || "unknown"}`,
       `Tasks ${dataset.meta?.taskCount || 0}`,
       `GPU ${gpuLabel}`,
+      `Workspace scan ${dataset.meta?.includeWorkspaceRuns ? "on" : "off"}`,
       `Scan root ${dataset.meta?.scanRoot || "unknown"}`,
     ].join(" • ");
   }

--- a/visualization/frontend/dashboard/styles.css
+++ b/visualization/frontend/dashboard/styles.css
@@ -1,0 +1,632 @@
+:root {
+  --bg: #f4efe5;
+  --bg-deep: #efe6d5;
+  --panel: rgba(255, 250, 241, 0.82);
+  --panel-strong: rgba(255, 250, 241, 0.94);
+  --ink: #1f2521;
+  --muted: #5f665f;
+  --line: rgba(31, 37, 33, 0.12);
+  --accent: #bb5b2f;
+  --accent-soft: rgba(187, 91, 47, 0.12);
+  --teal: #0d8472;
+  --teal-soft: rgba(13, 132, 114, 0.12);
+  --gold: #c98f1c;
+  --rose: #a84f49;
+  --pass: #1f8f67;
+  --partial: #bf7d11;
+  --fail: #b54747;
+  --unknown: #6e6c67;
+  --shadow: 0 24px 64px rgba(73, 53, 27, 0.12);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --font-sans: "Avenir Next", "Trebuchet MS", "Segoe UI", sans-serif;
+  --font-serif: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  --font-mono: "SFMono-Regular", "Menlo", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(201, 143, 28, 0.12), transparent 38%),
+    radial-gradient(circle at 85% 12%, rgba(13, 132, 114, 0.12), transparent 28%),
+    linear-gradient(180deg, #f7f2e7 0%, #efe5d4 100%);
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  background-image:
+    linear-gradient(rgba(31, 37, 33, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(31, 37, 33, 0.04) 1px, transparent 1px);
+  background-size: 36px 36px;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.page {
+  width: min(1380px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 36px 0 64px;
+}
+
+.page-glow {
+  position: fixed;
+  width: 420px;
+  height: 420px;
+  border-radius: 999px;
+  filter: blur(40px);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.page-glow-left {
+  top: -160px;
+  left: -120px;
+  background: rgba(201, 143, 28, 0.26);
+}
+
+.page-glow-right {
+  right: -140px;
+  top: 120px;
+  background: rgba(13, 132, 114, 0.18);
+}
+
+.hero,
+.panel {
+  backdrop-filter: blur(18px);
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.68);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 32px;
+  border-radius: 32px;
+  margin-bottom: 18px;
+  background:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.72), rgba(255, 247, 231, 0.88)),
+    var(--panel);
+}
+
+.eyebrow,
+.section-kicker {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.hero-topline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 12px;
+}
+
+.hero h1,
+.panel h2 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.hero h1 {
+  max-width: 900px;
+  font-size: clamp(2.3rem, 5vw, 4.4rem);
+  line-height: 0.96;
+}
+
+.hero-copy,
+.section-copy,
+.source-note {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.hero-copy {
+  max-width: 880px;
+  margin: 18px 0 0;
+}
+
+.source-note {
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(31, 37, 33, 0.06);
+  color: var(--ink);
+  white-space: nowrap;
+  font-size: 0.94rem;
+}
+
+.meta-pill::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--teal), #056756);
+  box-shadow: 0 0 0 6px rgba(13, 132, 114, 0.12);
+}
+
+.panel {
+  padding: 26px;
+  border-radius: var(--radius-lg);
+  margin-bottom: 18px;
+}
+
+.panel-wide {
+  padding-bottom: 18px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.panel-header h2 {
+  font-size: clamp(1.4rem, 2vw, 2rem);
+}
+
+.panel-header .section-copy {
+  max-width: 560px;
+  margin: 0;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.summary-card {
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(248, 241, 228, 0.88));
+  min-height: 148px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.summary-card-label {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.summary-card-value {
+  margin-top: 12px;
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+  font-family: var(--font-serif);
+}
+
+.summary-card-detail {
+  margin-top: 8px;
+  color: var(--muted);
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.filters-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.filter-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-block label,
+.filter-title-row span {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.filter-block input,
+.filter-block select {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--ink);
+}
+
+.filter-group {
+  margin-top: 18px;
+}
+
+.filter-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.link-button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 9px 12px;
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--muted);
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.chip.active {
+  color: var(--ink);
+  border-color: rgba(13, 132, 114, 0.28);
+  background: rgba(13, 132, 114, 0.12);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  transform: translateY(-1px);
+}
+
+.table-wrap,
+.heatmap-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 12px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.92rem;
+  white-space: nowrap;
+}
+
+tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.34);
+}
+
+.leaderboard-report {
+  min-width: 210px;
+}
+
+.report-name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.report-meta {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.metric-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 8px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(31, 37, 33, 0.06);
+}
+
+.source-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.source-link {
+  display: inline-flex;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.heatmap-table th,
+.heatmap-table td {
+  min-width: 140px;
+}
+
+.heatmap-rowhead {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--panel-strong);
+}
+
+.heatmap-cell {
+  border-radius: 16px;
+  padding: 12px;
+  color: #10221e;
+}
+
+.heatmap-value {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.heatmap-subvalue {
+  margin-top: 6px;
+  font-size: 0.84rem;
+  color: rgba(16, 34, 30, 0.76);
+}
+
+.spotlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.spotlight-card {
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(247, 241, 230, 0.9));
+  border: 1px solid var(--line);
+}
+
+.spotlight-type {
+  color: var(--muted);
+  font-size: 0.84rem;
+  margin-bottom: 10px;
+}
+
+.spotlight-task {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.spotlight-score {
+  margin-top: 12px;
+  font-size: 1.8rem;
+  font-family: var(--font-serif);
+  line-height: 1;
+}
+
+.spotlight-caption {
+  margin-top: 8px;
+  color: var(--muted);
+  line-height: 1.5;
+  font-size: 0.92rem;
+}
+
+.task-table th:first-child,
+.task-table td:first-child,
+.task-table th:nth-child(2),
+.task-table td:nth-child(2) {
+  position: sticky;
+  background: var(--panel-strong);
+  z-index: 1;
+}
+
+.task-table th:first-child,
+.task-table td:first-child {
+  left: 0;
+  min-width: 260px;
+}
+
+.task-table th:nth-child(2),
+.task-table td:nth-child(2) {
+  left: 260px;
+  min-width: 120px;
+}
+
+.task-name {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.task-cell {
+  min-width: 154px;
+}
+
+.task-cell-inner {
+  border-radius: 16px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.task-cell.best .task-cell-inner {
+  background: rgba(13, 132, 114, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(13, 132, 114, 0.22);
+}
+
+.task-metric {
+  margin-top: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.task-submetric {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  font-weight: 700;
+}
+
+.status-pass {
+  background: rgba(31, 143, 103, 0.12);
+  color: var(--pass);
+}
+
+.status-partial {
+  background: rgba(191, 125, 17, 0.14);
+  color: var(--partial);
+}
+
+.status-fail {
+  background: rgba(181, 71, 71, 0.12);
+  color: var(--fail);
+}
+
+.status-unknown {
+  background: rgba(110, 108, 103, 0.12);
+  color: var(--unknown);
+}
+
+.empty-state {
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px dashed var(--line);
+  color: var(--muted);
+}
+
+.error-banner {
+  padding: 14px 18px;
+  border-radius: 18px;
+  margin-bottom: 18px;
+  background: rgba(181, 71, 71, 0.12);
+  border: 1px solid rgba(181, 71, 71, 0.18);
+  color: #7c2d2d;
+}
+
+.hidden {
+  display: none;
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  animation: rise 560ms ease forwards;
+}
+
+.reveal:nth-of-type(2) {
+  animation-delay: 60ms;
+}
+
+.reveal:nth-of-type(3) {
+  animation-delay: 110ms;
+}
+
+.reveal:nth-of-type(4) {
+  animation-delay: 150ms;
+}
+
+.reveal:nth-of-type(5) {
+  animation-delay: 190ms;
+}
+
+.reveal:nth-of-type(6) {
+  animation-delay: 230ms;
+}
+
+@keyframes rise {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 980px) {
+  .page {
+    width: min(100vw - 20px, 1380px);
+    padding-top: 18px;
+  }
+
+  .hero,
+  .panel {
+    padding: 20px;
+    border-radius: 24px;
+  }
+
+  .hero-topline,
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .task-table th:nth-child(2),
+  .task-table td:nth-child(2) {
+    left: 220px;
+  }
+
+  .task-table th:first-child,
+  .task-table td:first-child {
+    min-width: 220px;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    background-size: 26px 26px;
+  }
+
+  .hero h1 {
+    line-height: 1.02;
+  }
+
+  th,
+  td {
+    padding: 10px 8px;
+  }
+}

--- a/visualization/frontend/index.html
+++ b/visualization/frontend/index.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Arena Report Dashboard</title>
+    <link rel="stylesheet" href="./dashboard/styles.css" />
+  </head>
+  <body>
+    <div class="page-glow page-glow-left"></div>
+    <div class="page-glow page-glow-right"></div>
+
+    <main class="page">
+      <header class="hero reveal">
+        <div class="eyebrow">Arena Visual Dashboard</div>
+        <div class="hero-topline">
+          <h1>Benchmark reports, compared the way you actually read them.</h1>
+          <div id="meta-pill" class="meta-pill">Waiting for data</div>
+        </div>
+        <p class="hero-copy">
+          Aggregates run reports discovered across AgentKernelArena, typically under
+          `workspace_*/run_*/reports`. Focus on total score, speedup distribution,
+          task-type performance, and per-task status deltas.
+        </p>
+        <div id="source-note" class="source-note"></div>
+      </header>
+
+      <section id="error-banner" class="error-banner hidden reveal"></section>
+
+      <section class="panel reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Overview</div>
+            <h2>Snapshot</h2>
+          </div>
+          <p class="section-copy">
+            Snapshot cards highlight the strongest total score, the steadiest
+            metrics, and the current dataset coverage.
+          </p>
+        </div>
+        <div id="summary-cards" class="summary-grid"></div>
+      </section>
+
+      <section class="panel reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Controls</div>
+            <h2>Filters</h2>
+          </div>
+          <p class="section-copy">
+            `Report` filters apply to every view. `Task type / status / search`
+            mainly shape the task explorer below.
+          </p>
+        </div>
+        <div class="filters-layout">
+          <div class="filter-block">
+            <label for="task-search">Task search</label>
+            <input id="task-search" type="search" placeholder="Search task name" />
+          </div>
+          <div class="filter-block">
+            <label for="heatmap-metric">Heatmap metric</label>
+            <select id="heatmap-metric">
+              <option value="average_speedup">Average speedup</option>
+              <option value="median_speedup">Median speedup</option>
+              <option value="average_score">Average score</option>
+              <option value="correctness_pass_rate">Correctness pass rate</option>
+              <option value="compilation_pass_rate">Compilation pass rate</option>
+              <option value="speedup_gt_1_rate">Speedup > 1 rate</option>
+            </select>
+          </div>
+          <div class="filter-block">
+            <label for="task-sort">Task sort</label>
+            <select id="task-sort">
+              <option value="max_speedup_desc">Best speedup</option>
+              <option value="avg_score_desc">Average score</option>
+              <option value="task_name_asc">Task name</option>
+              <option value="task_type_asc">Task type</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="filter-group">
+          <div class="filter-title-row">
+            <span>Reports</span>
+            <button type="button" class="link-button" data-filter-action="toggle-reports">
+              Clear / Reset
+            </button>
+          </div>
+          <div id="report-chips" class="chip-row"></div>
+        </div>
+
+        <div class="filter-group">
+          <div class="filter-title-row">
+            <span>Task types</span>
+            <button type="button" class="link-button" data-filter-action="toggle-task-types">
+              Clear / Reset
+            </button>
+          </div>
+          <div id="task-type-chips" class="chip-row"></div>
+        </div>
+
+        <div class="filter-group">
+          <div class="filter-title-row">
+            <span>Status</span>
+            <button type="button" class="link-button" data-filter-action="toggle-statuses">
+              Clear / Reset
+            </button>
+          </div>
+          <div id="status-chips" class="chip-row"></div>
+        </div>
+      </section>
+
+      <section class="panel reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Leaderboard</div>
+            <h2>Report Ranking</h2>
+          </div>
+          <p class="section-copy">
+            This table keeps the full report-level metrics visible so you can
+            quickly judge who is strongest, who is stable, and who fails more often.
+          </p>
+        </div>
+        <div class="table-wrap">
+          <table class="leaderboard-table">
+            <thead>
+              <tr>
+                <th>Report</th>
+                <th>Total score</th>
+                <th>Avg speedup</th>
+                <th>Median</th>
+                <th>Compile</th>
+                <th>Correct</th>
+                <th>&gt; 1.0</th>
+                <th>Sources</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboard-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Heatmap</div>
+            <h2>Task Type Comparison</h2>
+          </div>
+          <p id="heatmap-caption" class="section-copy"></p>
+        </div>
+        <div class="heatmap-wrap">
+          <table class="heatmap-table">
+            <thead id="heatmap-head"></thead>
+            <tbody id="heatmap-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Standouts</div>
+            <h2>Task Spotlight</h2>
+          </div>
+          <p class="section-copy">
+            Based on the current filters, this highlights the most interesting
+            tasks and the reports currently leading them.
+          </p>
+        </div>
+        <div id="spotlight-grid" class="spotlight-grid"></div>
+      </section>
+
+      <section class="panel panel-wide reveal">
+        <div class="panel-header">
+          <div>
+            <div class="section-kicker">Explorer</div>
+            <h2>Task Matrix</h2>
+          </div>
+          <p id="task-table-caption" class="section-copy"></p>
+        </div>
+        <div class="table-wrap">
+          <table class="task-table">
+            <thead id="task-table-head"></thead>
+            <tbody id="task-table-body"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script src="./dashboard/data.js"></script>
+    <script src="./dashboard/app.js"></script>
+  </body>
+</html>

--- a/visualization/setup.sh
+++ b/visualization/setup.sh
@@ -4,5 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-python backend/scripts/build_dashboard_data.py
+BUILD_ARGS=()
+if [[ "${1:-}" == "--include-workspace-runs" ]]; then
+  BUILD_ARGS+=("--include-workspace-runs")
+  shift
+fi
+
+python backend/scripts/build_dashboard_data.py "${BUILD_ARGS[@]}"
 python backend/server.py --host 0.0.0.0 --port 80

--- a/visualization/setup.sh
+++ b/visualization/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+python backend/scripts/build_dashboard_data.py
+python backend/server.py --host 0.0.0.0 --port 80


### PR DESCRIPTION
## Summary

This PR adds a static visualization app under `visualization/` for browsing and comparing AgentKernelArena run reports.

It includes:
- a lightweight frontend dashboard
- a small Python HTTP server
- a data build script that scans AgentKernelArena run outputs
- documentation and local ignore rules for generated dashboard payloads

## What Changed

- Added `visualization/frontend/` for the dashboard UI
- Added `visualization/backend/server.py` to serve the dashboard and report artifacts
- Added `visualization/backend/scripts/build_dashboard_data.py` to generate dashboard data
- Added `visualization/README.md` with usage instructions
- Added `visualization/setup.sh` to rebuild data and serve on port 80
- Added `visualization/.gitignore` for generated files like `frontend/dashboard/data.js` and `data.json`

## Behavior

The visualization does not depend on a local `visualization/reports/` folder.

Instead, it scans AgentKernelArena for report directories that contain:
- `overall_summary.csv`
- `task_type_breakdown.json`
- `overall_report.txt`

This matches the current run output layout, typically:
- `workspace_*/run_*/reports/`

## Verification

Tested locally with:
- `python visualization/backend/scripts/build_dashboard_data.py`
- `python visualization/backend/server.py --host 127.0.0.1 --port 8080`

Verified that:
- `/` returns the dashboard page
- `/dashboard/data.js` is served correctly
- artifact access is limited to report files (`.csv`, `.json`, `.txt`)
- non-report paths like `.git/config` are not exposed

## Notes

- If no run reports exist yet, the dashboard builds successfully and shows an empty state.
- Generated dashboard data files are intentionally ignored by `visualization/.gitignore`.
