### PR TITLE
Held-out generalization evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tmp*
 kill.sh
 saved_results
 .mcp.json
+
+# Generated held-out test data (methodology is in held_out/, data is private)
+held_out_tests/

--- a/agents/claude_code/agent_config.yaml
+++ b/agents/claude_code/agent_config.yaml
@@ -1,6 +1,6 @@
 max_iterations: 3
-timeout_seconds: 600
+timeout_seconds: 3600
 python_path: /root/AgentKernelArena/.venv/bin/python3
 # Optional: set explicit Claude model / effort so logs record exact runtime settings.
-# model: claude-sonnet-4-6
+model: claude-opus-4-6
 # effort: medium

--- a/agents/codex/agent_config.yaml
+++ b/agents/codex/agent_config.yaml
@@ -1,5 +1,5 @@
 max_iterations: 3
 timeout_seconds: 3600
-python_path: /root/AgentKernelArena/.venv/bin/python3
+python_path: /root/AgentKernelArena/.venv/bin/python
 # Optional: set explicitly so logs show the exact model used.
-model: gpt-5.3-codex 
+model: gpt-5.3-codex

--- a/agents/codex/agent_config.yaml
+++ b/agents/codex/agent_config.yaml
@@ -1,5 +1,5 @@
 max_iterations: 3
-timeout_seconds: 600
+timeout_seconds: 3600
 python_path: /root/AgentKernelArena/.venv/bin/python3
 # Optional: set explicitly so logs show the exact model used.
-# model: gpt-5.3-codex medium
+model: gpt-5.3-codex 

--- a/agents/codex/launch_agent.py
+++ b/agents/codex/launch_agent.py
@@ -12,6 +12,7 @@ import yaml
 
 from agents import register_agent
 from src.module_registration import AgentType, load_prompt_builder
+from src.runtime_env import build_subprocess_env
 
 
 def integrate_agent_config(prompt: str, agent_config: dict[str, Any]) -> str:
@@ -21,7 +22,10 @@ def integrate_agent_config(prompt: str, agent_config: dict[str, Any]) -> str:
         prompt = prompt.rstrip() + f"\n\nFor this optimization, you must iterate up to {max_iters} versions."
     python_path = agent_config.get("python_path")
     if python_path:
-        prompt = prompt.rstrip() + f"\n\nUse this Python interpreter: `{python_path}`."
+        prompt = prompt.rstrip() + (
+            f"\n\nUse this Python interpreter: `{python_path}`. "
+            f"When running pytest, use `{python_path} -m pytest` instead of bare `pytest`."
+        )
     return prompt
 
 
@@ -60,7 +64,7 @@ def _format_codex_event(raw_line: str) -> str:
     return raw_line
 
 
-def _get_codex_version(agent_cmd: str) -> str:
+def _get_codex_version(agent_cmd: str, env: dict[str, str] | None = None) -> str:
     """Best-effort Codex CLI version lookup for logging."""
     try:
         result = subprocess.run(
@@ -69,6 +73,7 @@ def _get_codex_version(agent_cmd: str) -> str:
             text=True,
             check=False,
             timeout=5,
+            env=env,
         )
     except Exception:
         return "unknown"
@@ -106,6 +111,7 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
     prompt = prompt_builder(task_config_dir, workspace, eval_config, logger)
     prompt = integrate_agent_config(prompt, agent_config)
     configured_model = agent_config.get("model")
+    process_env = build_subprocess_env(agent_config.get("python_path"))
 
     cmd = [
         AGENT,
@@ -122,8 +128,9 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
 
     logger.info("Codex Preflight")
     logger.info(f"  codex_binary: {codex_bin}")
-    logger.info(f"  codex_version: {_get_codex_version(AGENT)}")
+    logger.info(f"  codex_version: {_get_codex_version(AGENT, process_env)}")
     logger.info(f"  workspace: {workspace}")
+    logger.info(f"  python_path: {process_env.get('AGENT_KERNEL_ARENA_PYTHON', '<unset>')}")
     if configured_model:
         logger.info(f"  model: {configured_model} (explicit via agents/codex/agent_config.yaml)")
     else:
@@ -143,6 +150,7 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
         text=True,
         cwd=workspace,
         bufsize=1,
+        env=process_env,
     )
     if process.stdin:
         process.stdin.close()

--- a/agents/cursor/agent_config.yaml
+++ b/agents/cursor/agent_config.yaml
@@ -1,6 +1,6 @@
 max_iterations: 3
-timeout_seconds: 600
+timeout_seconds: 3600
 python_path: /root/AgentKernelArena/.venv/bin/python3
 # Optional: set explicit Cursor model so logs record exact runtime settings.
-# model: sonnet-4-thinking
+model: composer-2
 # Note: Cursor Agent CLI does not expose a separate `effort` flag; "thinking" is typically encoded in the model choice.

--- a/held_out/README.md
+++ b/held_out/README.md
@@ -1,0 +1,160 @@
+# Held-Out Evaluation
+
+Evaluates whether agent-generated kernels generalize to unseen input shapes,
+or are overfit to the test cases visible during development.
+
+## Overview
+
+1. **Generate** held-out shapes per task via an LLM agent (`generate_heldout.py`)
+2. **Evaluate** a completed run against those shapes (`run_heldout_eval.py`)
+3. **Compare** held-out vs original correctness and speedup to measure the
+   "generalization gap"
+
+The **code** (this directory) is checked into the repo. The **generated test
+data** (`held_out_tests/`) is `.gitignore`'d so that held-out shapes remain
+private for paper evaluation. Others can regenerate their own sets.
+
+## Scope
+
+| Task type | Subdirectory | Injection target |
+|-----------|-------------|------------------|
+| triton2triton | vllm | `TEST_SHAPES` in `scripts/task_runner.py` |
+| triton2triton | rocmbench | `@pytest.mark.parametrize` decorators in `test_*.py` (raw_replace) |
+| hip2hip | gpumode | `get_inputs()` in both `pytorch_code_module/*.py` and `pytorch_code_functional/*_func.py` |
+| torch2hip | gpumode | Same as hip2hip |
+
+## Quick start
+
+### 1. Generate held-out shapes
+
+```bash
+python held_out/generate_heldout.py \
+    --tasks-dir tasks/ \
+    --output-dir held_out_tests/ \
+    --backend claude_code \
+    --timeout 600
+```
+
+Use `--dry-run` to list tasks without launching agents.
+Use `--tasks hip2hip/gpumode/SiLU` to generate for a single task.
+Supported backends: `claude_code`, `codex`, `cursor` (same backends as the main arena agents).
+
+### 2. Evaluate a run
+
+```bash
+python held_out/run_heldout_eval.py \
+    --run-dir workspace_MI300_cursor/run_20260417_142419 \
+    --heldout-dir held_out_tests/ \
+    --tasks-dir tasks/
+```
+
+This creates `run_20260417_142419_heldout/` alongside the original run.
+Each task workspace contains two subdirectories:
+
+- `orig/` — the original (unoptimized) kernel restored from `tasks/`, with
+  held-out shapes injected. Evaluated for **compilation, correctness, and
+  baseline performance**.
+- `opt/` — the agent's optimized kernel, with the same held-out shapes
+  injected. Evaluated for **compilation, correctness, and optimized
+  performance**.
+
+Both kernels are evaluated on the same held-out shapes, producing a
+**generalization quadrant** for each task:
+
+| orig | opt | Status | Meaning |
+|------|-----|--------|---------|
+| ✓ | ✓ | `both_pass` | Normal — compare speedups |
+| ✓ | ✗ | `opt_regression` | Optimization broke generalization |
+| ✗ | ✗ | `both_fail` | Shape exceeds kernel design spec |
+| ✗ | ✓ | `opt_improvement` | Agent improved robustness |
+
+The key paper metric is **conditional correctness**: P(opt correct | orig
+correct), which measures generalization by excluding shapes that are
+inherently beyond the kernel's capability.
+
+Output files:
+- Per-task `heldout_task_result.yaml`
+- Aggregate `heldout_summary.yaml` (with quadrant counts and conditional
+  correctness rate)
+
+## held_out_shapes.yaml format
+
+Each task gets a YAML file storing replacement Python code for injection.
+
+### triton2triton example
+
+```yaml
+task_type: triton2triton
+num_original_shapes: 5
+injections:
+  - file: scripts/task_runner.py
+    find_marker: "TEST_SHAPES"
+    replacement_code: |
+      TEST_SHAPES = [
+          (64, 256, 128, True, False, True),
+          ...
+      ]
+```
+
+### triton2triton/rocmbench example
+
+```yaml
+task_type: triton2triton
+num_original_shapes: 2
+injections:
+  - file: test_add_kernel.py
+    find_marker: "raw_replace"
+    old_code: |
+      @pytest.mark.parametrize('SIZE,BLOCK_SIZE,dtype_str',
+                               [(98432, 1024, dtype_str) for dtype_str in ['float16', 'float32']])
+    replacement_code: |
+      @pytest.mark.parametrize('SIZE,BLOCK_SIZE,dtype_str',
+                               [(65536, 512, dtype_str) for dtype_str in ['float16', 'float32']])
+  - file: test_add_kernel.py
+    find_marker: "raw_replace"
+    old_code: |
+      @pytest.mark.parametrize('SIZE,BLOCK_SIZE_ARG,dtype_str',
+                               [(98432, 1024, dtype_str) for dtype_str in ['float16', 'float32']] +
+                               [(1048576, 2048, dtype_str) for dtype_str in ['float16', 'float32']])
+    replacement_code: |
+      @pytest.mark.parametrize('SIZE,BLOCK_SIZE_ARG,dtype_str',
+                               [(65536, 512, dtype_str) for dtype_str in ['float16', 'float32']])
+```
+
+### hip2hip / torch2hip example
+
+```yaml
+task_type: hip2hip
+num_original_shapes: 11
+init_constraints:
+  features: 4
+injections:
+  - file: pytorch_code_module/py_11754_layer_normalization.py
+    find_marker: "def get_inputs"
+    replacement_code: |
+      def get_inputs():
+          ...
+  - file: pytorch_code_functional/py_11754_layer_normalization_func.py
+    find_marker: "def get_inputs"
+    replacement_code: |
+      def get_inputs():
+          ...  # identical to modular
+```
+
+The `init_constraints` field documents shape constraints from `get_init_inputs()`.
+
+## How injection works
+
+The eval script copies the agent's workspace and replaces test shapes via
+text-based codegen replacement (`injection.py`):
+
+- **TEST_SHAPES**: Regex finds `TEST_SHAPES = [`, bracket-balances to find
+  the end, replaces the entire block
+- **get_inputs**: Regex finds `def get_inputs(`, indentation-based detection
+  finds the function end, replaces the entire function
+- **raw_replace**: Exact string match on `old_code`, replaces with
+  `replacement_code` (used for rocmbench `@pytest.mark.parametrize` decorators
+  and any other ad-hoc patterns)
+
+The agent's optimized kernel code is untouched — only the test harness shapes
+change.

