### PR TITLE
add CODEOWNERS, CONTRIBUTING.md, SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Team slugs: https://github.com/orgs/AMD-AGI/teams
+# Syntax:     https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Last matching rule wins. Prefer GitHub Teams over individuals.
+
+# Default — every file requires project-team approval
+# (any of: team OR any listed contributor satisfies the rule)
+*                            @AMD-AGI/brain-tio @irvineoy @sharareh-y @sinarafati-amd @sharonzhou 
+
+# Stricter paths — leads must approve
+.github/CODEOWNERS           @AMD-AGI/brain-tio-leads
+/.github/workflows/          @AMD-AGI/brain-tio-leads
+/src/core/                   @AMD-AGI/brain-tio-leads

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,18 @@
 # Team slugs: https://github.com/orgs/AMD-AGI/teams
 # Syntax:     https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # Last matching rule wins. Prefer GitHub Teams over individuals.
+# NOTE: A dedicated AMD-AGI team slug for this project was not yet
+# available at authoring time. Add @AMD-AGI/<team-slug> below once the
+# team exists and has write access to this repo.
 
-# Default — every file requires project-team approval
-# (any of: team OR any listed contributor satisfies the rule)
-*                            @AMD-AGI/brain-tio @irvineoy @sharareh-y @sinarafati-amd @sharonzhou 
+# Default — every file requires owner approval
+# (any of the listed contributors satisfies the rule)
+*                            @sinarafati-amd @irvineoy @sharareh-y @chushic @sharonzhou @ppalanga @yueliu14
 
 # Stricter paths — leads must approve
