### PR TITLE
adding rocm documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 
 # Default — every file requires owner approval
 # (any of the listed contributors satisfies the rule)
-*                            @sinarafati-amd @irvineoy @sharareh-y @chushic @sharonzhou @ppalanga @yueliu14
+*                            @sinarafati-amd @irvineoy @sharareh-y
 
 # Stricter paths — leads must approve
 .github/CODEOWNERS           @sinarafati-amd

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ saved_results
 
 # Generated held-out test data (methodology is in held_out/, data is private)
 held_out_tests/
+
+# Documentation build environment and output
+.docvenv/
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration for AgentKernelArena documentation.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/sphinx/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py
+
+# Only build HTML (+ htmlzip). PDF/epub are intentionally disabled: the docs
+# contain Mermaid diagrams, which require a headless browser to render in the
+# LaTeX/PDF pipeline and are not needed for the hosted HTML site.
+formats:
+  - htmlzip

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+_build/
+_doxygen/
+_toc.yml
+sphinx/_toc.yml

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# AgentKernelArena documentation
+
+This directory contains the source for the AgentKernelArena documentation site.
+It follows the same structure as other ROCm toolkit component docs and is built
+with [Sphinx](https://www.sphinx-doc.org/) and
+[rocm-docs-core](https://github.com/ROCm/rocm-docs-core). Both Markdown (MyST,
+`.md`) and reStructuredText (`.rst`) sources are supported and can be mixed.
+
+## Building locally
+
+```bash
+# From the repository root
+python3 -m venv .docvenv
+source .docvenv/bin/activate
+pip install -r docs/sphinx/requirements.txt
+
+python -m sphinx -T -b html docs docs/_build/html
+# Open docs/_build/html/index.html
+```
+
+## Layout
+
+| Path | Page | Notes |
+| --- | --- | --- |
+| `index.rst` | Overview | Landing page; feature summary, use cases, links to all subpages and the GitHub repo. |
+| `install/install.md` | Installation | `make setup` (ROCm auto-detect), manual venv, agent CLIs, and API keys. |
+| `reference/release-notes.md` | Release Notes | Per-release feature breakdown; initial release lists all features. |
+| `reference/compatibility-matrix.md` | Compatibility Matrix | Verified hardware/software versions. Contains `TODO (verify)` markers. |
+| `reference/api-reference.md` | Configuration and API reference | `config.yaml` schema, task `config.yaml` schema, CLI flags, scoring, and the agent registry. |
+| `how-to/run-evaluation.md` | How-to | Configure `config.yaml`, run `main.py`, resume runs, and read results. |
+| `how-to/agents.md` | How-to | Supported agents, model providers, and A/B testing. |
+| `how-to/add-task.md` | How-to | Task directory layout, `config.yaml` fields, and task types. |
+| `how-to/task-validator.md` | How-to | The task_validator agent and its 10 checks. |
+| `how-to/visualization.md` | How-to | Build dashboard data and serve the comparison dashboard. |
+| `examples/examples.md` | Examples | Step-by-step walkthroughs with expected output. |
+| `about/license.md` | License | Full Apache 2.0 license reference (mirrors the repo `LICENSE`). |
+
+Navigation (the left sidebar) is defined in `sphinx/_toc.yml.in`.
+
+## Configuration files
+
+| File | Purpose |
+| --- | --- |
+| `../.readthedocs.yaml` | Read the Docs build configuration. |
+| `conf.py` | Sphinx configuration (rocm-docs-core, MyST, mermaid). |
+| `sphinx/_toc.yml.in` | Table of contents / sidebar navigation. |
+| `sphinx/requirements.in` | Top-level documentation dependencies. |
+| `sphinx/requirements.txt` | Pinned documentation dependencies used by the build. |
+
+## Notes on the local build
+
+A local build outside AMD infrastructure prints benign warnings for intersphinx
+inventory fetches and a `Current project 'AgentKernelArena' not found in
+projects` message until the project is registered in the rocm-docs-core project
+registry. The build itself succeeds.

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,0 +1,26 @@
+# License
+
+AgentKernelArena is released under the Apache License, Version 2.0. The full
+license text is in the
+[`LICENSE`](https://github.com/AMD-AGI/AgentKernelArena/blob/main/LICENSE) file
+in the AgentKernelArena GitHub repository.
+
+```text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+Copyright 2026 Advanced Micro Devices, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,45 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# AgentKernelArena documentation is built with rocm-docs-core, which configures
+# the theme, navigation, MyST Markdown support, and shared ROCm options. Both
+# Markdown (.md, via MyST) and reStructuredText (.rst) source files build out of
+# the box.
+#
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/
+
+# -- Project information ------------------------------------------------------
+
+project = "AgentKernelArena"
+author = "Advanced Micro Devices, Inc."
+copyright = "2026, Advanced Micro Devices, Inc."
+
+# Single-sourced version. Update alongside the package version.
+version = "0.1.0"
+release = version
+
+# -- General configuration ----------------------------------------------------
+
+extensions = ["rocm_docs", "sphinxcontrib.mermaid"]
+
+# Render fenced ```mermaid code blocks in Markdown as diagrams.
+myst_fence_as_directive = ["mermaid"]
+
+external_toc_path = "./sphinx/_toc.yml"
+
+# Don't load intersphinx inventories for other ROCm projects. AgentKernelArena
+# is not yet registered in the rocm-docs-core project registry, so the default
+# ("all") tries to fetch internal inventories that are not publicly reachable
+# and aborts the build under Sphinx 9.x. These docs do not cross-reference other
+# ROCm projects. Once the project is onboarded, this can be set back to "all" or
+# to an explicit list of related projects.
+external_projects = []
+
+# docs/README.md documents the build process for contributors and is not a
+# published page; keep it out of the source build so it is not treated as an
+# orphan document.
+exclude_patterns = ["README.md"]
+
+# rocm-docs-core options.
+html_theme = "rocm_docs_theme"
+html_theme_options = {"flavor": "rocm-docs-home"}

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -1,0 +1,133 @@
+# Examples
+
+These walkthroughs assume you have completed [installation](../install/install.md)
+and activated the virtual environment (`make act`).
+
+## Example 1: Evaluate one agent on one task
+
+Run a single HIP task with the Cursor agent.
+
+1. Edit `config.yaml`:
+
+```yaml
+agent:
+  template: cursor
+
+tasks:
+  - hip2hip/gpumode/GELU
+
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+2. Run:
+
+```bash
+python main.py
+```
+
+3. Inspect the result:
+
+```text
+workspace_MI300_cursor/
+└── run_<timestamp>/
+    └── hip2hip_gpumode_GELU_<timestamp>/
+        └── task_result.yaml
+```
+
+A successful `task_result.yaml` looks like:
+
+```yaml
+task_name: hip2hip/gpumode/GELU
+pass_compilation: true
+pass_correctness: true
+base_execution_time: 1.82
+best_optimized_execution_time: 1.15
+speedup_ratio: 1.58
+score: 278.0
+```
+
+## Example 2: Run a whole task category
+
+Evaluate Claude Code across all vLLM Triton tasks.
+
+```yaml
+agent:
+  template: claude_code
+
+tasks:
+  - triton2triton/vllm
+
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+```bash
+python main.py
+```
+
+Each task gets its own workspace under the same `run_<timestamp>/` directory, and
+post-processing aggregates them into a run report.
+
+## Example 3: A/B test an agent capability
+
+Measure whether a new MCP server, skill, or prompt change helps. Run the same
+task set twice with distinct run suffixes.
+
+```bash
+# Baseline (capability disabled in the agent configuration)
+python main.py --run-suffix baseline
+
+# Treatment (capability enabled)
+python main.py --run-suffix with_capability
+```
+
+Both runs land in `workspace_MI300_<agent>/` with distinct run names. Build the
+dashboard and compare them side-by-side:
+
+```bash
+cd visualization
+python backend/scripts/build_dashboard_data.py --include-workspace-runs
+python backend/server.py --host 127.0.0.1 --port 8080
+```
+
+Open <http://127.0.0.1:8080> to compare scores. See
+[Visualize and compare runs](../how-to/visualization.md) for details.
+
+## Example 4: Validate a new task
+
+Before merging a new task, run the task_validator agent against it.
+
+```yaml
+agent:
+  template: task_validator
+
+tasks:
+  - hip2hip/others/my_new_kernel
+
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+```bash
+python3 main.py
+```
+
+Open the generated `validation_report.yaml` in the task workspace. The task must
+reach **PASS** (or **WARN** with justification) before merging. See
+[Validate tasks](../how-to/task-validator.md).
+
+## Example 5: Resume an interrupted run
+
+If a long run is interrupted, resume it without repeating completed tasks:
+
+```bash
+# Resume the most recent run
+python main.py --resume-latest
+
+# Or resume a specific run directory
+python main.py --resume-run run_20260617_101500
+```

--- a/docs/how-to/add-task.md
+++ b/docs/how-to/add-task.md
@@ -1,0 +1,103 @@
+# Add a task
+
+A task is a single GPU kernel optimization problem. Each task lives in its own
+directory under `tasks/<task_type>/<task_name>/` and is described by a
+`config.yaml`. This page covers the directory layout, the configuration schema,
+and the supported task types.
+
+## Task types
+
+The `task_type` field declares what kind of optimization the task represents:
+
+| `task_type` | Meaning |
+| --- | --- |
+| `hip2hip` | Optimize an existing HIP kernel |
+| `cuda2hip` | Port and optimize a CUDA kernel to HIP |
+| `triton2triton` | Optimize an existing Triton kernel |
+| `instruction2triton` | Write a Triton kernel from an instruction/spec |
+| `torch2hip` | Replace a PyTorch reference with a HIP kernel |
+| `flydsl2flydsl` | Optimize a FlyDSL kernel (requires FlyDSL) |
+| `repository` | Repository-level task |
+
+The repository ships task suites including `hip2hip` (gpumode and others),
+`triton2triton` (vLLM and ROCmBench), `torch2hip`, `instruction2triton`, and
+`flydsl2flydsl`.
+
+## Directory layout
+
+```text
+tasks/<task_type>/<task_name>/
+├── config.yaml                  # Task configuration (required)
+├── scripts/
+│   └── task_runner.py           # Compile/correctness/performance runner (recommended)
+└── source/                      # or src/
+    └── <kernel files>           # .cu, .hip, .py, etc.
+```
+
+Makefile-based or test-file-based layouts are also acceptable, as long as every
+path referenced in `config.yaml` resolves inside the task directory.
+
+## Required `config.yaml` fields
+
+All command fields are **lists**, even when there is a single command.
+
+```yaml
+# Source files containing the kernel code (relative to the task root)
+source_file_path:
+  - source/my_kernel.hip
+
+# Kernel function names that must be defined in the source files
+target_kernel_functions:
+  - my_kernel_function
+
+# Command(s) to compile or build-check the task
+compile_command:
+  - python3 scripts/task_runner.py --mode compile
+
+# Command(s) to run correctness validation
+correctness_command:
+  - python3 scripts/task_runner.py --mode correctness
+
+# One of: hip2hip, cuda2hip, triton2triton, instruction2triton,
+#         torch2hip, flydsl2flydsl, repository
+task_type: hip2hip
+```
+
+## Optional `config.yaml` fields
+
+```yaml
+# Command(s) to measure performance
+performance_command:
+  - python3 scripts/task_runner.py --mode performance
+
+# Override which result template to use (null = default)
+task_result_template: null
+
+# Prompt overrides for the optimization agent (null = auto-generated)
+prompt:
+  source_code: null      # override the default source-code section
+  instructions: null     # custom instructions
+  cheatsheet: null        # reference/cheatsheet content
+```
+
+## Authoring rules
+
+To produce trustworthy, comparable scores, every task must be **self-contained**
+and must validate correctness meaningfully.
+
+- **Self-contained**: no references to external repositories or absolute paths,
+  no missing headers or Python imports, and no external data downloads. Generate
+  test inputs inline or bundle small files in the task directory.
+- **Real correctness check**: compare against a CPU/NumPy reference, known-good
+  output, or a PyTorch eager baseline; use sensible tolerances; test 2–3 shapes;
+  and exit non-zero on failure.
+- **Real compilation check**: actually compile or syntax-check the source, not a
+  text-pattern search; exit code `0` means success.
+- **Performance methodology**: a recommended pattern is 10 warmup iterations plus
+  100 measured iterations, reporting the average runtime.
+
+## Validate before merging
+
+Every new task must pass the **task_validator** agent before it is merged. It
+runs 10 automated checks and emits a `validation_report.yaml`. See
+[Validate tasks](task-validator.md) for the full check list and how to run it.

--- a/docs/how-to/add-task.md
+++ b/docs/how-to/add-task.md
@@ -39,7 +39,9 @@ path referenced in `config.yaml` resolves inside the task directory.
 
 ## Required `config.yaml` fields
 
-All command fields are **lists**, even when there is a single command.
+Most tasks optimize files that are copied into the task workspace. For those
+isolated-kernel tasks, all command fields are **lists**, even when there is a
+single command.
 
 ```yaml
 # Source files containing the kernel code (relative to the task root)
@@ -61,6 +63,24 @@ correctness_command:
 # One of: hip2hip, cuda2hip, triton2triton, instruction2triton,
 #         torch2hip, flydsl2flydsl, repository
 task_type: hip2hip
+```
+
+Repository-level tasks (`task_type: repository`) use a different shape because
+they clone and optimize an upstream project rather than a small source bundle.
+They require `repo_url`, `repository_language`, `compile_command`, and
+`correctness_command`; `source_file_path` and `target_kernel_functions` are
+optional hints when the target files and symbols are known.
+
+```yaml
+repo_url: https://github.com/ROCm/rocPRIM.git
+task_type: repository
+repository_language: hip
+
+compile_command:
+  - python3 scripts/task_runner.py compile
+
+correctness_command:
+  - python3 scripts/task_runner.py correctness
 ```
 
 ## Optional `config.yaml` fields

--- a/docs/how-to/agents.md
+++ b/docs/how-to/agents.md
@@ -1,0 +1,85 @@
+# Configure agents and models
+
+AgentKernelArena evaluates one agent per run. The agent is selected by the
+`agent.template` field in `config.yaml`. This page lists the supported agents,
+explains how models and providers are configured, and describes how to use the
+arena for A/B testing.
+
+## Supported agents
+
+| `agent.template` | Description |
+| --- | --- |
+| `cursor` | Cursor Agent CLI |
+| `claude_code` | Anthropic Claude Code CLI |
+| `codex` | OpenAI Codex CLI |
+| `swe_agent` | SWE-agent |
+| `openevolve` | OpenEvolve (GEAK) evolutionary search |
+| `geak_optimagentv2` | GEAK OptimAgent v2 |
+| `geak_hip` | GEAK HIP agent |
+| `geak_ourllm_kernel2kernel` | GEAK OurLLM kernel-to-kernel agent |
+| `single_llm_call` | A single LLM call (no agent loop) |
+| `task_validator` | Task quality validator (see [Validate tasks](task-validator.md)) |
+
+Select one in `config.yaml`:
+
+```yaml
+agent:
+  template: claude_code
+```
+
+Each agent lives under `agents/<agent_name>/` and is registered into a shared
+registry, so the framework loads only the agent you select.
+
+## Models and providers
+
+The model an agent uses is configured by that agent's own integration (its CLI
+configuration or an `agent_config.yaml` under `agents/<agent_name>/`).
+Supported providers include:
+
+- **OpenAI** (for example, GPT-5)
+- **Anthropic Claude** (for example, Opus and Sonnet families)
+- **OpenRouter** — access to a broad set of hosted models
+- **Local vLLM** — a self-hosted model served on port `30001` (`make vllm`)
+
+Export the matching API keys before running:
+
+```bash
+export OPENAI_API_KEY="..."
+export ANTHROPIC_API_KEY="..."
+export OPENROUTER_API_KEY="..."
+```
+
+## A/B testing and ablation studies
+
+Beyond ranking different agents and models, AgentKernelArena works as a
+controlled A/B testing harness for agent-side capabilities — a new MCP server,
+skill, prompt strategy, or tool integration.
+
+Run the **same task set twice**, once with the capability enabled and once
+without, then compare the standardized scores:
+
+```bash
+# Baseline
+python main.py --run-suffix baseline
+
+# With the new capability enabled in the agent configuration
+python main.py --run-suffix with_capability
+```
+
+Both runs land in the same workspace directory with distinct run names, so the
+[visualization dashboard](visualization.md) can show them side-by-side. Because
+the tasks, environment, prompts, and scoring are held constant, score deltas
+reflect the impact of the capability under test.
+
+## Add a new agent
+
+To integrate a custom agent:
+
+1. Create `agents/<your_agent>/` with a launch function decorated with
+   `@register_agent("<your_agent>")`.
+2. Add an entry to the `AgentType` enum and an import branch in
+   `src/module_registration.py`.
+3. Wire the agent into the prompt builder and post-processing handler in
+   `src/module_registration.py` if it needs the standard behavior.
+
+See the development section of the repository `README.md` for the full template.

--- a/docs/how-to/run-evaluation.md
+++ b/docs/how-to/run-evaluation.md
@@ -1,0 +1,126 @@
+# Run an evaluation
+
+An evaluation runs one agent against a set of tasks and produces scored results.
+This page walks through configuring the run, executing it, resuming an
+interrupted run, and reading the output.
+
+## 1. Configure `config.yaml`
+
+The root `config.yaml` selects the agent, the tasks, and the target GPU.
+
+```yaml
+agent:
+  template: cursor          # one agent template per run
+
+tasks:
+  - hip2hip/gpumode/GELU
+  - triton2triton/vllm/triton_rms_norm
+  # - hip2hip                 # all tasks under a category
+  # - all                     # every available task
+
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+### Selecting tasks
+
+Each entry in `tasks` is a path relative to the `tasks/` directory. You can
+select tasks at any level of granularity:
+
+| Entry | Selects |
+| --- | --- |
+| `all` | Every task in `tasks/` |
+| `hip2hip` | All tasks under `tasks/hip2hip/` |
+| `triton2triton/vllm` | All tasks under that subdirectory |
+| `hip2hip/gpumode/GELU` | A single task |
+
+See [Configuration and API reference](../reference/api-reference.md) for the full
+set of `config.yaml` fields.
+
+## 2. Run
+
+```bash
+python main.py
+```
+
+Use a non-default config file to keep multiple task sets side-by-side:
+
+```bash
+python main.py --config_name config_triton.yaml
+```
+
+Add a suffix to label a run directory (useful for A/B testing):
+
+```bash
+python main.py --run-suffix cursor_with_mcp
+# → workspace_MI300_cursor/run_20260617_101500_cursor_with_mcp
+```
+
+## 3. What happens during a run
+
+```mermaid
+flowchart TD
+    A[Load config.yaml] --> B[Register agent launcher]
+    B --> C[Discover tasks]
+    C --> D[Create timestamped workspace per task]
+    D --> E[Measure baseline performance]
+    E --> F[Launch agent in workspace]
+    F --> G[Evaluate: compile, correctness, performance]
+    G --> H[Write task_result.yaml + score]
+    H --> I[Post-processing: aggregate report]
+```
+
+For each task, the framework:
+
+1. Copies the task into an isolated, timestamped workspace.
+2. Measures a **baseline** (compiles and times the original kernel; for
+   `torch2hip` tasks it times the PyTorch reference directly).
+3. Launches the configured agent with a generated prompt.
+4. Evaluates the agent's kernel for compilation, correctness, and performance.
+5. Writes a standardized `task_result.yaml` and computes a score.
+
+After all tasks finish, a post-processing step aggregates the per-task results
+into a run report.
+
+## 4. Resume an interrupted run
+
+Long runs can be resumed; completed tasks are skipped.
+
+```bash
+# Resume a specific run directory
+python main.py --resume-run run_20260617_101500
+
+# Resume the most recent run
+python main.py --resume-latest
+```
+
+## 5. Read the results
+
+A run produces this layout under the workspace directory:
+
+```text
+workspace_<gpu>_<agent>/
+└── run_<timestamp>/
+    └── <task_name>_<timestamp>/
+        ├── task_result.yaml      # per-task result + score
+        └── ...                   # agent output, modified kernel, logs
+```
+
+Each `task_result.yaml` contains the scored outcome:
+
+```yaml
+task_name: hip2hip/gpumode/GELU
+pass_compilation: true
+pass_correctness: true
+base_execution_time: 1.82        # ms
+best_optimized_execution_time: 1.15
+speedup_ratio: 1.58
+optimization_summary: "..."
+score: 278.0
+```
+
+The `score` combines compilation, correctness, and speedup. See
+[Configuration and API reference](../reference/api-reference.md#scoring) for the
+scoring formula, and [Visualize and compare runs](visualization.md) to render and
+compare reports across agents.

--- a/docs/how-to/task-validator.md
+++ b/docs/how-to/task-validator.md
@@ -1,0 +1,90 @@
+# Validate tasks
+
+The **task_validator** agent checks that tasks are correctly configured,
+self-contained, and functional. It does not optimize kernels — it audits them.
+Use it to validate new tasks before merging and to audit existing tasks before
+publishing results to a leaderboard.
+
+## Run the validator
+
+Set the validator as the agent in `config.yaml` and list the tasks to check:
+
+```yaml
+agent:
+  template: task_validator
+tasks:
+  - hip2hip/gpumode/GELU
+  - triton2triton/vllm/triton_rms_norm
+  # - all                     # validate every task
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+Then run:
+
+```bash
+python3 main.py
+```
+
+Each task workspace receives a `validation_report.yaml` with per-check results,
+and a `validation_summary.yaml` with aggregated statistics is written to the
+workspace root.
+
+## Validator configuration
+
+The validator's own backend and limits are set in
+`agents/task_validator/agent_config.yaml`:
+
+```yaml
+backend: claude_code          # claude_code | codex | cursor
+timeout_seconds: 600          # max time per task validation (0 disables the timeout)
+python_path: /root/AgentKernelArena/.venv/bin/python3
+```
+
+## The 10 checks
+
+| # | Check | What it verifies |
+| --- | --- | --- |
+| 1 | `config_schema` | All required fields exist with correct types |
+| 2 | `source_files_exist` | Every file in `source_file_path` exists |
+| 3 | `target_symbols_found` | Every `target_kernel_functions` symbol is defined in source |
+| 4 | `compilation` | `compile_command` succeeds (exit 0, within 120s) |
+| 5 | `correctness` | `correctness_command` succeeds (exit 0, within 180s) |
+| 6 | `performance` | `performance_command` succeeds, if present (within 180s) |
+| 7 | `correctness_implementation_review` | The correctness check is meaningful, not trivially passing |
+| 8 | `self_contained` | No missing headers/imports or references to external repos/paths |
+| 9 | `gpu_hang_check` | No command hangs or times out |
+| 10 | `result_template_compatibility` | Output maps to the standard `task_result_template.yaml` |
+
+## Overall status
+
+- **PASS** — all checks passed.
+- **WARN** — no failures, but at least one warning (for example, a questionable
+  correctness implementation). Acceptable with justification.
+- **FAIL** — at least one check failed; the task must be fixed before merging.
+
+## Result template
+
+A validated task's compile → correctness → performance flow must produce results
+that populate the standard template:
+
+```yaml
+task_name: "<task_type>/<task_name>"
+best_optimized_source_file_path:
+  - <source files>
+best_optimized_kernel_functions:
+  - <kernel functions>
+pass_compilation: true/false
+compilation_error_message: null
+pass_correctness: true/false
+correctness_error_message: null
+base_execution_time: 0.0          # ms
+best_optimized_execution_time: 0.0
+speedup_ratio: 0.0
+optimization_summary: ""
+```
+
+For the full author checklist and self-containedness rules, see
+`agents/task_validator/README.md` in the repository and
+[Add a task](add-task.md).

--- a/docs/how-to/visualization.md
+++ b/docs/how-to/visualization.md
@@ -1,0 +1,81 @@
+# Visualize and compare runs
+
+AgentKernelArena ships a static dashboard under `visualization/` for comparing
+run reports across agents and models. This page covers building the dashboard
+data and serving it.
+
+## What the dashboard reads
+
+The dashboard scans for report directories that contain:
+
+- `overall_summary.csv`
+- `task_type_breakdown.json`
+- `overall_report.txt`
+
+By default it scans only visualization-specific report bundles:
+
+```text
+visualization/reports/<report_name>/
+```
+
+Workspace-run reports, which are usually located at
+`workspace_<gpu>_<agent>/run_<timestamp>/reports/`, can also be scanned, but this
+is opt-in.
+
+## Build the dashboard data and serve it
+
+From the `visualization/` directory:
+
+```bash
+python backend/scripts/build_dashboard_data.py
+python backend/server.py --host 127.0.0.1 --port 8080
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8080
+```
+
+### Serve on port 80
+
+Port `80` usually requires elevated privileges:
+
+```bash
+sudo python backend/server.py --host 0.0.0.0 --port 80
+```
+
+Or use the helper script, which rebuilds the data first and then serves on port
+`80`:
+
+```bash
+bash setup.sh
+```
+
+## Rebuild after new runs
+
+Whenever a run produces new reports, rebuild the dashboard payload:
+
+```bash
+python backend/scripts/build_dashboard_data.py
+```
+
+To also include workspace runs (not just `visualization/reports/`):
+
+```bash
+python backend/scripts/build_dashboard_data.py --include-workspace-runs
+# or
+bash setup.sh --include-workspace-runs
+```
+
+The dashboard picks up newly discovered report directories on the next refresh.
+
+## Notes
+
+- The HTTP service serves the UI from `visualization/frontend/`.
+- Source-file links are exposed through an `/artifacts/...` route that only
+  allows `.csv`, `.json`, and `.txt` files.
+- If no reports are found yet, the dashboard still builds and shows an empty
+  state.
+- `frontend/dashboard/data.js` and `frontend/dashboard/data.json` are generated
+  files; do not edit them by hand.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,97 @@
+.. meta::
+   :description: AgentKernelArena is a standardized arena for evaluating AI coding agents on real GPU kernel optimization tasks on AMD GPUs.
+   :keywords: AgentKernelArena, ROCm, GPU, kernel, optimization, agent, LLM, HIP, Triton, benchmark, AMD
+
+******************************
+AgentKernelArena documentation
+******************************
+
+AgentKernelArena is a standardized evaluation arena, built by AMD, that measures
+how well AI coding agents perform on real GPU kernel optimization tasks. It runs
+LLM-powered agents side-by-side on the same tasks in isolated workspaces and
+scores them with objective, reproducible metrics for compilation, correctness,
+and GPU performance.
+
+The AgentKernelArena source code is hosted in the
+`AMD-AGI/AgentKernelArena <https://github.com/AMD-AGI/AgentKernelArena>`_ GitHub
+repository.
+
+What AgentKernelArena does
+==========================
+
+AgentKernelArena gives each agent the same kernel task, runs it in a siloed,
+timestamped workspace, then evaluates the result through a common pipeline:
+
+* **Compile** -- Build the agent's kernel and confirm it compiles cleanly.
+* **Validate** -- Run the task's correctness check against a reference.
+* **Profile** -- Measure GPU execution time and compute speedup over a baseline.
+* **Score** -- Combine the results into a single comparable score.
+
+Key features
+============
+
+* **Multi-agent arena**: Cursor, Claude Code, Codex, SWE-agent, OpenEvolve
+  (GEAK), GEAK HIP, single-LLM-call, and custom agents.
+* **Multi-model support**: OpenAI, Anthropic, and other models via OpenRouter or
+  a local vLLM server.
+* **Task categories**: HIP (``hip2hip``), CUDA-to-HIP (``cuda2hip``), Triton
+  (``triton2triton``, ``instruction2triton``), Torch-to-HIP (``torch2hip``), and
+  FlyDSL (``flydsl2flydsl``).
+* **Objective metrics**: automated compilation, correctness, and real GPU
+  performance speedups.
+* **Workspace isolation**: each task runs in its own timestamped workspace for
+  reproducibility.
+* **A/B testing**: run the same task set with and without a new MCP server,
+  skill, prompt, or tool to measure its real impact.
+* **Task validator**: an agent that runs 10 automated checks on task quality
+  before tasks enter the leaderboard.
+* **Visualization dashboard**: a static dashboard for comparing run reports.
+
+Use cases
+=========
+
+* Compare AI coding agents head-to-head on GPU kernel optimization.
+* Rank models and agent configurations on a standardized leaderboard.
+* A/B test whether a new agent capability (MCP server, skill, prompt) improves
+  outcomes under identical conditions.
+* Curate and validate a high-quality, self-contained GPU kernel task suite.
+
+Documentation
+=============
+
+The AgentKernelArena documentation is organized into the following categories.
+
+.. grid:: 2
+   :gutter: 3
+
+   .. grid-item-card:: Install
+
+      * :doc:`Install AgentKernelArena <install/install>`
+
+   .. grid-item-card:: Reference
+
+      * :doc:`Release notes <reference/release-notes>`
+      * :doc:`Compatibility matrix <reference/compatibility-matrix>`
+      * :doc:`Configuration and API reference <reference/api-reference>`
+
+   .. grid-item-card:: How to
+
+      * :doc:`Run an evaluation <how-to/run-evaluation>`
+      * :doc:`Configure agents and models <how-to/agents>`
+      * :doc:`Add a task <how-to/add-task>`
+      * :doc:`Validate tasks <how-to/task-validator>`
+      * :doc:`Visualize and compare runs <how-to/visualization>`
+
+   .. grid-item-card:: Examples
+
+      * :doc:`Examples <examples/examples>`
+
+   .. grid-item-card:: About
+
+      * :doc:`License <about/license>`
+
+To contribute to the documentation, see the
+`AgentKernelArena GitHub repository <https://github.com/AMD-AGI/AgentKernelArena>`_.
+
+AgentKernelArena is released under the Apache 2.0 license. For details, see the
+:doc:`License <about/license>` page.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,0 +1,121 @@
+# Install AgentKernelArena
+
+AgentKernelArena runs AI coding agents against GPU kernel tasks on an AMD GPU and
+evaluates the results. Installation sets up a Python environment with the correct
+ROCm PyTorch build, installs the framework dependencies, and makes at least one
+agent CLI available.
+
+## Prerequisites
+
+- **Python 3.12+**
+- **AMD GPU with ROCm** — ROCm 6.4, 7.0, or 7.1 (the `Makefile` auto-detects the
+  installed version under `/opt/rocm-*`)
+- **ROCm toolchain for HIP tasks** — `hipcc` and `rocprof-compute`
+- **Triton** — required for Triton tasks (installed with the ROCm PyTorch wheel)
+- **[uv](https://github.com/astral-sh/uv)** — used by the `Makefile` to create the
+  virtual environment
+- **Git**
+- At least one supported agent CLI and the matching API key (see
+  [Configure agents and models](../how-to/agents.md))
+
+## Recommended: `make setup`
+
+From the repository root, the `Makefile` detects your ROCm version, creates a
+`.venv` virtual environment with the matching ROCm PyTorch build, and installs
+all dependencies.
+
+```bash
+git clone https://github.com/AMD-AGI/AgentKernelArena.git
+cd AgentKernelArena
+
+# Full environment setup (venv + deps; includes FlyDSL by default)
+make setup
+
+# Or set up without FlyDSL support
+make setup WITH_FLYDSL=0
+```
+
+Activate the environment:
+
+```bash
+make act
+# or
+source .venv/bin/activate
+```
+
+`make setup` will fail with `Could not detect ROCm installation` if no
+`/opt/rocm-*` directory is found. Install ROCm first, then re-run.
+
+### FlyDSL tasks
+
+The `flydsl2flydsl` task category requires [FlyDSL](https://github.com/ROCm/FlyDSL).
+It is installed by default with `make setup`. To install or verify it on its own:
+
+```bash
+make setup-flydsl     # install FlyDSL into the venv and verify
+make verify-flydsl    # verify FlyDSL import and ROCm PyTorch GPU access
+```
+
+## Manual installation
+
+If you prefer not to use the `Makefile`:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+
+# Install the ROCm PyTorch build that matches your ROCm version, for example:
+pip install torch torchvision torchaudio \
+  --index-url https://download.pytorch.org/whl/rocm6.4
+
+pip install -r requirements.txt
+```
+
+## Install agent CLIs
+
+Install whichever agents you plan to evaluate. For example:
+
+```bash
+# Cursor Agent CLI
+make install-cursor-agent
+
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Codex CLI: follow the official Codex CLI instructions, then ensure
+# `codex` is available on PATH.
+```
+
+## Configure API keys
+
+Export the keys for the providers you will use:
+
+```bash
+export OPENAI_API_KEY="your_openai_key"
+export ANTHROPIC_API_KEY="your_anthropic_key"
+export OPENROUTER_API_KEY="your_openrouter_key"
+```
+
+To run against a self-hosted model instead of a hosted provider, start a local
+vLLM server:
+
+```bash
+make vllm
+```
+
+This launches a `rocm/vllm` container serving a model on port `30001`. Set
+`local_llm_enabled: true` in the relevant agent configuration to use it.
+
+## Verify the installation
+
+Run a single quick task to confirm the framework, GPU, and agent CLI all work
+together. Edit `config.yaml` to select one agent and one task, then run:
+
+```bash
+python main.py
+```
+
+A successful run creates a timestamped workspace directory
+(`workspace_<gpu>_<agent>/run_<timestamp>/`), logs to `logs/`, and writes a
+`task_result.yaml` per task. See [Run an evaluation](../how-to/run-evaluation.md)
+for the full workflow.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -51,16 +51,36 @@ python main.py --config_name config_triton.yaml --run-suffix with_mcp
 Each task is defined by a `config.yaml` in its directory. Command fields are
 **lists**.
 
+For isolated-kernel tasks (`hip2hip`, `cuda2hip`, `triton2triton`,
+`instruction2triton`, `torch2hip`, and `flydsl2flydsl`):
+
 | Field | Required | Description |
 | --- | --- | --- |
 | `source_file_path` | yes | Source files containing the kernel, relative to the task root. |
 | `target_kernel_functions` | yes | Kernel function names that must be defined in the source. |
 | `compile_command` | yes | Command(s) to compile or build-check. |
 | `correctness_command` | yes | Command(s) to validate correctness. |
-| `task_type` | yes | One of `hip2hip`, `cuda2hip`, `triton2triton`, `instruction2triton`, `torch2hip`, `flydsl2flydsl`, `repository`. |
+| `task_type` | yes | One of `hip2hip`, `cuda2hip`, `triton2triton`, `instruction2triton`, `torch2hip`, or `flydsl2flydsl`. |
 | `performance_command` | no | Command(s) to measure performance. |
 | `task_result_template` | no | Override the result template (`null` = default). |
 | `prompt.source_code` | no | Override the prompt's source-code section. |
+| `prompt.instructions` | no | Custom prompt instructions. |
+| `prompt.cheatsheet` | no | Reference/cheatsheet content for the prompt. |
+
+For repository-level tasks (`task_type: repository`):
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `repo_url` | yes | Upstream repository to clone for the task. |
+| `task_type` | yes | Must be `repository`. |
+| `repository_language` | yes | Primary optimization stack, for example `hip` or `triton`. |
+| `compile_command` | yes | Command(s) to compile or build-check. |
+| `correctness_command` | yes | Command(s) to validate correctness. |
+| `performance_command` | no | Command(s) to measure performance. |
+| `post_clone_install` | no | Setup command(s) to run after cloning the upstream repository. |
+| `post_clone_install_mode` | no | Controls when `post_clone_install` runs, for example `every_setup`. |
+| `source_file_path` | no | Optional target source-file hints, relative to the cloned repository root. |
+| `target_kernel_functions` | no | Optional target function or kernel-symbol hints. |
 | `prompt.instructions` | no | Custom prompt instructions. |
 | `prompt.cheatsheet` | no | Reference/cheatsheet content for the prompt. |
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1,0 +1,128 @@
+# Configuration and API reference
+
+This page documents the run configuration (`config.yaml`), the per-task
+configuration, the command-line flags, the scoring formula, and the agent
+registry.
+
+## Run configuration (`config.yaml`)
+
+The root `config.yaml` defines a single evaluation run.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `agent.template` | string | Agent to run. One of the [supported agents](../how-to/agents.md#supported-agents). |
+| `tasks` | list of strings | Task selectors relative to `tasks/`. Use `all` for every task, a category prefix for a group, or a full path for a single task. |
+| `target_gpu_model` | string | Target GPU model, for example `MI300`. Used to set `PYTORCH_ROCM_ARCH` and to name the workspace. |
+| `log_directory` | string | Directory for run logs. |
+| `workspace_directory_prefix` | string | Prefix for the workspace directory. The full name is `<prefix>_<gpu>_<agent>`. |
+
+Example:
+
+```yaml
+agent:
+  template: cursor
+
+tasks:
+  - hip2hip/gpumode/GELU
+  - triton2triton/vllm/triton_rms_norm
+
+target_gpu_model: MI300
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+## Command-line flags
+
+`main.py` accepts the following flags:
+
+| Flag | Description |
+| --- | --- |
+| `--config_name <file>` | Config file to load (default `config.yaml`). Use separate files to keep multiple task sets in one folder. |
+| `--run-suffix <suffix>` | Suffix appended to the run directory name (letters, numbers, `.`, `_`, `-` only). Useful for labeling A/B runs. |
+| `--resume-run <run_dir>` | Resume a specific run directory, skipping completed tasks. |
+| `--resume-latest` | Resume the most recent run in the workspace. |
+
+```bash
+python main.py --config_name config_triton.yaml --run-suffix with_mcp
+```
+
+## Task configuration
+
+Each task is defined by a `config.yaml` in its directory. Command fields are
+**lists**.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `source_file_path` | yes | Source files containing the kernel, relative to the task root. |
+| `target_kernel_functions` | yes | Kernel function names that must be defined in the source. |
+| `compile_command` | yes | Command(s) to compile or build-check. |
+| `correctness_command` | yes | Command(s) to validate correctness. |
+| `task_type` | yes | One of `hip2hip`, `cuda2hip`, `triton2triton`, `instruction2triton`, `torch2hip`, `flydsl2flydsl`, `repository`. |
+| `performance_command` | no | Command(s) to measure performance. |
+| `task_result_template` | no | Override the result template (`null` = default). |
+| `prompt.source_code` | no | Override the prompt's source-code section. |
+| `prompt.instructions` | no | Custom prompt instructions. |
+| `prompt.cheatsheet` | no | Reference/cheatsheet content for the prompt. |
+
+See [Add a task](../how-to/add-task.md) for layout and authoring rules.
+
+## Result schema (`task_result.yaml`)
+
+Each task produces a `task_result.yaml` in its workspace:
+
+| Field | Description |
+| --- | --- |
+| `task_name` | `<task_type>/<task_name>` |
+| `pass_compilation` | Whether the optimized kernel compiled |
+| `compilation_error_message` | Error text if compilation failed, else `null` |
+| `pass_correctness` | Whether correctness passed |
+| `correctness_error_message` | Error text if correctness failed, else `null` |
+| `base_execution_time` | Baseline runtime in ms |
+| `best_optimized_execution_time` | Best optimized runtime in ms |
+| `speedup_ratio` | Speedup over baseline |
+| `optimization_summary` | Free-text summary from the agent |
+| `score` | Computed score (see below) |
+
+## Scoring
+
+The score is the sum of three components:
+
+| Component | Points | Condition |
+| --- | --- | --- |
+| Compilation | `20` | The kernel compiles successfully. |
+| Correctness | `100` | The kernel passes the correctness check. |
+| Speedup | `speedup_ratio × 100` | Added only when compilation **and** correctness pass. |
+
+The rules, expressed as the framework applies them:
+
+- Compilation fails → score `0`.
+- Compilation passes, correctness fails → score `20`.
+- Both pass → `120 + speedup_ratio × 100`.
+
+**Example**: a kernel that compiles (`20`), is correct (`100`), and achieves a
+`1.58×` speedup scores `20 + 100 + 158 = 278`.
+
+The speedup used for scoring prefers the explicit `speedup_ratio` written by the
+evaluator (which weights each test case equally for multi-testcase tasks) and
+falls back to `base_execution_time / best_optimized_execution_time` when an
+explicit ratio is not present.
+
+This is the default scoring scheme; you can define your own in `src/score.py`.
+
+## Agent registry
+
+Agents register themselves into a shared registry with the `register_agent`
+decorator, and the framework loads only the selected agent:
+
+```python
+from agents import register_agent
+
+@register_agent("your_agent")
+def launch_agent(eval_config, task_config_dir, workspace):
+    ...
+    return result
+```
+
+The selectable agent names are defined by the `AgentType` enum in
+`src/module_registration.py`. See [Configure agents and models](../how-to/agents.md)
+for the integration steps.

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -1,0 +1,44 @@
+# Compatibility matrix
+
+The following versions are the supported and tested configurations for
+AgentKernelArena. Entries marked `TODO (verify)` must be confirmed against a
+tested environment before publication.
+
+## Hardware
+
+| Component | Supported | Notes |
+| --- | --- | --- |
+| GPU architecture | AMD Instinct MI300 series | `target_gpu_model: MI300`. TODO (verify) other architectures. |
+| GPU architecture | AMD Instinct MI355X | TODO (verify) |
+
+## Software
+
+| Component | Version | Notes |
+| --- | --- | --- |
+| ROCm | 6.4, 7.0, 7.1 | Auto-detected by the `Makefile` from `/opt/rocm-*`. |
+| Python | 3.12+ | |
+| PyTorch | ROCm build matching the detected ROCm version | Installed by `make setup` (nightly for ROCm 7.x). |
+| Triton | Bundled with the ROCm PyTorch wheel | Required for Triton task categories. |
+| FlyDSL | Latest from PyPI | Required for `flydsl2flydsl` tasks. TODO (verify) pinned version. |
+| uv | Latest | Used to create the virtual environment. |
+| hipcc | Matches ROCm | Required for HIP tasks. |
+| rocprof-compute | Matches ROCm | Required for HIP performance profiling. |
+
+## Agents
+
+| Agent | Tested version | Notes |
+| --- | --- | --- |
+| Cursor Agent CLI | TODO (verify) | Installed via `make install-cursor-agent`. |
+| Claude Code | TODO (verify) | `npm install -g @anthropic-ai/claude-code`. |
+| Codex CLI | TODO (verify) | Installed per the official Codex CLI instructions. |
+| SWE-agent | TODO (verify) | |
+| OpenEvolve (GEAK) | TODO (verify) | |
+
+## Model providers
+
+| Provider | Notes |
+| --- | --- |
+| OpenAI | Requires `OPENAI_API_KEY`. |
+| Anthropic | Requires `ANTHROPIC_API_KEY`. |
+| OpenRouter | Requires `OPENROUTER_API_KEY`. |
+| Local vLLM | Self-hosted on port `30001` via `make vllm`. |

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -1,0 +1,37 @@
+# Release notes
+
+## AgentKernelArena 0.1.0
+
+Initial release of AgentKernelArena, a standardized arena for evaluating AI
+coding agents on GPU kernel optimization tasks on AMD GPUs.
+
+### Features
+
+- **Multi-agent arena**: run Cursor, Claude Code, Codex, SWE-agent, OpenEvolve
+  (GEAK), GEAK HIP, GEAK OptimAgent v2, GEAK OurLLM kernel-to-kernel, and
+  single-LLM-call agents through a common evaluation pipeline.
+- **Multi-model support**: OpenAI, Anthropic, and additional models via
+  OpenRouter or a self-hosted vLLM server.
+- **Task categories**: `hip2hip`, `cuda2hip`, `triton2triton`,
+  `instruction2triton`, `torch2hip`, and `flydsl2flydsl`, with bundled suites
+  from gpumode, vLLM, and ROCmBench.
+- **Objective metrics**: automated evaluation of compilation, correctness, and
+  real GPU performance speedups, combined into a single comparable score.
+- **Workspace isolation**: each task runs in a timestamped duplicate workspace
+  for reproducibility.
+- **Resumable runs**: resume an interrupted run and skip completed tasks with
+  `--resume-run` or `--resume-latest`.
+- **A/B testing**: run the same task set with and without an agent-side
+  capability to measure its real impact.
+- **Task validator**: a dedicated agent that runs 10 automated quality checks on
+  tasks and emits a `validation_report.yaml`.
+- **Visualization dashboard**: a static dashboard for comparing run reports
+  across agents and models.
+- **ROCm environment auto-detection**: the `Makefile` detects ROCm 6.4, 7.0, or
+  7.1 and installs the matching PyTorch build.
+
+### Known limitations
+
+- Agents can hang during task execution and block test completion.
+- The published leaderboard is forthcoming; the live demo is illustrative only.
+- Task suites for several categories are being expanded toward 100+ tasks each.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -1,0 +1,46 @@
+# Table of contents for the AgentKernelArena documentation site.
+# Processed by rocm-docs-core into sphinx/_toc.yml at build time.
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/
+
+defaults:
+  numbered: false
+
+root: index
+
+subtrees:
+  - caption: Install
+    entries:
+      - file: install/install
+        title: Install AgentKernelArena
+
+  - caption: Reference
+    entries:
+      - file: reference/release-notes
+        title: Release notes
+      - file: reference/compatibility-matrix
+        title: Compatibility matrix
+      - file: reference/api-reference
+        title: Configuration and API reference
+
+  - caption: How to
+    entries:
+      - file: how-to/run-evaluation
+        title: Run an evaluation
+      - file: how-to/agents
+        title: Configure agents and models
+      - file: how-to/add-task
+        title: Add a task
+      - file: how-to/task-validator
+        title: Validate tasks
+      - file: how-to/visualization
+        title: Visualize and compare runs
+
+  - caption: Examples
+    entries:
+      - file: examples/examples
+        title: Examples
+
+  - caption: About
+    entries:
+      - file: about/license
+        title: License

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,2 @@
+rocm-docs-core==1.35.0
+sphinxcontrib-mermaid==1.0.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,0 +1,5 @@
+# Documentation build requirements for AgentKernelArena.
+# rocm-docs-core pulls in Sphinx, the ROCm theme, MyST parser, and the
+# external-toc extension. Pin matches docs/sphinx/requirements.in.
+rocm-docs-core==1.35.0
+sphinxcontrib-mermaid==1.0.0


### PR DESCRIPTION
## Summary
- Add a Sphinx + rocm-docs-core documentation site for AgentKernelArena under `docs/`
- Cover install, how-to (run evaluation, agents, add task, task validator, visualization), reference (config/API, scoring, release notes, compatibility matrix), examples, and license
- Add `.readthedocs.yaml` for hosted builds