### PR TITLE
feat(hip2hip): inject generic task contract at framework level

### DIFF
--- a/agents/geak_v3/launch_agent.py
+++ b/agents/geak_v3/launch_agent.py
@@ -160,8 +160,15 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
     # minimal, so the cheatsheet (and the arch-precheck directive) are
     # appended here from the shared prompt_builder helpers, mirroring the
     # section layout used by src/prompt_builder.py::prompt_builder.
+    #
+    # Also inject the hip2hip task contract for hip2hip tasks so the
+    # constraints (preserve names/signatures, launch interface, build
+    # interface, shared-memory sizing) reach GEAK-v3 agents too. The
+    # contract is hosted at the framework level rather than per-task to
+    # keep all hip2hip configs uniform.
     try:
         from src.prompt_builder import _load_cheatsheet, _gpu_arch_precheck_prompt
+        from src.prompts import task_type as _task_type_module
         with open(task_config_dir, "r") as _f:
             _task_config = yaml.safe_load(_f) or {}
         _task_type_name = _task_config.get("task_type", "")
@@ -172,11 +179,19 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
                 _task_type_name, _target_gpu_model, _project_root, _task_config, logger,
             )
             _precheck = _gpu_arch_precheck_prompt(_target_gpu_model, _gfx_arch)
-            _extras = [p for p in [_precheck, _cheatsheet_text] if p]
+            _contract = (
+                _task_type_module.hip2hip_task_contract(
+                    _task_config.get("target_kernel_functions")
+                )
+                if _task_type_name == "hip2hip"
+                else ""
+            )
+            _extras = [p for p in [_precheck, _contract, _cheatsheet_text] if p]
             if _extras:
                 prompt = prompt.rstrip() + "\n\n" + "\n\n---\n\n".join(_extras) + "\n"
                 logger.info(
-                    f"Appended cheatsheet (arch={_gfx_arch}, +{sum(len(p) for p in _extras)} chars)"
+                    f"Appended cheatsheet (arch={_gfx_arch}, +{sum(len(p) for p in _extras)} chars"
+                    f"{', incl. hip2hip contract' if _contract else ''})"
                 )
     except Exception as _e:  # noqa: BLE001 — keep agent launch resilient
         logger.warning(f"Cheatsheet injection skipped: {_e}")