--- a/held_out/__init__.py
+++ b/held_out/__init__.py
@@ -1,0 +1,1 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.

--- a/held_out/generate_heldout.py
+++ b/held_out/generate_heldout.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""
+Generate held-out test shapes for AgentKernelArena tasks.
+
+Launches a coding agent (claude_code, codex, or cursor) per task to inspect
+the existing test infrastructure, understand shape constraints, and produce
+a held_out_shapes.yaml with replacement code that can be injected by
+run_heldout_eval.py.
+
+Supported task types (scope):
+  - triton2triton/vllm
+  - triton2triton/rocmbench
+  - hip2hip/gpumode
+  - torch2hip/gpumode
+
+Usage:
+    python held_out/generate_heldout.py \
+        --tasks-dir tasks/ \
+        --output-dir held_out_tests/ \
+        [--backend claude_code] \
+        [--timeout 600]
+"""
+import argparse
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+import sys
+import threading
+import yaml
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+logger = logging.getLogger("generate_heldout")
+
+SUPPORTED_SCOPES = {
+    "triton2triton": ["vllm", "rocmbench"],
+    "hip2hip": ["gpumode"],
+    "torch2hip": ["gpumode"],
+}
+
+NUM_HELDOUT_SHAPES = 8
+
+# Shared generalization methodology referenced by all prompt builders.
+# Each held-out shape targets a specific generalization axis so the paper
+# can report per-category pass rates (e.g., "92% on production shapes but
+# only 64% on alignment-stress shapes").
+GENERALIZATION_CATEGORIES = """
+## Generalization Categories
+
+You must generate exactly {n} held-out shapes across 6 categories (some
+categories get 2 shapes for statistical robustness).  Tag each shape with
+its category in an inline comment.
+
+### Category 1: Edge-case / boundary  (1 shape)
+Minimal or boundary sizes that stress partial-tile handling, single-element
+batches, or degenerate dimensions.  Examples: batch=1, sequence_len=1, a
+dimension equal to the kernel's BLOCK_SIZE, or a size just above/below a
+tile boundary.
+
+### Category 2: Scale-up  (1 shape)
+Dimensions significantly LARGER than the original test shapes (at least
+2-4× in the dominant dimension).  Tests whether the optimization scales:
+tiling strategies, shared-memory reuse, grid sizing.
+Keep within GPU memory (≤ 2 GB total allocation).
+
+### Category 3: Scale-down  (1 shape)
+Dimensions significantly SMALLER than the original test shapes (at least
+2-4× in the dominant dimension).  Many optimized kernels over-provision
+shared memory or assume a minimum occupancy; small inputs reveal that.
+
+### Category 4: Alignment-stress  (2 shapes)
+Sizes that are NOT multiples of common GPU tile sizes (32, 64, 128, 256).
+Use primes or odd composites (e.g., 37, 131, 1019, 4003).  This tests
+masking, bounds-checking, and padding logic.  This is the most common
+failure mode for optimized kernels — generate 2 distinct shapes here.
+
+### Category 5: Asymmetric / unusual aspect ratio  (1 shape)
+Highly skewed dimensions — e.g., M=1 with N=65536, or a very tall-skinny
+matrix (M>>N by 100×+).  Tests whether the kernel handles non-square or
+extreme-ratio workloads that break assumptions about grid partitioning.
+
+### Category 6: Production-realistic  (2 shapes)
+Shapes drawn from real ML workloads.  Generate 2 distinct shapes:
+  - For Triton/attention kernels: batch ∈ {{1,2,4,8}}, heads ∈ {{8,16,32,64}},
+    seq_len ∈ {{128,512,2048,4096,8192}}, head_dim ∈ {{64,128}}
+  - For HIP/element-wise kernels: NCHW with N ∈ {{1,2,4,8,16}},
+    C ∈ {{64,128,256,512,1024}}, H=W ∈ {{7,14,28,56,112,224}}
+  - For GEMM kernels: M,N,K from transformer FFN sizes
+    (e.g., 4096×11008×4096, 2048×8192×2048)
+  Pick the pattern that matches this kernel's semantics.
+
+### Tagging
+
+For EACH shape, add a short inline comment identifying its category, e.g.:
+```python
+(1, 64, 128, True, False),       # edge-case: batch=1
+(32, 4096, 8192, True, True),    # scale-up: 4x seq_len
+(2, 131, 64, False, True),       # alignment-stress: prime seq_len
+(1, 65536, 64, True, False),     # asymmetric: M=1 decode-like
+(8, 32, 2048, 128, True, False), # production: Llama-7B prefill
+```
+"""
+
+
+def discover_tasks(tasks_dir: Path) -> List[Tuple[str, Path]]:
+    """Return list of (task_id, task_dir) for all in-scope tasks."""
+    results = []
+    for task_type, subdir_filters in SUPPORTED_SCOPES.items():
+        for subdir_filter in subdir_filters:
+            base = tasks_dir / task_type / subdir_filter
+            if not base.exists():
+                continue
+            for config_path in base.rglob("config.yaml"):
+                task_dir = config_path.parent
+                rel = task_dir.relative_to(tasks_dir)
+                task_id = str(rel)
+                results.append((task_id, task_dir))
+    return sorted(results)
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+HELDOUT_YAML_SCHEMA_TRITON = """
+task_type: triton2triton
+num_original_shapes: <count of original TEST_SHAPES entries>
+injections:
+  - file: scripts/task_runner.py
+    find_marker: "TEST_SHAPES"
+    replacement_code: |
+      TEST_SHAPES = [
+          <tuple1>,
+          <tuple2>,
+          <tuple3>,
+          <tuple4>,
+          <tuple5>,
+      ]
+"""
+
+HELDOUT_YAML_SCHEMA_ROCMBENCH = """
+task_type: triton2triton
+num_original_shapes: <count of original parametrize entries for correctness>
+injections:
+  - file: <test_file.py>
+    find_marker: "raw_replace"
+    old_code: |
+      <exact original @pytest.mark.parametrize decorator text for correctness test>
+    replacement_code: |
+      <new @pytest.mark.parametrize decorator with held-out shapes>
+  - file: <test_file.py>
+    find_marker: "raw_replace"
+    old_code: |
+      <exact original @pytest.mark.parametrize decorator text for performance test>
+    replacement_code: |
+      <new @pytest.mark.parametrize decorator with held-out shapes>
+"""
+
+HELDOUT_YAML_SCHEMA_HIP = """
+task_type: <hip2hip or torch2hip>
+num_original_shapes: <count of original configs in get_inputs>
+init_constraints:
+  <key>: <value>   # shape-relevant params from get_init_inputs only
+injections:
+  - file: <pytorch_code_module/py_XXXX_Name.py>
+    find_marker: "def get_inputs"
+    replacement_code: |
+      def get_inputs():
+          configs = [
+              <config1>,
+              ...
+          ]
+          for shape in configs:
+              shape_list = shape[0] if isinstance(shape, tuple) and len(shape) == 1 else shape
+              <tensor creation matching the original pattern>
+              yield [<tensors>]
+  - file: <pytorch_code_functional/py_XXXX_Name_func.py>
+    find_marker: "def get_inputs"
+    replacement_code: |
+      def get_inputs():
+          <IDENTICAL code to the modular version above>
+"""
+
+
+def build_prompt(task_id: str, output_path: str) -> str:
+    task_type = task_id.split("/")[0]
+    sub_scope = task_id.split("/")[1] if "/" in task_id else ""
+
+    if task_type == "triton2triton" and sub_scope == "rocmbench":
+        return _build_prompt_rocmbench(task_id, output_path)
+    elif task_type == "triton2triton":
+        return _build_prompt_triton(task_id, output_path)
+    else:
+        return _build_prompt_hip(task_id, task_type, output_path)
+
+
+def _build_prompt_triton(task_id: str, output_path: str) -> str:
+    cats = GENERALIZATION_CATEGORIES.format(n=NUM_HELDOUT_SHAPES)
+    return f"""# Held-Out Test Shape Generator
+
+You are generating held-out test shapes for evaluating whether an
+agent-optimized GPU kernel generalizes to unseen inputs.  The results will
+be reported in a scientific paper, so the shapes must be methodologically
+motivated, not arbitrary.
+
+## Task
+- Task ID: `{task_id}`
+- Task type: triton2triton (Triton kernel optimization)
+
+## Your Mission
+
+1. **Read** `scripts/task_runner.py` in this workspace directory.
+2. **Also read** the kernel source file(s) in `source/` to understand what
+   the kernel computes, what its BLOCK_SIZE / tile parameters are, and
+   whether there are algorithmic branches (e.g., causal vs non-causal,
+   different code paths for head_dim <= 64 vs > 64).
+3. **Understand** the existing `TEST_SHAPES` list:
+   - What does each element of the tuple mean?
+   - What hard constraints exist (alignment, minimum sizes, dtype, divisibility)?
+   - What is the range of each dimension in the original shapes?
+   - How many shapes are there currently?
+4. **Generate exactly {NUM_HELDOUT_SHAPES} NEW test shape tuples** across
+   the generalization categories below (some categories require 2 shapes).
+5. **Write** the file `{output_path}` with the exact YAML format below.
+
+{cats}
+
+## Output Format
+
+Write `{output_path}` as a valid YAML file with this structure:
+```yaml
+{HELDOUT_YAML_SCHEMA_TRITON}
+```
+
+The `replacement_code` must be valid Python that can directly replace the
+existing TEST_SHAPES definition in task_runner.py.
+
+## Rules
+- Do NOT modify any existing files — only create the output YAML
+- Do NOT run any commands — this is a read-and-write task only
+- The output MUST be valid YAML
+- Each shape must satisfy ALL hard constraints you identified
+- Each shape MUST be tagged with its generalization category in a comment
+- Ensure no generated shape is identical to any original TEST_SHAPES entry
+"""
+
+
+def _build_prompt_rocmbench(task_id: str, output_path: str) -> str:
+    cats = GENERALIZATION_CATEGORIES.format(n=NUM_HELDOUT_SHAPES)
+    return f"""# Held-Out Test Shape Generator (rocmbench)
+
+You are generating held-out test shapes for evaluating whether an
+agent-optimized GPU kernel generalizes to unseen inputs.  The results will
+be reported in a scientific paper, so the shapes must be methodologically
+motivated, not arbitrary.
+
+## Task
+- Task ID: `{task_id}`
+- Task type: triton2triton / rocmbench
+
+## Your Mission
+
+1. **Read** the main Python test file in this workspace directory
+   (e.g. `test_*.py`, `softmax.py`, `gemm.py`, etc.)
+2. **Read the kernel code** to understand what it computes, its tile/block
+   parameters, and whether there are algorithmic branches that trigger at
+   certain sizes.
+3. **Find** all `@pytest.mark.parametrize(...)` decorators on test functions:
+   - The **correctness test** (any test NOT named `test_performance` or
+     `test_save_performance_results`)
+   - The **performance test** (`test_performance`)
+4. **Understand** the parametrize arguments:
+   - What do the parameters represent? (sizes, block sizes, dtypes, etc.)
+   - What hard constraints exist? (block sizes must be powers of 2, etc.)
+   - What is the range of each dimension in the original shapes?
+   - How many test configurations are there currently?
+5. **Generate exactly {NUM_HELDOUT_SHAPES} NEW parametrize entries** for
+   BOTH the correctness test and the performance test, across the
+   generalization categories below (some categories require 2 shapes).
+6. **Write** the file `{output_path}` with the exact YAML format below.
+
+{cats}
+
+## CRITICAL: Exact text matching
+
+For `raw_replace` injections, the `old_code` field must be the EXACT text of the
+original `@pytest.mark.parametrize(...)` decorator (including newlines, spaces, and
+the closing parenthesis). Copy it character-for-character from the source file.
+The `replacement_code` must be a valid `@pytest.mark.parametrize(...)` decorator
+that can replace the old one.
+
+You must create separate injection entries for EACH parametrize decorator
+(one for the correctness test, one for the performance test).
+
+## Output Format
+
+Write `{output_path}` as a valid YAML file with this structure:
+```yaml
+{HELDOUT_YAML_SCHEMA_ROCMBENCH}
+```
+
+## Rules
+- Do NOT modify any existing files — only create the output YAML
+- Do NOT run any commands — this is a read-and-write task only
+- The output MUST be valid YAML
+- The `old_code` must be an EXACT copy of the original decorator text
+- Each shape must satisfy ALL hard constraints you identified
+- Each shape MUST be tagged with its generalization category in a comment
+- Ensure no generated shape is identical to any original parametrize entry
+- If there are multiple correctness test functions with parametrize, include injections for each
+"""
+
+
+def _build_prompt_hip(task_id: str, task_type: str, output_path: str) -> str:
+    cats = GENERALIZATION_CATEGORIES.format(n=NUM_HELDOUT_SHAPES)
+    return f"""# Held-Out Test Shape Generator
+
+You are generating held-out test shapes for evaluating whether an
+agent-optimized GPU kernel generalizes to unseen inputs.  The results will
+be reported in a scientific paper, so the shapes must be methodologically
+motivated, not arbitrary.
+
+## Task
+- Task ID: `{task_id}`
+- Task type: {task_type} (HIP kernel optimization)
+
+## Your Mission
+
+1. **Read** both Python files in this workspace:
+   - `pytorch_code_module/py_*.py` (the modular version)
+   - `pytorch_code_functional/py_*_func.py` (the functional version)
+2. **Also read** the HIP kernel source in `hip/` to understand what the
+   kernel computes, its launch configuration (block/grid dims), and whether
+   there are algorithmic branches that trigger at certain input sizes.
+3. **Understand** the existing `get_inputs()` function:
+   - What tensors does it yield? (single tensor, pair, triple?)
+   - What shapes and dtypes are used?
+   - How many test configurations exist?
+   - What is the range of each dimension across the original configs?
+4. **Read `get_init_inputs()`** and identify shape constraints:
+   - If it returns `[[], {{'features': 4}}]`, the last dimension of inputs MUST be 4
+   - If it returns `[[], {{'input_channel_num': 4}}]`, the channel dimension (dim 1 in NCHW) MUST be 4
+   - If it returns `[[], {{'dim_model': 4}}]`, the model dimension MUST be 4
+   - If it returns `[[], {{'channel': 256}}]`, channel dimensions must be <= 256
+   - If it returns `[[], {{'max_sequence_length': N}}]`, sequence lengths must be <= N
+   - If it returns `[[], {{'heads': H, 'd_model': D}}]`, then D % H must equal 0
+   - Params like `prob_dropout`, `temp_factor` do NOT constrain shapes
+   - If it returns `[[], {{}}]`, there are no shape constraints beyond what the kernel needs
+5. **Generate exactly {NUM_HELDOUT_SHAPES} NEW test configurations** across
+   the generalization categories below (some categories require 2 shapes).
+   - RESPECT all get_init_inputs() constraints
+   - Use the SAME tensor structure as the original (same number of tensors, same dtypes)
+   - Keep total allocation ≤ 2 GB to avoid OOM
+6. **Write** the file `{output_path}` with the exact YAML format below.
+
+{cats}
+
+## CRITICAL: Dual-file injection
+
+The replacement `get_inputs()` function must be **IDENTICAL** in both the
+modular and functional injection entries. Find the exact filenames from the
+workspace (the `pytorch_code_module/` and `pytorch_code_functional/` directories).
+
+## Output Format
+
+Write `{output_path}` as a valid YAML file with this structure:
+```yaml
+{HELDOUT_YAML_SCHEMA_HIP}
+```
+
+The `replacement_code` must be valid Python that can directly replace the
+existing get_inputs() function. Keep the same coding style (configs list,
+for loop, yield pattern).
+
+## Rules
+- Do NOT modify any existing files — only create the output YAML
+- Do NOT run any commands — this is a read-and-write task only
+- The output MUST be valid YAML
+- The `init_constraints` field should only include params that constrain tensor shapes
+- Each shape must satisfy ALL constraints you identified (both hard and init_constraints)
+- Each shape MUST be tagged with its generalization category in a comment
+- Ensure no generated shape is identical to any original get_inputs() entry
+- The modular and functional replacement_code MUST be byte-for-byte identical
+"""
+
+
+# ---------------------------------------------------------------------------
+# Agent launchers (adapted from task_validator)
+# ---------------------------------------------------------------------------
+
+def _read_stream(stream, output_list, prefix, log_func):
+    try:
+        for line in iter(stream.readline, ''):
+            if not line:
+                break
+            raw = line.rstrip()
+            if raw.strip():
+                output_list.append(raw)
+                try:
+                    data = json.loads(raw)
+                    et = data.get("type", "")
+                    if et == "stream_event":
+                        ev = data.get("event", {})
+                        if ev.get("type") == "content_block_delta":
+                            continue
+                    log_func(f"{prefix} {raw[:200]}")
+                except (json.JSONDecodeError, AttributeError):
+                    log_func(f"{prefix} {raw[:200]}")
+    finally:
+        stream.close()
+
+
+def _launch_claude_code(prompt: str, workspace: str, timeout: int, log: logging.Logger,
+                        model: Optional[str] = None) -> str:
+    agent = "claude"
+    opts = (
+        "--print "
+        "--verbose "
+        "--output-format stream-json "
+        "--permission-mode bypassPermissions "
+        "--dangerously-skip-permissions"
+    )
+    if not shutil.which(agent):
+        raise RuntimeError(f"'{agent}' CLI not found in PATH")
+
+    if model:
+        opts += f" --model {shlex.quote(model)}"
+    cmd = f"{agent} {opts} {shlex.quote(prompt)}"
+    log.info(f"Launching claude_code (model={model or 'default'}): {cmd[:200]}...")
+
+    proc = subprocess.Popen(
+        cmd, shell=True,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, cwd=workspace, bufsize=1,
+    )
+    if proc.stdin:
+        proc.stdin.close()
+
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    t1 = threading.Thread(target=_read_stream, args=(proc.stdout, stdout_lines, "[GEN]", log.info), daemon=True)
+    t2 = threading.Thread(target=_read_stream, args=(proc.stderr, stderr_lines, "[GEN-ERR]", log.warning), daemon=True)
+    t1.start(); t2.start()
+
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log.warning(f"Agent timed out after {timeout}s; terminating")
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    t1.join(timeout=5); t2.join(timeout=5)
+    log.info(f"Agent exited with code {proc.returncode}")
+    return "\n".join(stdout_lines)
+
+
+def _launch_codex(prompt: str, workspace: str, timeout: int, log: logging.Logger,
+                  model: Optional[str] = None) -> str:
+    agent = "codex"
+    if not shutil.which(agent):
+        raise RuntimeError(f"'{agent}' CLI not found in PATH")
+
+    cmd = [
+        agent, "exec", "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+        "--cd", workspace,
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+    log.info(f"Launching codex (model={model or 'default'}): {' '.join(shlex.quote(p) for p in cmd[:8])}...")
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, cwd=workspace, bufsize=1,
+    )
+    if proc.stdin:
+        proc.stdin.close()
+
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    t1 = threading.Thread(target=_read_stream, args=(proc.stdout, stdout_lines, "[GEN]", log.info), daemon=True)
+    t2 = threading.Thread(target=_read_stream, args=(proc.stderr, stderr_lines, "[GEN-ERR]", log.warning), daemon=True)
+    t1.start(); t2.start()
+
+    try:
+        proc.wait(timeout=timeout if timeout > 0 else None)
+    except subprocess.TimeoutExpired:
+        log.warning(f"Agent timed out after {timeout}s; terminating")
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    t1.join(timeout=5); t2.join(timeout=5)
+    log.info(f"Agent exited with code {proc.returncode}")
+    return "\n".join(stdout_lines)
+
+
+def _launch_cursor(prompt: str, workspace: str, timeout: int, log: logging.Logger,
+                   model: Optional[str] = None) -> str:
+    agent = "cursor-agent"
+    if not shutil.which(agent):
+        raise RuntimeError(
+            f"'{agent}' CLI not found in PATH. "
+            "Ensure cursor-agent is installed and available."
+        )
+
+    opts = "--force --print --output-format stream-json --stream-partial-output"
+    if model:
+        opts += f" --model {shlex.quote(model)}"
+    cmd = f"{agent} {opts} {shlex.quote(prompt)}"
+    log.info(f"Launching cursor (model={model or 'default'}): {cmd[:200]}...")
+
+    proc = subprocess.Popen(
+        cmd, shell=True,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, cwd=workspace, bufsize=1,
+    )
+    if proc.stdin:
+        proc.stdin.close()
+
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    t1 = threading.Thread(target=_read_stream, args=(proc.stdout, stdout_lines, "[GEN]", log.info), daemon=True)
+    t2 = threading.Thread(target=_read_stream, args=(proc.stderr, stderr_lines, "[GEN-ERR]", log.warning), daemon=True)
+    t1.start(); t2.start()
+
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log.warning(f"Agent timed out after {timeout}s; terminating")
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    t1.join(timeout=5); t2.join(timeout=5)
+    log.info(f"Agent exited with code {proc.returncode}")
+    return "\n".join(stdout_lines)
+
+
+BACKENDS = {
+    "claude_code": _launch_claude_code,
+    "codex": _launch_codex,
+    "cursor": _launch_cursor,
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-task generation
+# ---------------------------------------------------------------------------
+
+def generate_for_task(
+    task_id: str,
+    task_dir: Path,
+    output_dir: Path,
+    backend: str,
+    timeout: int,
+    model: Optional[str] = None,
+) -> bool:
+    """Generate held_out_shapes.yaml for a single task. Returns True on success."""
+    log = logging.getLogger(f"gen.{task_id}")
+
+    out_path = output_dir / task_id / "held_out_shapes.yaml"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    prompt = build_prompt(task_id, str(out_path))
+
+    launcher = BACKENDS.get(backend)
+    if not launcher:
+        log.error(f"Unknown backend: {backend}")
+        return False
+
+    try:
+        agent_output = launcher(prompt, str(task_dir), timeout, log, model=model)
+    except Exception as e:
+        log.error(f"Agent launch failed: {e}")
+        return False
+
+    # Save agent log alongside the YAML output
+    log_path = out_path.parent / "agent_log.txt"
+    log_path.write_text(
+        f"# Task: {task_id}\n"
+        f"# Backend: {backend}\n"
+        f"# Model: {model or 'default'}\n"
+        f"# Timeout: {timeout}s\n"
+        f"{'=' * 80}\n"
+        f"{agent_output}\n"
+    )
+    log.info(f"Agent log saved -> {log_path}")
+
+    if out_path.exists():
+        try:
+            config = yaml.safe_load(out_path.read_text())
+            if not config or "injections" not in config:
+                log.error("Generated YAML missing 'injections' key")
+                return False
+            log.info(f"Generated held-out config -> {out_path}")
+            return True
+        except yaml.YAMLError as e:
+            log.error(f"Generated file is not valid YAML: {e}")
+            return False
+    else:
+        log.error(f"Agent did not create {out_path}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate held-out test shapes via coding agent")
+    parser.add_argument("--tasks-dir", default="tasks", help="Root tasks directory")
+    parser.add_argument("--output-dir", default="held_out_tests", help="Output directory for held-out configs")
+    parser.add_argument("--backend", default="claude_code", choices=list(BACKENDS.keys()),
+                        help="Agent backend to use (default: claude_code)")
+    parser.add_argument("--model", default=None,
+                        help="Model to use for the agent (e.g. claude-4.6-opus-high, o3). "
+                             "If not set, uses the agent's default model.")
+    parser.add_argument("--timeout", type=int, default=600, help="Per-task agent timeout in seconds")
+    parser.add_argument("--tasks", nargs="*", default=None, help="Specific task IDs to generate for")
+    parser.add_argument("--dry-run", action="store_true", help="Discover tasks but don't launch agents")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+    )
+
+    tasks_dir = Path(args.tasks_dir).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    all_tasks = discover_tasks(tasks_dir)
+    logger.info(f"Discovered {len(all_tasks)} in-scope tasks")
+
+    if args.tasks:
+        all_tasks = [(tid, td) for tid, td in all_tasks if tid in args.tasks]
+        logger.info(f"Filtered to {len(all_tasks)} requested tasks")
+
+    if args.dry_run:
+        for task_id, _ in all_tasks:
+            print(f"  {task_id}")
+        return
+
+    success = 0
+    failed = 0
+
+    for task_id, task_dir in all_tasks:
+        try:
+            if generate_for_task(task_id, task_dir, output_dir, args.backend, args.timeout, model=args.model):
+                success += 1
+            else:
+                failed += 1
+        except Exception as e:
+            logger.error(f"[{task_id}] Unexpected error: {e}")
+            failed += 1
+
+    logger.info(f"Done. {success} succeeded, {failed} failed out of {len(all_tasks)} tasks.")
+
+
+if __name__ == "__main__":
+    main()

--- a/held_out/injection.py
+++ b/held_out/injection.py
@@ -1,0 +1,229 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""
+Codegen injection for held-out shape replacement.
+
+Handles three patterns:
+1. triton2triton/vllm: replace TEST_SHAPES = [...] block in task_runner.py
+2. hip2hip/torch2hip gpumode: replace def get_inputs(): ... function in
+   both pytorch_code_module/*.py and pytorch_code_functional/*_func.py
+3. raw_replace: exact string find-and-replace, used for triton2triton/rocmbench
+   @pytest.mark.parametrize decorators and any other ad-hoc patterns
+"""
+import re
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _find_bracket_end(text: str, start: int) -> int:
+    """Find the index of the closing bracket matching the opening bracket at `start`."""
+    depth = 0
+    i = start
+    while i < len(text):
+        if text[i] == '[':
+            depth += 1
+        elif text[i] == ']':
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def replace_test_shapes(source: str, replacement_code: str) -> str:
+    """
+    Replace a TEST_SHAPES = [...] block in Python source code.
+
+    Finds the assignment via regex, then uses bracket balancing to locate
+    the full extent of the list literal (handles multiline lists).
+
+    Args:
+        source: Original file contents
+        replacement_code: Full replacement including 'TEST_SHAPES = [...]'
+
+    Returns:
+        Modified source with TEST_SHAPES block replaced
+
+    Raises:
+        ValueError: If TEST_SHAPES assignment not found or brackets unbalanced
+    """
+    pattern = re.compile(r'^([ \t]*)TEST_SHAPES\s*=\s*\[', re.MULTILINE)
+    match = pattern.search(source)
+    if not match:
+        raise ValueError("Could not find 'TEST_SHAPES = [' in source")
+
+    bracket_start = source.index('[', match.start())
+    bracket_end = _find_bracket_end(source, bracket_start)
+    if bracket_end == -1:
+        raise ValueError("Unbalanced brackets in TEST_SHAPES definition")
+
+    # Consume trailing newline if present
+    end = bracket_end + 1
+    if end < len(source) and source[end] == '\n':
+        end += 1
+
+    indent = match.group(1)
+    indented_replacement = '\n'.join(
+        (indent + line) if line.strip() else line
+        for line in replacement_code.strip().splitlines()
+    ) + '\n'
+
+    return source[:match.start()] + indented_replacement + source[end:]
+
+
+def _find_function_end(source: str, func_start: int) -> int:
+    """
+    Find the end of a top-level function definition starting at `func_start`.
+
+    Uses indentation: the function body consists of all lines after the def
+    line that are either blank or indented deeper than the def line.
+    """
+    lines = source[func_start:].split('\n')
+    if not lines:
+        return func_start
+
+    def_line = lines[0]
+    base_indent = len(def_line) - len(def_line.lstrip())
+
+    consumed = len(lines[0]) + 1  # +1 for the newline
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == '' or stripped.startswith('#'):
+            consumed += len(line) + 1
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent <= base_indent:
+            break
+        consumed += len(line) + 1
+
+    return func_start + consumed
+
+
+def replace_get_inputs(source: str, replacement_code: str) -> str:
+    """
+    Replace a def get_inputs(): ... function in Python source code.
+
+    Detects the function via regex, finds its end via indentation analysis,
+    and replaces the entire function body.
+
+    Args:
+        source: Original file contents
+        replacement_code: Full replacement including 'def get_inputs():'
+
+    Returns:
+        Modified source with get_inputs replaced
+
+    Raises:
+        ValueError: If get_inputs function not found
+    """
+    pattern = re.compile(r'^([ \t]*)def get_inputs\s*\(', re.MULTILINE)
+    match = pattern.search(source)
+    if not match:
+        raise ValueError("Could not find 'def get_inputs(' in source")
+
+    func_end = _find_function_end(source, match.start())
+    indent = match.group(1)
+
+    indented_replacement = '\n'.join(
+        (indent + line) if line.strip() else line
+        for line in replacement_code.strip().splitlines()
+    ) + '\n'
+
+    return source[:match.start()] + indented_replacement + source[func_end:]
+
+
+def apply_injection(
+    workspace: Path,
+    injection_spec: dict,
+    logger: Optional[logging.Logger] = None,
+) -> bool:
+    """
+    Apply a single injection (one file replacement) from a held_out_shapes.yaml entry.
+
+    Args:
+        workspace: Task workspace directory (the copied run workspace)
+        injection_spec: Dict with keys 'file', 'find_marker', 'replacement_code'
+        logger: Optional logger
+
+    Returns:
+        True if injection succeeded, False otherwise
+    """
+    log = logger or logging.getLogger(__name__)
+
+    target_file = workspace / injection_spec['file']
+    find_marker = injection_spec['find_marker']
+    replacement_code = injection_spec['replacement_code']
+
+    if not target_file.exists():
+        log.error(f"Injection target file not found: {target_file}")
+        return False
+
+    source = target_file.read_text()
+
+    try:
+        if find_marker == "TEST_SHAPES":
+            modified = replace_test_shapes(source, replacement_code)
+        elif find_marker.startswith("def get_inputs"):
+            modified = replace_get_inputs(source, replacement_code)
+        elif find_marker == "raw_replace":
+            old_code = injection_spec.get('old_code')
+            if not old_code:
+                log.error(f"raw_replace injection missing 'old_code' in spec for {target_file}")
+                return False
+            if old_code not in source:
+                log.error(
+                    f"raw_replace: old_code not found in {target_file}. "
+                    f"First 80 chars of old_code: {old_code[:80]!r}"
+                )
+                return False
+            modified = source.replace(old_code, replacement_code, 1)
+        else:
+            log.error(f"Unknown find_marker type: {find_marker}")
+            return False
+    except ValueError as e:
+        log.error(f"Injection failed for {target_file}: {e}")
+        return False
+
+    if modified == source:
+        log.warning(f"Injection produced no change in {target_file}")
+        return False
+
+    target_file.write_text(modified)
+    log.info(f"Injected held-out shapes into {target_file}")
+    return True
+
+
+def apply_all_injections(
+    workspace: Path,
+    heldout_config: dict,
+    logger: Optional[logging.Logger] = None,
+) -> bool:
+    """
+    Apply all injections from a held_out_shapes.yaml config to a workspace.
+
+    For hip2hip/torch2hip tasks this applies the same replacement to both
+    the modular and functional Python files.
+
+    Args:
+        workspace: Task workspace directory
+        heldout_config: Parsed held_out_shapes.yaml dict
+        logger: Optional logger
+
+    Returns:
+        True if all injections succeeded, False if any failed
+    """
+    log = logger or logging.getLogger(__name__)
+    injections = heldout_config.get('injections', [])
+
+    if not injections:
+        log.error("No injections defined in held-out config")
+        return False
+
+    all_ok = True
+    for spec in injections:
+        if not apply_injection(workspace, spec, log):
+            all_ok = False
+
+    return all_ok