-.github/CODEOWNERS           @AMD-AGI/brain-tio-leads
-/.github/workflows/          @AMD-AGI/brain-tio-leads
-/src/core/                   @AMD-AGI/brain-tio-leads
+.github/CODEOWNERS           @sinarafati-amd
+/.github/workflows/          @sinarafati-amd
+/main.py                     @sinarafati-amd
+/src/score.py                @sinarafati-amd
+/src/evaluator.py            @sinarafati-amd
+/src/runtime_env.py          @sinarafati-amd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in AgentKernelArena! This guide explains how to contrib
 
 ```bash
 # Complete environment setup (auto-detects ROCm, creates .venv, installs deps)
-make setup
+make setup-venv
 
 # Activate the venv
 make act

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to AgentKernelArena
+
+Thanks for your interest in AgentKernelArena! This guide explains how to contribute, report issues, and submit changes.
+
+## Before You Start
+
+- Read `README.md` to understand the project scope — a standardized arena for evaluating LLM coding agents on GPU kernel optimization tasks.
+- Skim `config.yaml` to understand how agents, tasks, and LLM parameters are configured.
+- Ensure you have a supported GPU environment (AMD GPU with ROCm 6.4+ / 7.0+ / 7.1+ — the Makefile auto-detects).
+- Confirm you have access to at least one supported agent (Cursor Agent, Claude Code, Codex, SWE-agent, GEAK, or single-LLM-call) and any required API keys.
+
+## Development Setup
+
+```bash
+# Complete environment setup (auto-detects ROCm, creates .venv, installs deps)
+make setup
+
+# Activate the venv
+make act
+
+# Optional: install Cursor Agent CLI
+make install-cursor-agent
+
+# Optional: start a local vLLM server for self-hosted models
+make vllm
+```
+
+## Workflow
+
+1. Create a new branch from `main`.
+2. Keep changes focused and scoped.
+3. Run a smoke test against at least one task before submitting:
+
+```bash
+python main.py        # uses config.yaml
+```
+
+4. Open a Pull Request with motivation, impact, and verification steps.
+
+## Code Style and Quality
+
+- Follow PEP 8 for Python code.
+- Keep agent integrations isolated under `agents/<agent_name>/` — don't leak agent-specific logic into `src/`.
+- Update `config.yaml`, `README.md`, and the agent registry (`agents/__init__.py`) when adding a new agent.
+- Add documentation or comments when intent is non-obvious.
+
+## Testing and Verification
+
+This project depends on GPU hardware/drivers and orchestrates external LLM agent CLIs. In your PR, include:
+
+- Test environment (GPU model, ROCm version, Python 3.12, OS)
+- Agent(s) used and their versions
+- Task category exercised (rocm-examples, rocprim, customer_hip, triton, torch2hip)
+- Key commands and output summary, e.g.:
+
+```bash
+python main.py
+python compare_runs.py --runs <run-id-1> <run-id-2>
+```
+
+- For changes to scoring or evaluation logic, attach before/after results on at least one task category.
+
+## Filing Issues
+
+Please include:
+
+- Reproduction steps (exact `config.yaml` snippet or command flags)
+- Expected vs actual behavior
+- Environment (OS, GPU, ROCm version, Python version, agent CLI version)
+- Relevant logs from the workspace under `works/` or a minimal repro
+
+## Security
+
+If you discover a security issue, do not open a public issue. Contact maintainers through a private channel.
+
+This project executes third-party AI agents in isolated workspaces — flag any sandbox-escape, credential-leakage, or supply-chain concerns privately.
+
+## Suggested Contributions
+
+- Add new agent integrations under `agents/`
+- Extend task coverage (new HIP, Triton, or Torch2HIP tasks under `tasks/`)
+- Improve scoring or fairness logic in `src/score.py`
+- Improve the leaderboard or visualization (`visualization/`)
+- Add support for new models / providers (OpenAI, Anthropic, OpenRouter, vLLM)
+- Improve docs, examples, and tests
+
+## License
+
+By contributing, you agree that your contributions are licensed under the repository `LICENSE` (MIT).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Do not open a public GitHub issue.** Report privately via one of:
 
-- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](../../security/advisories/new)
+- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](https://github.com/AMD-AGI/AgentKernelArena/security/advisories/new)
 - **AMD Product Security portal:** https://www.amd.com/en/resources/product-security.html
 
 Please include: description and impact, steps to reproduce, and affected versions or commits.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue.** Report privately via one of:
+
+- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](../../security/advisories/new)
+- **AMD Product Security portal:** https://www.amd.com/en/resources/product-security.html
+
+Please include: description and impact, steps to reproduce, and affected versions or commits.
+
+We aim to acknowledge reports within 1 business day.
+
+## Scope
+
+This policy covers code and configuration in this repository — the AgentKernelArena orchestration framework (`main.py`, `src/`), agent integrations under `agents/`, task definitions under `tasks/`, and workspace isolation logic.
+
+Because AgentKernelArena launches third-party LLM agent CLIs (Cursor Agent, Claude Code, Codex, SWE-agent, GEAK, etc.) inside per-task workspaces and executes the kernel code those agents produce, please flag any of the following privately:
+
+- Sandbox escape from a per-task workspace
+- Credential leakage through prompts, logs, or generated code
+- Supply-chain risk from dynamically installed agent CLIs or model SDKs
+- Resource-exhaustion or denial-of-service against the host runner
+
+For issues in the upstream agent CLIs themselves (Cursor, Claude Code, Codex, SWE-agent, GEAK) or in model providers (OpenAI, Anthropic, OpenRouter, vLLM), report to those vendors directly.
+
+For AMD product issues unrelated to this repo, use the [AMD Product Security portal](https://www.amd.com/en/resources/product-security.html).


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with team + individual contributor handles.
- Adds `CONTRIBUTING.md` at the repo root — project-tailored contribution guide mirroring the team's standard structure (Before You Start / Setup / Workflow / Code Style / Testing / Filing Issues / Security / Suggested Contributions / License).
- Adds `SECURITY.md` at the repo root — vulnerability-disclosure policy pointing to GitHub Private Vulnerability Reporting and the AMD Product Security portal, with a project-specific Scope section.