--- a/src/prompt_builder.py
+++ b/src/prompt_builder.py
@@ -220,7 +220,8 @@ def prompt_builder(task_config_dir: str, workspace_directory: Path, eval_config:
     Prompt section order:
         1. Task Type
         2. Source Code
-        3. GPU Arch Pre-check  ← new: fix mismatched arch before first build
+        2b. Task Contract  ← injected for task_type == 'hip2hip' only
+        3. GPU Arch Pre-check
         4. Instructions
         5. Output Format
         6. Cheatsheet  (architecture context + language knowledge, combined)
@@ -273,6 +274,15 @@ def prompt_builder(task_config_dir: str, workspace_directory: Path, eval_config:
             source_code_prompt = ""
 
     prompt_sections.append(source_code_prompt)
+
+    # 2b. Task Contract (hip2hip): generic per-task constraints applied
+    # uniformly to every hip2hip task. Hosted in src/prompts/task_type.py
+    # rather than duplicated in each config so the contract stays in
+    # lockstep across all hip2hip configs.
+    if task_type_name == 'hip2hip':
+        prompt_sections.append(
+            task_type.hip2hip_task_contract(task_config.get('target_kernel_functions'))
+        )
 
     # 3. Cheatsheet: architecture context + language knowledge
     project_root = Path(__file__).resolve().parent.parent

--- a/src/prompts/task_type.py
+++ b/src/prompts/task_type.py
@@ -2,6 +2,72 @@
 def hip2hip_task_type() -> str:
     return '''You are a Kernel Optimization Specialist with expertise in HIP programming. Your core mission is to systematically optimize existing HIP kernels for maximum performance while ensuring strict numerical correctness and functional equivalence to the original code. '''
 
+
+def hip2hip_task_contract(target_kernel_functions) -> str:
+    """Generic, per-task contract bullets for hip2hip tasks.
+
+    Injected by ``src/prompt_builder.py`` for every hip2hip task so the
+    contract is applied uniformly across all hip2hip configs without
+    duplicating it in each ``prompt.instructions`` field. Hosting it at
+    the framework level keeps the contract architecture-neutral and in
+    lockstep across tasks.
+
+    Args:
+        target_kernel_functions: list[str] | str — names from the task's
+            ``target_kernel_functions`` field. Listed by name in the
+            preserved-symbols bullet so the agent knows exactly which
+            functions are part of the task contract.
+    """
+    if isinstance(target_kernel_functions, (list, tuple)):
+        names = list(target_kernel_functions)
+    elif target_kernel_functions:
+        names = [str(target_kernel_functions)]
+    else:
+        names = []
+    if names:
+        names_block = "\n".join(f"    - `{n}`" for n in names)
+        names_intro = "The following kernel function(s) are part of the task contract and **must** be preserved by name and by signature:"
+    else:
+        names_block = ""
+        names_intro = "All kernel functions referenced by the task runner are part of the task contract and **must** be preserved by name and by signature."
+
+    body = f"""
+### Task Contract (Generic)
+
+These constraints apply to every hip2hip task and must be honored regardless
+of optimization strategy. Violating them will cause the task runner to fail
+even when your kernel is otherwise correct and faster.
+
+1. **Preserve kernel function names and signatures.**
+   {names_intro}
+{names_block}
+   Do not rename them, drop parameters, reorder parameters, change parameter
+   types, or change the return type. The task runner looks them up by exact
+   name and calls them with the exact original signature.
+
+2. **Keep the launch / configuration interface compatible.**
+   Grid / block dimensions, stream usage, and any host-side launch helpers
+   (wrapper functions, Python bindings, `extern "C"` shims) must remain
+   call-compatible with the original. Do not change the number or order of
+   launch parameters exposed to the host code that the task runner invokes.
+
+3. **Output must remain directly compilable and runnable with the same
+   interface.** The task's `compile_command`, `correctness_command`, and
+   `performance_command` must succeed against your modified source without
+   any external code changes (no edits to the test runner, no extra build
+   flags). If you add new files, they must be picked up by the existing
+   build invocation.
+
+4. **Handle shared-memory launch sizing correctly if shared memory is
+   introduced.** If your optimization introduces or grows `__shared__` /
+   dynamic LDS allocations, you are responsible for passing the correct
+   per-block shared-memory size at launch (`<<<grid, block, shmem_bytes,
+   stream>>>` or the equivalent `hipLaunchKernelGGL` argument). Static
+   shared memory must fit within the per-block LDS limit of the target
+   architecture.
+"""
+    return body
+
 def torch2hip_task_type() -> str:
     return '''You are a GPU Kernel Development Specialist with deep expertise in both PyTorch and HIP programming. Your core mission is to translate PyTorch operations and models into highly optimized custom HIP kernels for AMD GPUs, while ensuring strict numerical correctness and functional equivalence to the original PyTorch implementation. You understand PyTorch's tensor operations, autograd mechanics, and how to efficiently map high-level operations to low-level GPU primitives using HIP/ROCm.'''
 


### PR DESCRIPTION
## Summary

Follow-up to **#35** (review thread). @irvineoy asked that the four generic task constraints — preserve kernel names/signatures, keep launch/config interface compatible, keep the build/test interface intact, handle shared-memory launch sizing — survive the cleanup of the MI300X-specific prompt that previously lived in `tasks/hip2hip/others/points_in_boxes/config.yaml`. Per the agreed plan, this PR adds them at the **framework level** so every hip2hip task gets the same contract, with no per-task YAML duplication.

## No-touch guarantee

This PR is **strictly additive for `task_type == 'hip2hip'` only**. The following task types are **untouched** by this change — they render the exact same prompt before and after:

- `triton2triton` (incl. `rocmbench/*`, `geak_eval/*`, `repository/rocprim/*`)
- `torch2hip`
- `cuda2hip`
- `instruction2triton`
- `repository`

The injection sites in both `src/prompt_builder.py` and `agents/geak_v3/launch_agent.py` are gated by an `if task_type_name == 'hip2hip':` check; nothing else in either file moves.

Other things this PR does **not** touch:
- No task YAML edits (no `config.yaml` modified).
- No new dependencies.
- No changes to evaluator, scorer, task discovery, runner, or worktree handling.
- No changes to `default_cheatsheet.yaml`, the architecture cheatsheets, or the GPU arch-precheck directive.
- The cheatsheet injection added in #35 is preserved verbatim — the contract is appended alongside it, not in place of it.

## What changes

A new `### Task Contract (Generic)` section is rendered into the agent prompt for every `task_type == 'hip2hip'` task. The contract enumerates:

1. **Preserve kernel function names and signatures** — listed by name from the task's own `target_kernel_functions` field so the agent sees exactly which symbols are part of the contract.
2. **Keep the launch / configuration interface compatible** — grid/block dims, stream usage, host-side launch helpers, Python bindings, `extern "C"` shims.
3. **Output must remain directly compilable and runnable** — the task's existing `compile_command` / `correctness_command` / `performance_command` must succeed against the modified source with no edits to the test runner and no extra build flags.
4. **Handle shared-memory launch sizing correctly** when `__shared__` / dynamic LDS allocations are introduced.

The contract is injected from two places, mirroring the section ordering used by each prompt path:

- `src/prompt_builder.py::prompt_builder` — regular agents. Inserted right after the `### Source Code` section.
- `agents/geak_v3/launch_agent.py` — GEAK-v3 (uses `simple_prompt_builder`, bypasses the regular path). Mirrors the cheatsheet injection added in #35.

## Why framework-level (not per-task `prompt.instructions`)

Across the **36 current hip2hip configs**:
- 24 `gpumode/*` already have a generic role-preamble in `prompt.instructions` (no contract bullets).
- 12 `others/*` have `instructions: null` and `cheatsheet: null`.

Adding the contract per-config would require touching 36 YAMLs and inevitably drift over time. Hosting it in one function keeps the contract in lockstep across tasks, single-source-of-truth, and architecture-neutral by construction.

## Diffstat

\`\`\`text
agents/geak_v3/launch_agent.py | +17 -2
src/prompt_builder.py          | +11 -1
src/prompts/task_type.py       | +66
3 files, +94 / -3
\`\`\`

## Test plan

- [x] All 36 hip2hip configs render with the contract present and the correct kernel name(s) listed.
- [x] Sampled triton2triton configs (5/5) do NOT receive the contract (correctly scoped).
- [x] Regular `src/prompt_builder.py::prompt_builder` path verified.
- [x] GEAK-v3 `agents/geak_v3/launch_agent.py` path verified (logs `incl. hip2hip contract` when fired).
- [ ] End-to-end run on a representative `hip2hip` task confirms the agent receives the contract in `task_prompt.md`.
- [ ] Spot-check that an agent attempting to rename a target kernel function sees the contract section in its initial prompt.
- [ ] Spot-check a triton2triton run pre/post this PR — `task_prompt.md` is byte-identical.