--- a/held_out/run_heldout_eval.py
+++ b/held_out/run_heldout_eval.py
@@ -1,0 +1,588 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""
+Held-out evaluation script.
+
+Takes a completed run directory, copies each task workspace into two
+sub-workspaces (orig/ and opt/), injects held-out shapes into both,
+restores the original kernel in orig/, and measures baseline vs optimized
+performance on the unseen shapes.
+
+Usage:
+    python held_out/run_heldout_eval.py \
+        --run-dir workspace_MI300_cursor/run_20260417_142419 \
+        --heldout-dir held_out_tests/ \
+        --tasks-dir tasks/ \
+        [--output-suffix _heldout]
+"""
+import argparse
+import logging
+import shutil
+import sys
+import yaml
+import statistics
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+# Allow running from repo root
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from held_out.injection import apply_all_injections
+from src.evaluator import (
+    evaluate_compilation,
+    evaluate_correctness,
+    measure_performance,
+)
+from src.performance import measure_baseline
+from src.testcases import (
+    TestCaseResult,
+    save_performance_results,
+    calculate_average_speedup,
+)
+from src.score import score as calc_score
+
+
+def setup_logging(log_file: Optional[Path] = None) -> logging.Logger:
+    log = logging.getLogger("heldout_eval")
+    log.setLevel(logging.INFO)
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+
+    console = logging.StreamHandler()
+    console.setFormatter(fmt)
+    log.addHandler(console)
+
+    if log_file:
+        fh = logging.FileHandler(log_file)
+        fh.setFormatter(fmt)
+        log.addHandler(fh)
+
+    return log
+
+
+def _valid_perf_cases(cases: List[TestCaseResult]) -> List[TestCaseResult]:
+    return [c for c in cases if c.execution_time_ms is not None and c.execution_time_ms > 0]
+
+
+def resolve_task_id(workspace_dir: Path) -> Optional[str]:
+    """
+    Derive the canonical task id (e.g. 'hip2hip/gpumode/SiLU') from the
+    task_result.yaml written by the framework, falling back to config.yaml
+    or directory-name heuristics.
+    """
+    task_result = workspace_dir / "task_result.yaml"
+    if task_result.exists():
+        try:
+            data = yaml.safe_load(task_result.read_text()) or {}
+            name = data.get("task_name", "")
+            if "/" in name:
+                return name
+        except Exception:
+            pass
+
+    config = workspace_dir / "config.yaml"
+    if config.exists():
+        try:
+            data = yaml.safe_load(config.read_text()) or {}
+            task_type = data.get("task_type", "")
+            # config.yaml is a copy of the original, so its parent path
+            # doesn't help; use task_result.yaml's task_name or dir name
+        except Exception:
+            pass
+
+    # Heuristic: dir name is like hip2hip_gpumode_SiLU_20260417_142639
+    # or triton2triton_rocmbench_easy_test_add_kernel_20260417_142639
+    # Strip trailing _YYYYMMDD_HHMMSS
+    dir_name = workspace_dir.name
+    parts = dir_name.rsplit("_", 2)
+    if len(parts) >= 3:
+        task_slug = "_".join(parts[:-2])
+        # triton2triton/rocmbench has an extra level (easy/medium/hard)
+        # so 3 slashes instead of 2
+        if task_slug.startswith("triton2triton_rocmbench_"):
+            return task_slug.replace("_", "/", 3)
+        return task_slug.replace("_", "/", 2)
+
+    return None
+
+
+def _restore_original_kernel(
+    orig_workspace: Path,
+    task_dir: Path,
+    task_config: Dict[str, Any],
+    logger: logging.Logger,
+) -> bool:
+    """
+    Overwrite the agent-optimized kernel in *orig_workspace* with the
+    unoptimized original from the canonical tasks directory.
+
+    For hip2hip: copies ``target_file_path``.
+    For torch2hip: removes the agent-generated HIP file (the original is
+    pure PyTorch -- there is no HIP kernel to restore).
+    For triton2triton: copies every file in ``source_file_path``.
+
+    Returns True on success, False on failure.
+    """
+    task_type = task_config.get("task_type", "")
+
+    if task_type == "torch2hip":
+        target = task_config.get("target_file_path")
+        if target:
+            hip_file = orig_workspace / target
+            if hip_file.exists():
+                hip_file.unlink()
+                logger.info("Removed agent HIP kernel from orig/: %s", hip_file)
+        logger.info("torch2hip: orig/ will use PyTorch baseline (no HIP kernel)")
+        return True
+
+    if task_type == "hip2hip":
+        target = task_config.get("target_file_path")
+        if not target:
+            logger.error("config.yaml has no target_file_path for %s task", task_type)
+            return False
+        files_to_copy = [target]
+    else:
+        files_to_copy = task_config.get("source_file_path", [])
+        if not files_to_copy:
+            logger.error("config.yaml has no source_file_path for %s task", task_type)
+            return False
+
+    for rel_path in files_to_copy:
+        src = task_dir / rel_path
+        dst = orig_workspace / rel_path
+        if not src.exists():
+            logger.error("Original kernel not found: %s", src)
+            return False
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        logger.info("Restored original kernel: %s -> %s", src, dst)
+
+    return True
+
+
+def _clear_build_artifacts(workspace: Path) -> None:
+    """Remove stale build artifacts so performance reports are fresh."""
+    build_dir = workspace / "build"
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
+
+def _classify_generalization(orig_correct: bool, opt_correct: bool) -> str:
+    """
+    Classify the held-out outcome into one of four quadrants:
+
+    - both_pass:      orig ✓  opt ✓  — normal, compare speedups
+    - opt_regression:  orig ✓  opt ✗  — optimization broke generalization
+    - both_fail:       orig ✗  opt ✗  — shape exceeds kernel spec
+    - opt_improvement: orig ✗  opt ✓  — agent improved robustness
+    """
+    if orig_correct and opt_correct:
+        return "both_pass"
+    if orig_correct and not opt_correct:
+        return "opt_regression"
+    if not orig_correct and not opt_correct:
+        return "both_fail"
+    return "opt_improvement"
+
+
+def evaluate_single_task(
+    original_workspace: Path,
+    output_workspace: Path,
+    heldout_config: dict,
+    task_dir: Path,
+    logger: logging.Logger,
+) -> Dict[str, Any]:
+    """
+    Create orig/ and opt/ workspace copies, inject held-out shapes into
+    both, restore the original kernel in orig/, and evaluate both.
+
+    - ``orig/``: original unoptimized kernel — compile, correctness, performance
+    - ``opt/``: agent's optimized kernel — compile, correctness, performance
+
+    The ``generalization_status`` field classifies the outcome:
+
+    - ``both_pass``:      orig correct, opt correct — compare speedups
+    - ``opt_regression``:  orig correct, opt failed — genuine generalization failure
+    - ``both_fail``:       both incorrect — shape exceeds kernel design spec
+    - ``opt_improvement``: orig failed, opt correct — agent improved robustness
+
+    Returns a result dict for heldout_task_result.yaml.
+    """
+    task_id = resolve_task_id(original_workspace) or original_workspace.name
+
+    run_result: Dict[str, Any] = {}
+    run_result_file = original_workspace / "task_result.yaml"
+    if run_result_file.exists():
+        run_result = yaml.safe_load(run_result_file.read_text()) or {}
+
+    result: Dict[str, Any] = {
+        "task_name": task_id,
+        "heldout": True,
+        # opt kernel results
+        "opt_pass_compilation": False,
+        "opt_pass_correctness": False,
+        "opt_execution_time": 0.0,
+        # orig kernel results on held-out shapes
+        "orig_heldout_pass_compilation": False,
+        "orig_heldout_pass_correctness": False,
+        "orig_heldout_execution_time": 0.0,
+        # comparison
+        "generalization_status": "both_fail",
+        "speedup_ratio": 0.0,
+        "score": 0.0,
+        # original run results (on original shapes, for reference)
+        "original_run_pass_correctness": run_result.get("pass_correctness", False),
+        "original_run_speedup_ratio": run_result.get("speedup_ratio", 0.0),
+        "original_run_score": run_result.get("score", 0.0),
+        "error": None,
+    }
+
+    # ── 1. Prepare opt/ and orig/ workspaces ────────────────────────────
+    if output_workspace.exists():
+        shutil.rmtree(output_workspace)
+    output_workspace.mkdir(parents=True)
+
+    opt_ws = output_workspace / "opt"
+    orig_ws = output_workspace / "orig"
+
+    shutil.copytree(original_workspace, opt_ws)
+    shutil.copytree(original_workspace, orig_ws)
+    logger.info(f"Created opt/ and orig/ workspaces under {output_workspace}")
+
+    _clear_build_artifacts(opt_ws)
+    _clear_build_artifacts(orig_ws)
+
+    # ── 2. Restore original (unoptimized) kernel in orig/ ───────────────
+    config_file = opt_ws / "config.yaml"
+    if not config_file.exists():
+        result["error"] = "config.yaml not found in workspace"
+        _write_result(output_workspace, result)
+        return result
+    task_config = yaml.safe_load(config_file.read_text()) or {}
+
+    if not _restore_original_kernel(orig_ws, task_dir, task_config, logger):
+        result["error"] = "Failed to restore original kernel in orig/"
+        _write_result(output_workspace, result)
+        return result
+
+    # ── 3. Inject held-out shapes into both workspaces ──────────────────
+    for label, ws in [("opt", opt_ws), ("orig", orig_ws)]:
+        if not apply_all_injections(ws, heldout_config, logger):
+            result["error"] = f"Injection failed in {label}/"
+            logger.error(f"[{task_id}] Injection failed in {label}/, skipping")
+            _write_result(output_workspace, result)
+            return result
+
+    # ── 4. Evaluate ORIGINAL kernel (orig/) ─────────────────────────────
+    is_torch2hip = task_config.get("task_type") == "torch2hip"
+
+    if is_torch2hip:
+        # torch2hip: the "original" is pure PyTorch -- no HIP kernel to
+        # compile or correctness-check.  We treat the PyTorch module as
+        # always correct and measure its baseline latency in step 7.
+        logger.info(f"[{task_id}] torch2hip: skipping compilation/correctness for orig/ "
+                     "(PyTorch baseline)")
+        orig_comp = True
+        orig_correct = True
+        result["orig_heldout_pass_compilation"] = True
+        result["orig_heldout_pass_correctness"] = True
+    else:
+        logger.info(f"[{task_id}] Compiling original kernel (orig/)...")
+        orig_comp, orig_comp_err = evaluate_compilation(orig_ws, task_config, logger)
+        result["orig_heldout_pass_compilation"] = orig_comp
+
+        orig_correct = False
+        if orig_comp:
+            logger.info(f"[{task_id}] Running correctness on original kernel (orig/)...")
+            orig_correct, _ = evaluate_correctness(orig_ws, task_config, logger)
+            result["orig_heldout_pass_correctness"] = orig_correct
+        else:
+            logger.warning(f"[{task_id}] Original kernel failed compilation on held-out shapes")
+
+    # ── 5. Evaluate OPTIMIZED kernel (opt/) ─────────────────────────────
+    logger.info(f"[{task_id}] Compiling optimized kernel (opt/)...")
+    opt_comp, opt_comp_err = evaluate_compilation(opt_ws, task_config, logger)
+    result["opt_pass_compilation"] = opt_comp
+
+    opt_correct = False
+    if opt_comp:
+        logger.info(f"[{task_id}] Running correctness on optimized kernel (opt/)...")
+        opt_correct, opt_corr_err = evaluate_correctness(opt_ws, task_config, logger)
+        result["opt_pass_correctness"] = opt_correct
+        if not opt_correct:
+            result["error"] = opt_corr_err
+    else:
+        result["error"] = opt_comp_err
+
+    # ── 6. Classify generalization outcome ──────────────────────────────
+    status = _classify_generalization(orig_correct, opt_correct)
+    result["generalization_status"] = status
+    logger.info(f"[{task_id}] Generalization status: {status}")
+
+    # ── 7. Performance (only when the respective kernel is correct) ─────
+    valid_baseline: List[TestCaseResult] = []
+    valid_optimized: List[TestCaseResult] = []
+
+    if orig_correct:
+        if is_torch2hip:
+            # For torch2hip the baseline is the PyTorch module, measured
+            # via the performance script with --baseline_only (no HIP
+            # compilation needed).  Use opt/ workspace which still has
+            # the PyTorch source files and eval_tools intact.
+            logger.info(f"[{task_id}] Measuring PyTorch baseline performance (opt/ --baseline_only)...")
+            baseline_cases = measure_baseline(opt_ws, task_config, logger)
+        else:
+            logger.info(f"[{task_id}] Measuring baseline performance (orig/)...")
+            baseline_cases = measure_baseline(orig_ws, task_config, logger)
+        valid_baseline = _valid_perf_cases(baseline_cases)
+        if valid_baseline:
+            result["orig_heldout_execution_time"] = (
+                sum(c.execution_time_ms for c in valid_baseline) / len(valid_baseline)
+            )
+
+    if opt_correct:
+        logger.info(f"[{task_id}] Measuring optimized performance (opt/)...")
+        optimized_cases = measure_performance(opt_ws, task_config, logger)
+        valid_optimized = _valid_perf_cases(optimized_cases)
+        if valid_optimized:
+            result["opt_execution_time"] = (
+                sum(c.execution_time_ms for c in valid_optimized) / len(valid_optimized)
+            )
+            save_performance_results(valid_optimized, opt_ws, "optimized_perf.yaml", logger)
+
+    if status == "both_pass" and valid_baseline and valid_optimized:
+        result["speedup_ratio"] = calculate_average_speedup(
+            valid_baseline, valid_optimized, logger,
+        )
+
+    # ── 8. Score ────────────────────────────────────────────────────────
+    result["score"] = calc_score(
+        opt_comp,
+        opt_correct,
+        result["orig_heldout_execution_time"],
+        result["opt_execution_time"],
+        result["speedup_ratio"],
+    )
+
+    logger.info(
+        f"[{task_id}] Held-out result: status={status}, "
+        f"orig_correct={orig_correct}, opt_correct={opt_correct}, "
+        f"speedup={result['speedup_ratio']:.2f}x "
+        f"(original_run={result['original_run_speedup_ratio']:.2f}x)"
+    )
+
+    _write_result(output_workspace, result)
+    return result
+
+
+def _write_result(workspace: Path, result: dict) -> None:
+    out_file = workspace / "heldout_task_result.yaml"
+    with open(out_file, "w") as f:
+        yaml.dump(result, f, default_flow_style=False, sort_keys=False)
+
+
+def write_summary(
+    output_dir: Path,
+    results: List[Dict[str, Any]],
+    logger: logging.Logger,
+) -> None:
+    """Write aggregate heldout_summary.yaml and log a report."""
+    total = len(results)
+    if total == 0:
+        logger.warning("No held-out results to summarize")
+        return
+
+    def _stats(vals):
+        if not vals:
+            return {"mean": 0.0, "median": 0.0, "std": 0.0}
+        return {
+            "mean": round(sum(vals) / len(vals), 4),
+            "median": round(statistics.median(vals), 4),
+            "std": round(statistics.stdev(vals) if len(vals) > 1 else 0.0, 4),
+        }
+
+    # ── Quadrant counts ────────────────────────────────────────────────
+    quadrants = {"both_pass": 0, "opt_regression": 0, "both_fail": 0, "opt_improvement": 0}
+    for r in results:
+        status = r.get("generalization_status", "both_fail")
+        quadrants[status] = quadrants.get(status, 0) + 1
+
+    # ── Conditional correctness: P(opt correct | orig correct) ─────────
+    orig_correct_tasks = [r for r in results if r["orig_heldout_pass_correctness"]]
+    n_orig_correct = len(orig_correct_tasks)
+    n_opt_correct_given_orig = sum(1 for r in orig_correct_tasks if r["opt_pass_correctness"])
+    conditional_correctness = (
+        round(n_opt_correct_given_orig / n_orig_correct * 100, 1)
+        if n_orig_correct > 0 else 0.0
+    )
+
+    # ── Speedups (only for both_pass) ──────────────────────────────────
+    both_pass = [r for r in results if r["generalization_status"] == "both_pass"]
+    heldout_speedups = [r["speedup_ratio"] for r in both_pass if r["speedup_ratio"] > 0]
+    orig_run_speedups = [r["original_run_speedup_ratio"] for r in both_pass if r["original_run_speedup_ratio"] > 0]
+
+    # ── Per-task detail ────────────────────────────────────────────────
+    per_task = []
+    for r in results:
+        per_task.append({
+            "task_name": r["task_name"],
+            "generalization_status": r["generalization_status"],
+            "orig_heldout_correct": r["orig_heldout_pass_correctness"],
+            "opt_heldout_correct": r["opt_pass_correctness"],
+            "heldout_speedup": round(r["speedup_ratio"], 4),
+            "original_run_speedup": round(r["original_run_speedup_ratio"], 4),
+            "speedup_delta": round(r["speedup_ratio"] - r["original_run_speedup_ratio"], 4),
+            "heldout_score": round(r["score"], 2),
+            "original_run_score": round(r["original_run_score"], 2),
+            "error": r.get("error"),
+        })
+
+    summary = {
+        "total_tasks": total,
+        "quadrant_counts": quadrants,
+        "conditional_correctness": {
+            "description": "P(opt correct on held-out | orig correct on held-out)",
+            "orig_correct_count": n_orig_correct,
+            "opt_also_correct_count": n_opt_correct_given_orig,
+            "rate_pct": conditional_correctness,
+        },
+        "heldout_speedup_stats": {
+            "description": "Speedup on held-out shapes (both_pass tasks only)",
+            "count": len(heldout_speedups),
+            **_stats(heldout_speedups),
+        },
+        "original_run_speedup_stats": {
+            "description": "Speedup from original run (both_pass tasks only, for reference)",
+            "count": len(orig_run_speedups),
+            **_stats(orig_run_speedups),
+        },
+        "generalization_gap": {
+            "correctness_retention_pct": conditional_correctness,
+            "speedup_mean_delta": round(
+                _stats(heldout_speedups)["mean"] - _stats(orig_run_speedups)["mean"], 4
+            ),
+        },
+        "per_task": per_task,
+    }
+
+    summary_file = output_dir / "heldout_summary.yaml"
+    with open(summary_file, "w") as f:
+        yaml.dump(summary, f, default_flow_style=False, sort_keys=False)
+    logger.info(f"Summary written to {summary_file}")
+
+    # ── Log summary ───────────────────────────────────────────────────
+    logger.info("=" * 80)
+    logger.info("HELD-OUT EVALUATION SUMMARY")
+    logger.info("=" * 80)
+    logger.info(f"Total tasks evaluated: {total}")
+    logger.info("")
+    logger.info("Generalization quadrants:")
+    logger.info(f"  both_pass (orig ✓ opt ✓):       {quadrants['both_pass']}")
+    logger.info(f"  opt_regression (orig ✓ opt ✗):   {quadrants['opt_regression']}")
+    logger.info(f"  both_fail (orig ✗ opt ✗):        {quadrants['both_fail']}")
+    logger.info(f"  opt_improvement (orig ✗ opt ✓):  {quadrants['opt_improvement']}")
+    logger.info("")
+    logger.info(f"Conditional correctness:  {n_opt_correct_given_orig}/{n_orig_correct} "
+                f"= {conditional_correctness:.1f}%  "
+                f"(P(opt correct | orig correct))")
+    s = _stats(heldout_speedups)
+    logger.info(f"Held-out speedup:         mean={s['mean']:.2f}x, median={s['median']:.2f}x "
+                f"(n={len(heldout_speedups)} both_pass tasks)")
+    s2 = _stats(orig_run_speedups)
+    logger.info(f"Original run speedup:     mean={s2['mean']:.2f}x, median={s2['median']:.2f}x "
+                f"(same tasks, for reference)")
+    gap = summary["generalization_gap"]
+    logger.info(f"Speedup retention:        {gap['speedup_mean_delta']:+.4f}x mean delta")
+    logger.info("=" * 80)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Held-out evaluation for AgentKernelArena")
+    parser.add_argument(
+        "--run-dir", required=True,
+        help="Path to the completed run directory (e.g. workspace_MI300_cursor/run_20260417_142419)",
+    )
+    parser.add_argument(
+        "--heldout-dir", required=True,
+        help="Path to held_out_tests/ directory containing per-task held_out_shapes.yaml",
+    )
+    parser.add_argument(
+        "--tasks-dir", required=True,
+        help="Path to the canonical tasks/ directory (for restoring original kernels)",
+    )
+    parser.add_argument(
+        "--output-suffix", default="_heldout",
+        help="Suffix to append to the run directory name for output (default: _heldout)",
+    )
+    parser.add_argument(
+        "--tasks", nargs="*", default=None,
+        help="Optional list of task IDs to evaluate (default: all tasks with held-out configs)",
+    )
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir).resolve()
+    heldout_dir = Path(args.heldout_dir).resolve()
+    tasks_dir = Path(args.tasks_dir).resolve()
+    output_dir = run_dir.parent / (run_dir.name + args.output_suffix)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger = setup_logging(output_dir / "heldout_eval.log")
+    logger.info(f"Run directory:     {run_dir}")
+    logger.info(f"Held-out data:     {heldout_dir}")
+    logger.info(f"Tasks directory:   {tasks_dir}")
+    logger.info(f"Output directory:  {output_dir}")
+
+    # Discover task workspaces
+    task_workspaces = sorted(
+        p for p in run_dir.iterdir()
+        if p.is_dir() and (p / "task_result.yaml").exists()
+    )
+    logger.info(f"Found {len(task_workspaces)} completed task workspaces")
+
+    # Build list of evaluable tasks so we can show Task N/M progress
+    eval_queue: List[tuple] = []
+    for ws in task_workspaces:
+        task_id = resolve_task_id(ws)
+        if task_id is None:
+            logger.warning(f"Could not resolve task ID for {ws.name}, skipping")
+            continue
+        if args.tasks and task_id not in args.tasks:
+            continue
+        heldout_yaml = heldout_dir / task_id / "held_out_shapes.yaml"
+        if not heldout_yaml.exists():
+            logger.debug(f"No held-out config for {task_id}, skipping")
+            continue
+        task_dir = tasks_dir / task_id
+        if not task_dir.exists():
+            logger.warning(f"Canonical task directory not found: {task_dir}, skipping")
+            continue
+        heldout_config = yaml.safe_load(heldout_yaml.read_text()) or {}
+        eval_queue.append((ws, task_id, heldout_config, task_dir))
+
+    total_tasks = len(eval_queue)
+    logger.info(f"Tasks to evaluate: {total_tasks}")
+
+    results: List[Dict[str, Any]] = []
+
+    for idx, (ws, task_id, heldout_config, task_dir) in enumerate(eval_queue, 1):
+        logger.info("=" * 80)
+        logger.info(f"Task {idx}/{total_tasks}: {task_id}")
+        logger.info("=" * 80)
+
+        out_ws = output_dir / ws.name
+        result = evaluate_single_task(ws, out_ws, heldout_config, task_dir, logger)
+        results.append(result)
+
+        status = result["generalization_status"]
+        spd = result["speedup_ratio"]
+        logger.info(
+            f"Task {idx}/{total_tasks} done: {task_id} — "
+            f"{status}, speedup={spd:.2f}x"
+        )
+
+    write_summary(output_dir, results, logger)
+    logger.info(f"Done. {len(results)} tasks evaluated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/held_out/run_heldout_eval.py
+++ b/held_out/run_heldout_eval.py
@@ -16,6 +16,7 @@ Usage:
 """
 import argparse
 import logging
+import re
 import shutil
 import sys
 import yaml
@@ -238,6 +239,11 @@ def evaluate_single_task(
     }
 
     # ── 1. Prepare opt/ and orig/ workspaces ────────────────────────────
+    if output_workspace.resolve() == original_workspace.resolve():
+        raise ValueError(
+            f"Refusing to overwrite original task workspace: {original_workspace}"
+        )
+
     if output_workspace.exists():
         shutil.rmtree(output_workspace)
     output_workspace.mkdir(parents=True)
@@ -275,17 +281,27 @@ def evaluate_single_task(
 
     # ── 4. Evaluate ORIGINAL kernel (orig/) ─────────────────────────────
     is_torch2hip = task_config.get("task_type") == "torch2hip"
+    valid_baseline: List[TestCaseResult] = []
 
     if is_torch2hip:
         # torch2hip: the "original" is pure PyTorch -- no HIP kernel to
-        # compile or correctness-check.  We treat the PyTorch module as
-        # always correct and measure its baseline latency in step 7.
-        logger.info(f"[{task_id}] torch2hip: skipping compilation/correctness for orig/ "
-                     "(PyTorch baseline)")
+        # compile.  Use baseline execution as the orig validity check so
+        # invalid held-out shapes do not get counted as orig-correct.
+        logger.info(f"[{task_id}] torch2hip: measuring PyTorch baseline validity "
+                    "(opt/ --baseline_only)...")
         orig_comp = True
-        orig_correct = True
         result["orig_heldout_pass_compilation"] = True
-        result["orig_heldout_pass_correctness"] = True
+        baseline_cases = measure_baseline(opt_ws, task_config, logger)
+        valid_baseline = _valid_perf_cases(baseline_cases)
+        orig_correct = bool(valid_baseline)
+        result["orig_heldout_pass_correctness"] = orig_correct
+        if valid_baseline:
+            result["orig_heldout_execution_time"] = (
+                sum(c.execution_time_ms for c in valid_baseline) / len(valid_baseline)
+            )
+        else:
+            result["orig_heldout_pass_correctness"] = False
+            result["error"] = "PyTorch baseline failed on held-out shapes"
     else:
         logger.info(f"[{task_id}] Compiling original kernel (orig/)...")
         orig_comp, orig_comp_err = evaluate_compilation(orig_ws, task_config, logger)
@@ -320,20 +336,11 @@ def evaluate_single_task(
     logger.info(f"[{task_id}] Generalization status: {status}")
 
     # ── 7. Performance (only when the respective kernel is correct) ─────
-    valid_baseline: List[TestCaseResult] = []
     valid_optimized: List[TestCaseResult] = []
 
-    if orig_correct:
-        if is_torch2hip:
-            # For torch2hip the baseline is the PyTorch module, measured
-            # via the performance script with --baseline_only (no HIP
-            # compilation needed).  Use opt/ workspace which still has
-            # the PyTorch source files and eval_tools intact.
-            logger.info(f"[{task_id}] Measuring PyTorch baseline performance (opt/ --baseline_only)...")
-            baseline_cases = measure_baseline(opt_ws, task_config, logger)
-        else:
-            logger.info(f"[{task_id}] Measuring baseline performance (orig/)...")
-            baseline_cases = measure_baseline(orig_ws, task_config, logger)
+    if orig_correct and not is_torch2hip:
+        logger.info(f"[{task_id}] Measuring baseline performance (orig/)...")
+        baseline_cases = measure_baseline(orig_ws, task_config, logger)
         valid_baseline = _valid_perf_cases(baseline_cases)
         if valid_baseline:
             result["orig_heldout_execution_time"] = (
@@ -523,7 +530,14 @@ def main():
     run_dir = Path(args.run_dir).resolve()
     heldout_dir = Path(args.heldout_dir).resolve()
     tasks_dir = Path(args.tasks_dir).resolve()
-    output_dir = run_dir.parent / (run_dir.name + args.output_suffix)
+    if not args.output_suffix:
+        parser.error("--output-suffix must be non-empty")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", args.output_suffix):
+        parser.error("--output-suffix may only contain letters, numbers, dot, underscore, and dash")
+
+    output_dir = (run_dir.parent / (run_dir.name + args.output_suffix)).resolve()
+    if output_dir == run_dir:
+        parser.error("held-out output directory must differ from --run-dir")
     output_dir.mkdir(parents=True, exist_ok=True)
 
     logger = setup_logging(output_dir / "heldout_eval.log")

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from src.tasks import get_task_config
 from src.preprocessing import setup_workspace, setup_rocm_env, is_task_complete
 from src.module_registration import AgentType, load_agent_launcher, load_post_processing_handler
 from src.evaluator import measure_baseline, evaluate_kernel, write_task_result
+from src.runtime_env import apply_subprocess_python_path
 
 
 parser = argparse.ArgumentParser(description="arguments for AgentKernelArena")
@@ -49,6 +50,10 @@ def main() -> None:
     project_root = Path(__file__).resolve().parent
     workspace_directory = (project_root / workspace_directory_name).resolve()
 
+    if args.run_suffix and not re.fullmatch(r"[A-Za-z0-9._-]+", args.run_suffix):
+        print("Error: --run-suffix may only contain letters, numbers, dot, underscore, and dash")
+        return
+
     # Handle resume functionality
     resume_mode = False
     if args.resume_run:
@@ -71,8 +76,10 @@ def main() -> None:
     elif args.resume_latest:
         # Resume latest run
         # Find all run directories and get the most recent one
-        run_dirs = sorted([d for d in workspace_directory.iterdir() 
-                          if d.is_dir() and d.name.startswith("run_")], 
+        run_dirs = sorted([d for d in workspace_directory.iterdir()
+                          if d.is_dir()
+                          and d.name.startswith("run_")
+                          and not d.name.endswith("_heldout")],
                          key=lambda x: x.name, reverse=True)
         if not run_dirs:
             print(f"Error: No run directories found in {workspace_directory}")
@@ -122,6 +129,9 @@ def main() -> None:
         logger.info(f"RESUME MODE: Resuming existing run {run_directory_name}")
     else:
         logger.info(f"NEW RUN: Creating new run {run_directory_name}")
+
+    python_path = apply_subprocess_python_path()
+    logger.info(f"Subprocess Python environment: {python_path}")
 
     # Set PYTORCH_ROCM_ARCH based on target_gpu_model before any task runs
     setup_rocm_env(target_gpu_model, logger)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 # Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+import re
 import yaml
 import logging
 import argparse
@@ -13,6 +14,8 @@ from src.evaluator import measure_baseline, evaluate_kernel, write_task_result
 parser = argparse.ArgumentParser(description="arguments for AgentKernelArena")
 parser.add_argument("--config_name", type=str, default="config.yaml",help="the config of AgentKernelArena, default set to config. \
                     You can set different tasks in different config yaml file in order to run multi evaluation task in one folder.")
+parser.add_argument("--run-suffix", type=str, default=None,
+                    help="Suffix appended to the run directory name, e.g. --run-suffix composer2_hip → run_20260416_120000_composer2_hip")
 parser.add_argument("--resume-run", type=str, default=None,
                     help="Resume an existing run by specifying the run directory name (e.g., run_20250115_143022)")
 parser.add_argument("--resume-latest", action="store_true",
@@ -56,11 +59,14 @@ def main() -> None:
             print(f"Error: Run directory does not exist: {run_directory}")
             return
         resume_mode = True
-        # Extract timestamp from run directory name: run_20250115_143022 -> 20250115_143022
-        if run_directory_name.startswith("run_"):
-            timestamp = run_directory_name[4:]  # Remove "run_" prefix
+        # Extract the YYYYMMDD_HHMMSS timestamp from run directory name.
+        # The name may include a suffix: run_20260429_194009_claude_opus_hip
+        # Task directories use only the timestamp portion, not the suffix.
+        m = re.match(r"^run_(\d{8}_\d{6})", run_directory_name)
+        if m:
+            timestamp = m.group(1)
         else:
-            print(f"Error: Invalid run directory name format: {run_directory_name}. Expected format: run_YYYYMMDD_HHMMSS")
+            print(f"Error: Invalid run directory name format: {run_directory_name}. Expected format: run_YYYYMMDD_HHMMSS[_suffix]")
             return
     elif args.resume_latest:
         # Resume latest run
@@ -74,20 +80,23 @@ def main() -> None:
         run_directory = run_dirs[0]
         run_directory_name = run_directory.name
         resume_mode = True
-        # Extract timestamp from run directory name
-        if run_directory_name.startswith("run_"):
-            timestamp = run_directory_name[4:]
+        # Extract the YYYYMMDD_HHMMSS timestamp (same regex as --resume-run)
+        m = re.match(r"^run_(\d{8}_\d{6})", run_directory_name)
+        if m:
+            timestamp = m.group(1)
         else:
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     else:
         # Create new run
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        run_directory_name = f"run_{timestamp}"
+        suffix = f"_{args.run_suffix}" if args.run_suffix else ""
+        run_directory_name = f"run_{timestamp}{suffix}"
         run_directory = workspace_directory / run_directory_name
         run_directory.mkdir(parents=True, exist_ok=True)
     log_dir = Path(log_directory)
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_filename = f"{target_gpu_model}_{agent.value}_{timestamp}.log"
+    log_suffix = f"_{args.run_suffix}" if args.run_suffix else ""
+    log_filename = f"{target_gpu_model}_{agent.value}_{timestamp}{log_suffix}.log"
     log_path = log_dir / log_filename
 
     # Configure logging

--- a/src/evaluator_utils.py
+++ b/src/evaluator_utils.py
@@ -5,9 +5,29 @@ Utilities for evaluator: command execution and file I/O.
 import subprocess
 import logging
 import yaml
+import shlex
 from pathlib import Path
 from typing import Tuple, Optional, List
 from .testcases import TestCaseResult
+from .runtime_env import PYTHON_ENV_VAR, build_subprocess_env
+
+
+def _replace_leading_token(command: str, token: str, replacement: str) -> str:
+    leading_len = len(command) - len(command.lstrip())
+    leading = command[:leading_len]
+    stripped = command[leading_len:]
+    if stripped == token or stripped.startswith(f"{token} "):
+        return f"{leading}{replacement}{stripped[len(token):]}"
+    return command
+
+
+def normalize_python_command(command: str, python_path: str) -> str:
+    """Route bare Python tooling commands through the selected interpreter."""
+    normalized = command
+    normalized = _replace_leading_token(normalized, "python3", python_path)
+    normalized = _replace_leading_token(normalized, "python", python_path)
+    normalized = _replace_leading_token(normalized, "pytest", f"{python_path} -m pytest")
+    return normalized
 
 
 def run_command(
@@ -31,16 +51,24 @@ def run_command(
     log = logger or logging.getLogger(__name__)
     
     try:
-        log.info(f"Running command: {command}")
+        env = build_subprocess_env()
+        python_path = env.get(PYTHON_ENV_VAR)
+        quoted_python = shlex.quote(python_path) if python_path else None
+        command_to_run = normalize_python_command(command, quoted_python) if quoted_python else command
+
+        log.info(f"Running command: {command_to_run}")
+        if command_to_run != command:
+            log.info(f"Original command: {command}")
         log.info(f"Working directory: {workspace}")
         
         result = subprocess.run(
-            command,
+            command_to_run,
             shell=True,
             cwd=str(workspace),
             capture_output=True,
             text=True,
-            timeout=timeout
+            timeout=timeout,
+            env=env,
         )
         
         if result.returncode == 0:
@@ -60,4 +88,3 @@ def run_command(
     except Exception as e:
         log.error(f"Command execution failed: {e}")
         return False, "", str(e)
-

--- a/src/runtime_env.py
+++ b/src/runtime_env.py
@@ -1,0 +1,50 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""Helpers for keeping subprocesses on the same Python environment."""
+import os
+import sys
+from pathlib import Path
+
+
+PYTHON_ENV_VAR = "AGENT_KERNEL_ARENA_PYTHON"
+
+
+def _absolute_path(path: Path) -> Path:
+    """Return an absolute path without resolving symlinks."""
+    path = path.expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return Path(os.path.abspath(path))
+
+
+def _path_without(path_value: str, remove_dir: Path) -> list[str]:
+    """Return PATH entries without duplicates of remove_dir."""
+    entries: list[str] = []
+    for raw_entry in path_value.split(os.pathsep):
+        if not raw_entry:
+            continue
+        if _absolute_path(Path(raw_entry)) == remove_dir:
+            continue
+        entries.append(raw_entry)
+    return entries
+
+
+def build_subprocess_env(python_path: str | None = None) -> dict[str, str]:
+    """Build an environment where bare python/pytest use this run's interpreter."""
+    env = os.environ.copy()
+    selected_python = _absolute_path(Path(python_path or sys.executable))
+    python_bin = selected_python.parent
+
+    if python_bin.exists():
+        path_entries = _path_without(env.get("PATH", ""), python_bin)
+        env["PATH"] = os.pathsep.join([str(python_bin), *path_entries])
+        env[PYTHON_ENV_VAR] = str(selected_python)
+
+    return env
+
+
+def apply_subprocess_python_path(python_path: str | None = None) -> str:
+    """Apply build_subprocess_env() to the current process and return the Python path."""
+    env = build_subprocess_env(python_path)
+    os.environ.update(env)
+    fallback = str(_absolute_path(Path(python_path or sys.executable)))
+    return env.get(PYTHON_ENV_VAR, fallback)

--- a/tasks/hip2hip/gpumode/GateGRUSelectionLayer/pytorch_code_module/py_5334_GateGRUSelectionLayer.py
+++ b/tasks/hip2hip/gpumode/GateGRUSelectionLayer/pytorch_code_module/py_5334_GateGRUSelectionLayer.py
@@ -23,14 +23,15 @@ def get_inputs():
     """
     Generate multiple test cases with varying sizes
     GateGRUSelectionLayer expects 4D tensors [B0, B1, B2, D]
+    All test cases must use D=4 to match dim_model=4 in get_init_inputs()
     """
     configs = [
-        # 4D tensors: (B0, B1, B2, D)
-        ([4, 4, 4, 4],),
-        ([8, 8, 8, 8],),
-        ([16, 16, 16, 16],),
-        ([32, 32, 32, 32],),
-        ([64, 64, 64, 64],),
+        # 4D tensors: (B0, B1, B2, D) where D must be 4
+        ([4, 4, 4, 4],),  # (4, 4, 4, 4)
+        ([8, 4, 4, 4],),  # (8, 4, 4, 4) - keep D=4
+        ([16, 4, 4, 4],),  # (16, 4, 4, 4) - keep D=4
+        ([32, 4, 4, 4],),  # (32, 4, 4, 4) - keep D=4
+        ([64, 4, 4, 4],),  # (64, 4, 4, 4) - keep D=4
     ]
     
     for shape in configs:

--- a/tasks/hip2hip/gpumode/NormalAttention_embedded_gaussian/pytorch_code_module/py_1003_NormalAttention_embedded_gaussian.py
+++ b/tasks/hip2hip/gpumode/NormalAttention_embedded_gaussian/pytorch_code_module/py_1003_NormalAttention_embedded_gaussian.py
@@ -34,13 +34,14 @@ class NormalAttention_embedded_gaussian(nn.Module):
 def get_inputs():
     """
     Generate multiple test cases for attention kernels
+    All test cases must use C=4 to match input_channel_num=4 in get_init_inputs()
     """
     configs = [
-        ([4, 4, 4, 4],),  # (B, C, H, W)
-        ([8, 8, 8, 8],),
-        ([16, 16, 16, 16],),
-        ([32, 32, 32, 32],),
-        ([64, 64, 64, 64],),
+        ([4, 4, 4, 4],),  # (B=4, C=4, H=4, W=4)
+        ([8, 4, 8, 8],),  # (B=8, C=4, H=8, W=8) - keep C=4
+        ([16, 4, 16, 16],),  # (B=16, C=4, H=16, W=16) - keep C=4
+        ([32, 4, 32, 32],),  # (B=32, C=4, H=32, W=32) - keep C=4
+        ([64, 4, 64, 64],),  # (B=64, C=4, H=64, W=64) - keep C=4
     ]
     
     for shape in configs:


### PR DESCRIPTION
## Add held-out generalization evaluation, run_suffix support, and bug fixes

### Summary

This PR introduces the held-out generalization evaluation framework, adds `--run-suffix` support for better run identification, increases agent timeouts, sets default models, and fixes input shape bugs in two HIP tasks.

### Changes

**Held-out generalization evaluation** (`held_out/`)
- `generate_heldout.py`: LLM-driven generation of structurally diverse held-out input shapes per task (supports `claude_code`, `codex`, and `cursor` backends). Generates 8 held-out shapes per task spanning edge-case/boundary, scaling, asymmetric, dtype, and stress categories.
- `run_heldout_eval.py`: Evaluates a completed agent run against held-out shapes. For each task, restores the original kernel and the agent's optimized kernel, injects held-out shapes, and measures compilation, correctness, and performance on both. Classifies each task into a generalization quadrant (`both_pass`, `opt_regression`, `both_fail`, `opt_improvement`) and computes conditional correctness. Handles all three task types: `hip2hip`, `triton2triton`, and `torch2hip` (where the original is PyTorch, not HIP).
- `injection.py`: Text-based shape injection supporting three strategies: `TEST_SHAPES` block replacement (Triton/vLLM), `get_inputs` function replacement (HIP/Torch), and `raw_replace` exact string match (ROCmBench pytest parametrize).
- `README.md`: Documentation covering scope, quick start, YAML format, and injection mechanics.

**Run suffix support** (`main.py`)
- New `--run-suffix` CLI argument appends a descriptive suffix to the run directory and log file (e.g., `run_20260416_120000_composer2_hip`).
- Updated timestamp extraction in `--resume-run` and `--resume-latest` to use regex, correctly handling suffixed directory names.

**Agent config updates** (`agents/*/agent_config.yaml`)
- Increased `timeout_seconds` from 600 to 3600 for Cursor, Claude Code, and Codex agents (600s was too short for complex tasks).
- Set default models: `claude-opus-4-6` for Claude Code, `gpt-5.3-codex` for Codex, `composer-2` for Cursor.

**HIP task input fixes** (`tasks/hip2hip/gpumode/`)
- `GateGRUSelectionLayer`: Fixed test inputs to keep `D=4` across all shapes (must match `dim_model=4` from `get_init_inputs()`). Previously all dimensions scaled together, causing shape mismatches.
- `NormalAttention_embedded_gaussian`: Fixed test inputs to keep `C=4` across all shapes (must match `input_channel_num=4` from `get_init_inputs()`).
