### PR TITLE
ROCm docs style IA and style guide updates

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,3 +1,10 @@
+---
+myst:
+    html_meta:
+        "description": "AgentKernelArena is released under the Apache License, Version 2.0 by Advanced Micro Devices, Inc. View the full license text on this page."
+        "keywords": "AgentKernelArena, license, Apache 2.0, open source, AMD"
+---
+
 # License
 
 AgentKernelArena is released under the Apache License, Version 2.0. The full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,45 +1,63 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# AgentKernelArena documentation is built with rocm-docs-core, which configures
-# the theme, navigation, MyST Markdown support, and shared ROCm options. Both
-# Markdown (.md, via MyST) and reStructuredText (.rst) source files build out of
-# the box.
-#
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/
+"""
+html_theme is usually unchanged (rocm_docs_theme).
+flavor defines the site header display, select the flavor for the corresponding portals
+flavor options: rocm, rocm-docs-home, rocm-blogs, rocm-ds, instinct, ai-developer-hub, local, generic
+"""
 
-# -- Project information ------------------------------------------------------
+version_number = "0.1.0"
 
+html_theme = "rocm_docs_theme"
+html_theme_options = {
+    "flavor": "generic",
+    "header_title": f"AgentKernelArena {version_number}",
+    "header_link": False,
+    "version_list_link": False,
+    "nav_secondary_items": {
+        "GitHub": False,
+        "Community": False,
+        "Blogs": "https://rocm.blogs.amd.com/",
+        "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
+        "Instinct™ Docs": "https://instinct.docs.amd.com/",
+        "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
+        "Support": False,
+    },
+    "link_main_doc": False,
+}
+
+# This section turns on/off article info
+setting_all_article_info = True
+all_article_info_os = ["linux"]
+all_article_info_author = ""
+
+# for PDF output on Read the Docs
 project = "AgentKernelArena"
 author = "Advanced Micro Devices, Inc."
-copyright = "2026, Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
 
-# Single-sourced version. Update alongside the package version.
-version = "0.1.0"
-release = version
+external_toc_path = "./sphinx/_toc.yml"  # Defines Table of Content structure definition path
 
-# -- General configuration ----------------------------------------------------
+"""
+Doxygen Settings
+Ensure Doxyfile is located at docs/doxygen.
+If the component does not need doxygen, delete this section for optimal build time
+"""
+# doxygen_root = "doxygen"
+# doxysphinx_enabled = True
+# doxygen_project = {
+#    "name": "doxygen",
+#    "path": "doxygen/xml",
+# }
 
-extensions = ["rocm_docs", "sphinxcontrib.mermaid"]
+# Add more addtional package accordingly
+extensions = [
+    "rocm_docs",
+    "sphinxcontrib.mermaid"
+]
 
-# Render fenced ```mermaid code blocks in Markdown as diagrams.
 myst_fence_as_directive = ["mermaid"]
 
-external_toc_path = "./sphinx/_toc.yml"
+html_title = f"{project} {version_number} documentation"
 
-# Don't load intersphinx inventories for other ROCm projects. AgentKernelArena
-# is not yet registered in the rocm-docs-core project registry, so the default
-# ("all") tries to fetch internal inventories that are not publicly reachable
-# and aborts the build under Sphinx 9.x. These docs do not cross-reference other
-# ROCm projects. Once the project is onboarded, this can be set back to "all" or
-# to an explicit list of related projects.
-external_projects = []
-
-# docs/README.md documents the build process for contributors and is not a
-# published page; keep it out of the source build so it is not treated as an
-# orphan document.
-exclude_patterns = ["README.md"]
-
-# rocm-docs-core options.
-html_theme = "rocm_docs_theme"
-html_theme_options = {"flavor": "rocm-docs-home"}
+external_projects_current_project = "AgentKernelArena"

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -1,6 +1,13 @@
-# Examples
+---
+myst:
+    html_meta:
+        "description": "Step-by-step examples for running AgentKernelArena evaluations, A/B testing agent capabilities, validating tasks, and resuming interrupted runs."
+        "keywords": "AgentKernelArena, examples, evaluation, A/B test, task validation, GPU kernel, ROCm, HIP, Triton"
+---
 
-These walkthroughs assume you have completed [installation](../install/install.md)
+# AgentKernelArena examples
+
+These walkthroughs assume you've completed the [installation](../install/install.md)
 and activated the virtual environment (`make act`).
 
 ## Example 1: Evaluate one agent on one task
@@ -9,32 +16,32 @@ Run a single HIP task with the Cursor agent.
 
 1. Edit `config.yaml`:
 
-```yaml
-agent:
-  template: cursor
+    ```yaml
+    agent:
+      template: cursor
 
-tasks:
-  - hip2hip/gpumode/GELU
+    tasks:
+      - hip2hip/gpumode/GELU
 
-target_gpu_model: MI300
-log_directory: logs
-workspace_directory_prefix: workspace
-```
+    target_gpu_model: MI300
+    log_directory: logs
+    workspace_directory_prefix: workspace
+    ```
 
 2. Run:
 
-```bash
-python main.py
-```
+    ```bash
+    python main.py
+    ```
 
 3. Inspect the result:
 
-```text
-workspace_MI300_cursor/
-└── run_<timestamp>/
-    └── hip2hip_gpumode_GELU_<timestamp>/
-        └── task_result.yaml
-```
+    ```text
+    workspace_MI300_cursor/
+    └── run_<timestamp>/
+        └── hip2hip_gpumode_GELU_<timestamp>/
+            └── task_result.yaml
+    ```
 
 A successful `task_result.yaml` looks like:
 
@@ -73,7 +80,7 @@ post-processing aggregates them into a run report.
 
 ## Example 3: A/B test an agent capability
 
-Measure whether a new MCP server, skill, or prompt change helps. Run the same
+Measure whether a new Model Context Protocol (MCP) server, skill, or prompt change helps. Run the same
 task set twice with distinct run suffixes.
 
 ```bash
@@ -118,7 +125,7 @@ python3 main.py
 
 Open the generated `validation_report.yaml` in the task workspace. The task must
 reach **PASS** (or **WARN** with justification) before merging. See
-[Validate tasks](../how-to/task-validator.md).
+[Validate tasks](../how-to/task-validator.md) for more information.
 
 ## Example 5: Resume an interrupted run
 

--- a/docs/how-to/add-task.md
+++ b/docs/how-to/add-task.md
@@ -1,8 +1,15 @@
-# Add a task
+---
+myst:
+    html_meta:
+        "description": "Learn how to create a new GPU kernel task for AgentKernelArena, including directory layout, config.yaml schema, supported task types, and authoring rules."
+        "keywords": "AgentKernelArena, add task, GPU kernel, HIP, Triton, CUDA, config.yaml, task types, ROCm"
+---
+
+# Add a task in AgentKernelArena
 
 A task is a single GPU kernel optimization problem. Each task lives in its own
 directory under `tasks/<task_type>/<task_name>/` and is described by a
-`config.yaml`. This page covers the directory layout, the configuration schema,
+`config.yaml`. This topic covers the directory layout, the configuration schema,
 and the supported task types.
 
 ## Task types
@@ -40,7 +47,7 @@ path referenced in `config.yaml` resolves inside the task directory.
 ## Required `config.yaml` fields
 
 Most tasks optimize files that are copied into the task workspace. For those
-isolated-kernel tasks, all command fields are **lists**, even when there is a
+isolated-kernel tasks, all command fields are *lists*, even when there's a
 single command.
 
 ```yaml
@@ -102,22 +109,22 @@ prompt:
 
 ## Authoring rules
 
-To produce trustworthy, comparable scores, every task must be **self-contained**
+To produce trustworthy, comparable scores, every task must be *self-contained*
 and must validate correctness meaningfully.
 
-- **Self-contained**: no references to external repositories or absolute paths,
+- **Self-contained**: No references to external repositories or absolute paths,
   no missing headers or Python imports, and no external data downloads. Generate
   test inputs inline or bundle small files in the task directory.
-- **Real correctness check**: compare against a CPU/NumPy reference, known-good
+- **Real correctness check**: Compare against a CPU/NumPy reference, known-good
   output, or a PyTorch eager baseline; use sensible tolerances; test 2–3 shapes;
   and exit non-zero on failure.
-- **Real compilation check**: actually compile or syntax-check the source, not a
+- **Real compilation check**: Actually compile or syntax-check the source, not a
   text-pattern search; exit code `0` means success.
-- **Performance methodology**: a recommended pattern is 10 warmup iterations plus
+- **Performance methodology**: A recommended pattern is 10 warmup iterations plus
   100 measured iterations, reporting the average runtime.
 
 ## Validate before merging
 
-Every new task must pass the **task_validator** agent before it is merged. It
+Every new task must pass the `task_validator` agent before it's merged. It
 runs 10 automated checks and emits a `validation_report.yaml`. See
 [Validate tasks](task-validator.md) for the full check list and how to run it.

--- a/docs/how-to/agents.md
+++ b/docs/how-to/agents.md
@@ -1,7 +1,14 @@
-# Configure agents and models
+---
+myst:
+    html_meta:
+        "description": "Configure agents and model providers in AgentKernelArena. Covers supported agents, OpenAI and Anthropic integration, A/B testing, and adding custom agents."
+        "keywords": "AgentKernelArena, agents, models, Claude Code, Cursor, Codex, OpenAI, Anthropic, A/B testing, ROCm, GPU"
+---
+
+# Configure agents and models in AgentKernelArena
 
 AgentKernelArena evaluates one agent per run. The agent is selected by the
-`agent.template` field in `config.yaml`. This page lists the supported agents,
+`agent.template` field in `config.yaml`. This topic lists the supported agents,
 explains how models and providers are configured, and describes how to use the
 arena for A/B testing.
 
@@ -52,10 +59,10 @@ export OPENROUTER_API_KEY="..."
 ## A/B testing and ablation studies
 
 Beyond ranking different agents and models, AgentKernelArena works as a
-controlled A/B testing harness for agent-side capabilities — a new MCP server,
+controlled A/B testing harness for agent-side capabilities — a new Model Context Protocol (MCP) server,
 skill, prompt strategy, or tool integration.
 
-Run the **same task set twice**, once with the capability enabled and once
+Run the same task set twice, once with the capability enabled and once
 without, then compare the standardized scores:
 
 ```bash
@@ -82,4 +89,4 @@ To integrate a custom agent:
 3. Wire the agent into the prompt builder and post-processing handler in
    `src/module_registration.py` if it needs the standard behavior.
 
-See the development section of the repository `README.md` for the full template.
+See the development section of the repository [`README.md`](https://github.com/AMD-AGI/AgentKernelArena/blob/main/README.md#development) for the full template.

--- a/docs/how-to/run-evaluation.md
+++ b/docs/how-to/run-evaluation.md
@@ -1,12 +1,19 @@
-# Run an evaluation
+---
+myst:
+    html_meta:
+        "description": "Learn how to configure config.yaml, run an AgentKernelArena evaluation against GPU kernel tasks, resume interrupted runs, and read scored results."
+        "keywords": "AgentKernelArena, run evaluation, config.yaml, GPU kernel, ROCm, AMD, task results, resume run, scoring"
+---
+
+# Run an evaluation in AgentKernelArena
 
 An evaluation runs one agent against a set of tasks and produces scored results.
-This page walks through configuring the run, executing it, resuming an
-interrupted run, and reading the output.
+This topic explains how to configure a run, execute it, resume an
+interrupted run, and read the output.
 
-## 1. Configure `config.yaml`
+## Configure `config.yaml`
 
-The root `config.yaml` selects the agent, the tasks, and the target GPU.
+The root `config.yaml` selects the agent, the tasks, and the target GPU:
 
 ```yaml
 agent:
@@ -23,7 +30,7 @@ log_directory: logs
 workspace_directory_prefix: workspace
 ```
 
-### Selecting tasks
+### Select tasks
 
 Each entry in `tasks` is a path relative to the `tasks/` directory. You can
 select tasks at any level of granularity:
@@ -38,7 +45,7 @@ select tasks at any level of granularity:
 See [Configuration and API reference](../reference/api-reference.md) for the full
 set of `config.yaml` fields.
 
-## 2. Run
+## Start a run
 
 ```bash
 python main.py
@@ -57,7 +64,7 @@ python main.py --run-suffix cursor_with_mcp
 # → workspace_MI300_cursor/run_20260617_101500_cursor_with_mcp
 ```
 
-## 3. What happens during a run
+### What happens during a run
 
 ```mermaid
 flowchart TD
@@ -74,7 +81,7 @@ flowchart TD
 For each task, the framework:
 
 1. Copies the task into an isolated, timestamped workspace.
-2. Measures a **baseline** (compiles and times the original kernel; for
+2. Measures a *baseline* (compiles and times the original kernel; for
    `torch2hip` tasks it times the PyTorch reference directly).
 3. Launches the configured agent with a generated prompt.
 4. Evaluates the agent's kernel for compilation, correctness, and performance.
@@ -83,7 +90,7 @@ For each task, the framework:
 After all tasks finish, a post-processing step aggregates the per-task results
 into a run report.
 
-## 4. Resume an interrupted run
+## Resume an interrupted run
 
 Long runs can be resumed; completed tasks are skipped.
 
@@ -95,7 +102,7 @@ python main.py --resume-run run_20260617_101500
 python main.py --resume-latest
 ```
 
-## 5. Read the results
+## Read the results
 
 A run produces this layout under the workspace directory:
 

--- a/docs/how-to/task-validator.md
+++ b/docs/how-to/task-validator.md
@@ -1,7 +1,14 @@
-# Validate tasks
+---
+myst:
+    html_meta:
+        "description": "Use the AgentKernelArena task_validator agent to run 10 automated quality checks on GPU kernel tasks before merging or publishing leaderboard results."
+        "keywords": "AgentKernelArena, task validator, GPU kernel, quality checks, ROCm, HIP, Triton, validation report"
+---
 
-The **task_validator** agent checks that tasks are correctly configured,
-self-contained, and functional. It does not optimize kernels — it audits them.
+# Validate tasks in AgentKernelArena
+
+The `task_validator` agent checks that tasks are correctly configured,
+self-contained, and functional. It doesn't optimize kernels — it audits them.
 Use it to validate new tasks before merging and to audit existing tasks before
 publishing results to a leaderboard.
 
@@ -42,7 +49,9 @@ timeout_seconds: 600          # max time per task validation (0 disables the tim
 python_path: /root/AgentKernelArena/.venv/bin/python3
 ```
 
-## The 10 checks
+## `task_validator` checks
+
+The `task_validator` runs these checks in order:
 
 | # | Check | What it verifies |
 | --- | --- | --- |
@@ -66,7 +75,7 @@ python_path: /root/AgentKernelArena/.venv/bin/python3
 
 ## Result template
 
-A validated task's compile → correctness → performance flow must produce results
+A validated task's **compile → correctness → performance** flow must produce results
 that populate the standard template:
 
 ```yaml

--- a/docs/how-to/visualization.md
+++ b/docs/how-to/visualization.md
@@ -1,8 +1,15 @@
-# Visualize and compare runs
+---
+myst:
+    html_meta:
+        "description": "Build and serve the AgentKernelArena visualization dashboard to compare GPU kernel evaluation run reports across agents and model providers."
+        "keywords": "AgentKernelArena, visualization, dashboard, compare runs, agents, models, ROCm, GPU kernel, evaluation"
+---
+
+# Visualize and compare runs in AgentKernelArena
 
 AgentKernelArena ships a static dashboard under `visualization/` for comparing
-run reports across agents and models. This page covers building the dashboard
-data and serving it.
+run reports across agents and models. This topic covers how to build the dashboard
+data and serve it.
 
 ## What the dashboard reads
 
@@ -12,7 +19,7 @@ The dashboard scans for report directories that contain:
 - `task_type_breakdown.json`
 - `overall_report.txt`
 
-By default it scans only visualization-specific report bundles:
+By default, it scans only visualization-specific report bundles:
 
 ```text
 visualization/reports/<report_name>/
@@ -37,7 +44,7 @@ Then open:
 http://127.0.0.1:8080
 ```
 
-### Serve on port 80
+### Serve on port `80`
 
 Port `80` usually requires elevated privileges:
 
@@ -70,7 +77,9 @@ bash setup.sh --include-workspace-runs
 
 The dashboard picks up newly discovered report directories on the next refresh.
 
-## Notes
+## Dashboard implementation notes
+
+The following details apply to the dashboard implementation:
 
 - The HTTP service serves the UI from `visualization/frontend/`.
 - Source-file links are exposed through an `/artifacts/...` route that only
@@ -78,4 +87,4 @@ The dashboard picks up newly discovered report directories on the next refresh.
 - If no reports are found yet, the dashboard still builds and shows an empty
   state.
 - `frontend/dashboard/data.js` and `frontend/dashboard/data.json` are generated
-  files; do not edit them by hand.
+  files; don't edit them by hand.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,63 +16,12 @@ The AgentKernelArena source code is hosted in the
 `AMD-AGI/AgentKernelArena <https://github.com/AMD-AGI/AgentKernelArena>`_ GitHub
 repository.
 
-What AgentKernelArena does
-==========================
-
-AgentKernelArena gives each agent the same kernel task, runs it in a siloed,
-timestamped workspace, then evaluates the result through a common pipeline:
-
-* **Compile** -- Build the agent's kernel and confirm it compiles cleanly.
-* **Validate** -- Run the task's correctness check against a reference.
-* **Profile** -- Measure GPU execution time and compute speedup over a baseline.
-* **Score** -- Combine the results into a single comparable score.
-
-Key features
-============
-
-* **Multi-agent arena**: Cursor, Claude Code, Codex, SWE-agent, OpenEvolve
-  (GEAK), GEAK HIP, single-LLM-call, and custom agents.
-* **Multi-model support**: OpenAI, Anthropic, and other models via OpenRouter or
-  a local vLLM server.
-* **Task categories**: HIP (``hip2hip``), CUDA-to-HIP (``cuda2hip``), Triton
-  (``triton2triton``, ``instruction2triton``), Torch-to-HIP (``torch2hip``), and
-  FlyDSL (``flydsl2flydsl``).
-* **Objective metrics**: automated compilation, correctness, and real GPU
-  performance speedups.
-* **Workspace isolation**: each task runs in its own timestamped workspace for
-  reproducibility.
-* **A/B testing**: run the same task set with and without a new MCP server,
-  skill, prompt, or tool to measure its real impact.
-* **Task validator**: an agent that runs 10 automated checks on task quality
-  before tasks enter the leaderboard.
-* **Visualization dashboard**: a static dashboard for comparing run reports.
-
-Use cases
-=========
-
-* Compare AI coding agents head-to-head on GPU kernel optimization.
-* Rank models and agent configurations on a standardized leaderboard.
-* A/B test whether a new agent capability (MCP server, skill, prompt) improves
-  outcomes under identical conditions.
-* Curate and validate a high-quality, self-contained GPU kernel task suite.
-
-Documentation
-=============
-
-The AgentKernelArena documentation is organized into the following categories.
-
 .. grid:: 2
    :gutter: 3
 
    .. grid-item-card:: Install
 
       * :doc:`Install AgentKernelArena <install/install>`
-
-   .. grid-item-card:: Reference
-
-      * :doc:`Release notes <reference/release-notes>`
-      * :doc:`Compatibility matrix <reference/compatibility-matrix>`
-      * :doc:`Configuration and API reference <reference/api-reference>`
 
    .. grid-item-card:: How to
 
@@ -86,9 +35,9 @@ The AgentKernelArena documentation is organized into the following categories.
 
       * :doc:`Examples <examples/examples>`
 
-   .. grid-item-card:: About
+   .. grid-item-card:: Reference
 
-      * :doc:`License <about/license>`
+      * :doc:`Configuration and API reference <reference/api-reference>`
 
 To contribute to the documentation, see the
 `AgentKernelArena GitHub repository <https://github.com/AMD-AGI/AgentKernelArena>`_.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,3 +1,10 @@
+---
+myst:
+    html_meta:
+        "description": "Learn how to install AgentKernelArena on an AMD GPU system using make setup, manual virtual environment setup, or direct agent CLI installation."
+        "keywords": "AgentKernelArena, install, ROCm, AMD GPU, HIP, PyTorch, setup, venv, agent CLI"
+---
+
 # Install AgentKernelArena
 
 AgentKernelArena runs AI coding agents against GPU kernel tasks on an AMD GPU and
@@ -7,7 +14,7 @@ agent CLI available.
 
 ## Prerequisites
 
-- **Python 3.12+**
+- **Python 3.12 or later**
 - **AMD GPU with ROCm** — ROCm 6.4, 7.0, or 7.1 (the `Makefile` auto-detects the
   installed version under `/opt/rocm-*`)
 - **ROCm toolchain for HIP tasks** — `hipcc` and `rocprof-compute`
@@ -22,7 +29,7 @@ agent CLI available.
 
 From the repository root, the `Makefile` detects your ROCm version, creates a
 `.venv` virtual environment with the matching ROCm PyTorch build, and installs
-all dependencies.
+all dependencies:
 
 ```bash
 git clone https://github.com/AMD-AGI/AgentKernelArena.git

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1,6 +1,13 @@
-# Configuration and API reference
+---
+myst:
+    html_meta:
+        "description": "Complete reference for AgentKernelArena configuration: run config.yaml schema, task config fields, CLI flags, scoring formula, and the agent registry."
+        "keywords": "AgentKernelArena, API reference, config.yaml, CLI flags, scoring, agent registry, ROCm, GPU kernel"
+---
 
-This page documents the run configuration (`config.yaml`), the per-task
+# AgentKernelArena configuration and API reference
+
+This topic documents the run configuration (`config.yaml`), the per-task
 configuration, the command-line flags, the scoring formula, and the agent
 registry.
 
@@ -33,14 +40,14 @@ workspace_directory_prefix: workspace
 
 ## Command-line flags
 
-`main.py` accepts the following flags:
+`main.py` accepts these flags:
 
 | Flag | Description |
 | --- | --- |
-| `--config_name <file>` | Config file to load (default `config.yaml`). Use separate files to keep multiple task sets in one folder. |
-| `--run-suffix <suffix>` | Suffix appended to the run directory name (letters, numbers, `.`, `_`, `-` only). Useful for labeling A/B runs. |
-| `--resume-run <run_dir>` | Resume a specific run directory, skipping completed tasks. |
-| `--resume-latest` | Resume the most recent run in the workspace. |
+| `--config_name <file>` | Config file to load (default `config.yaml`). Use separate files to keep multiple task sets in one folder |
+| `--run-suffix <suffix>` | Suffix appended to the run directory name (letters, numbers, `.`, `_`, `-` only). Useful for labeling A/B runs |
+| `--resume-run <run_dir>` | Resume a specific run directory, skipping completed tasks |
+| `--resume-latest` | Resume the most recent run in the workspace |
 
 ```bash
 python main.py --config_name config_triton.yaml --run-suffix with_mcp
@@ -49,40 +56,40 @@ python main.py --config_name config_triton.yaml --run-suffix with_mcp
 ## Task configuration
 
 Each task is defined by a `config.yaml` in its directory. Command fields are
-**lists**.
+*lists*.
 
 For isolated-kernel tasks (`hip2hip`, `cuda2hip`, `triton2triton`,
 `instruction2triton`, `torch2hip`, and `flydsl2flydsl`):
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `source_file_path` | yes | Source files containing the kernel, relative to the task root. |
-| `target_kernel_functions` | yes | Kernel function names that must be defined in the source. |
-| `compile_command` | yes | Command(s) to compile or build-check. |
-| `correctness_command` | yes | Command(s) to validate correctness. |
-| `task_type` | yes | One of `hip2hip`, `cuda2hip`, `triton2triton`, `instruction2triton`, `torch2hip`, or `flydsl2flydsl`. |
-| `performance_command` | no | Command(s) to measure performance. |
-| `task_result_template` | no | Override the result template (`null` = default). |
-| `prompt.source_code` | no | Override the prompt's source-code section. |
-| `prompt.instructions` | no | Custom prompt instructions. |
-| `prompt.cheatsheet` | no | Reference/cheatsheet content for the prompt. |
+| `source_file_path` | Yes | Source files containing the kernel, relative to the task root |
+| `target_kernel_functions` | Yes | Kernel function names that must be defined in the source |
+| `compile_command` | Yes | Command(s) to compile or build-check |
+| `correctness_command` | Yes | Command(s) to validate correctness |
+| `task_type` | Yes | One of `hip2hip`, `cuda2hip`, `triton2triton`, `instruction2triton`, `torch2hip`, or `flydsl2flydsl` |
+| `performance_command` | No | Command(s) to measure performance |
+| `task_result_template` | No | Override the result template (`null` = default) |
+| `prompt.source_code` | No | Override the prompt's source-code section |
+| `prompt.instructions` | No | Custom prompt instructions |
+| `prompt.cheatsheet` | No | Reference/cheatsheet content for the prompt |
 
 For repository-level tasks (`task_type: repository`):
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `repo_url` | yes | Upstream repository to clone for the task. |
-| `task_type` | yes | Must be `repository`. |
-| `repository_language` | yes | Primary optimization stack, for example `hip` or `triton`. |
-| `compile_command` | yes | Command(s) to compile or build-check. |
-| `correctness_command` | yes | Command(s) to validate correctness. |
-| `performance_command` | no | Command(s) to measure performance. |
-| `post_clone_install` | no | Setup command(s) to run after cloning the upstream repository. |
-| `post_clone_install_mode` | no | Controls when `post_clone_install` runs, for example `every_setup`. |
-| `source_file_path` | no | Optional target source-file hints, relative to the cloned repository root. |
-| `target_kernel_functions` | no | Optional target function or kernel-symbol hints. |
-| `prompt.instructions` | no | Custom prompt instructions. |
-| `prompt.cheatsheet` | no | Reference/cheatsheet content for the prompt. |
+| `repo_url` | Yes | Upstream repository to clone for the task |
+| `task_type` | Yes | Must be `repository` |
+| `repository_language` | Yes | Primary optimization stack, for example `hip` or `triton` |
+| `compile_command` | Yes | Command(s) to compile or build-check |
+| `correctness_command` | Yes | Command(s) to validate correctness |
+| `performance_command` | No | Command(s) to measure performance |
+| `post_clone_install` | No | Setup command(s) to run after cloning the upstream repository |
+| `post_clone_install_mode` | No | Controls when `post_clone_install` runs, for example `every_setup` |
+| `source_file_path` | No | Optional target source-file hints, relative to the cloned repository root |
+| `target_kernel_functions` | No | Optional target function or kernel-symbol hints |
+| `prompt.instructions` | No | Custom prompt instructions |
+| `prompt.cheatsheet` | No | Reference/cheatsheet content for the prompt |
 
 See [Add a task](../how-to/add-task.md) for layout and authoring rules.
 
@@ -109,9 +116,9 @@ The score is the sum of three components:
 
 | Component | Points | Condition |
 | --- | --- | --- |
-| Compilation | `20` | The kernel compiles successfully. |
-| Correctness | `100` | The kernel passes the correctness check. |
-| Speedup | `speedup_ratio × 100` | Added only when compilation **and** correctness pass. |
+| Compilation | `20` | The kernel compiles successfully |
+| Correctness | `100` | The kernel passes the correctness check |
+| Speedup | `speedup_ratio × 100` | Added only when compilation *and* correctness pass |
 
 The rules, expressed as the framework applies them:
 
@@ -119,7 +126,7 @@ The rules, expressed as the framework applies them:
 - Compilation passes, correctness fails → score `20`.
 - Both pass → `120 + speedup_ratio × 100`.
 
-**Example**: a kernel that compiles (`20`), is correct (`100`), and achieves a
+**Example**: A kernel that compiles (`20`), is correct (`100`), and achieves a
 `1.58×` speedup scores `20 + 100 + 158 = 278`.
 
 The speedup used for scoring prefers the explicit `speedup_ratio` written by the

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -1,4 +1,11 @@
-# Compatibility matrix
+---
+myst:
+    html_meta:
+        "description": "Supported and tested hardware, software versions, agent CLIs, and model providers for AgentKernelArena, including ROCm and Python requirements."
+        "keywords": "AgentKernelArena, compatibility matrix, ROCm, AMD Instinct, Python, PyTorch, GPU, agents, model providers"
+---
+
+# AgentKernelArena compatibility matrix
 
 The following versions are the supported and tested configurations for
 AgentKernelArena. Entries marked `TODO (verify)` must be confirmed against a
@@ -6,12 +13,16 @@ tested environment before publication.
 
 ## Hardware
 
+The following hardware configurations are supported and tested.
+
 | Component | Supported | Notes |
 | --- | --- | --- |
-| GPU architecture | AMD Instinct MI300 series | `target_gpu_model: MI300`. TODO (verify) other architectures. |
+| GPU architecture | AMD Instinct™ MI300 series | `target_gpu_model: MI300`. TODO (verify) other architectures. |
 | GPU architecture | AMD Instinct MI355X | TODO (verify) |
 
 ## Software
+
+The following software versions are required or verified.
 
 | Component | Version | Notes |
 | --- | --- | --- |
@@ -26,9 +37,11 @@ tested environment before publication.
 
 ## Agents
 
+The following agent CLIs have been tested with AgentKernelArena.
+
 | Agent | Tested version | Notes |
 | --- | --- | --- |
-| Cursor Agent CLI | TODO (verify) | Installed via `make install-cursor-agent`. |
+| Cursor Agent CLI | TODO (verify) | Installed using `make install-cursor-agent`. |
 | Claude Code | TODO (verify) | `npm install -g @anthropic-ai/claude-code`. |
 | Codex CLI | TODO (verify) | Installed per the official Codex CLI instructions. |
 | SWE-agent | TODO (verify) | |
@@ -36,9 +49,11 @@ tested environment before publication.
 
 ## Model providers
 
+The following model providers are supported.
+
 | Provider | Notes |
 | --- | --- |
 | OpenAI | Requires `OPENAI_API_KEY`. |
 | Anthropic | Requires `ANTHROPIC_API_KEY`. |
 | OpenRouter | Requires `OPENROUTER_API_KEY`. |
-| Local vLLM | Self-hosted on port `30001` via `make vllm`. |
+| Local vLLM | Self-hosted on port `30001` using `make vllm`. |

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -1,4 +1,11 @@
-# Release notes
+---
+myst:
+    html_meta:
+        "description": "Release notes for AgentKernelArena, covering new features, known limitations, supported GPU task categories, and agent integration changes for each release."
+        "keywords": "AgentKernelArena, release notes, changelog, ROCm, GPU kernel, HIP, Triton, agents, evaluation"
+---
+
+# AgentKernelArena release notes
 
 ## AgentKernelArena 0.1.0
 
@@ -7,10 +14,12 @@ coding agents on GPU kernel optimization tasks on AMD GPUs.
 
 ### Features
 
+AgentKernelArena 0.1.0 includes the following features.
+
 - **Multi-agent arena**: run Cursor, Claude Code, Codex, SWE-agent, OpenEvolve
   (GEAK), GEAK HIP, GEAK OptimAgent v2, GEAK OurLLM kernel-to-kernel, and
   single-LLM-call agents through a common evaluation pipeline.
-- **Multi-model support**: OpenAI, Anthropic, and additional models via
+- **Multi-model support**: OpenAI, Anthropic, and additional models through
   OpenRouter or a self-hosted vLLM server.
 - **Task categories**: `hip2hip`, `cuda2hip`, `triton2triton`,
   `instruction2triton`, `torch2hip`, and `flydsl2flydsl`, with bundled suites
@@ -31,6 +40,8 @@ coding agents on GPU kernel optimization tasks on AMD GPUs.
   7.1 and installs the matching PyTorch build.
 
 ### Known limitations
+
+The following limitations are present in this release.
 
 - Agents can hang during task execution and block test completion.
 - The published leaderboard is forthcoming; the live demo is illustrative only.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -8,39 +8,43 @@ defaults:
 root: index
 
 subtrees:
-  - caption: Install
-    entries:
-      - file: install/install
-        title: Install AgentKernelArena
+- entries:
+  - file: what-is-aka
+    title: What is AgentKernelArena?
+  - file: reference/release-notes
+    title: Release notes
+  - file: reference/compatibility-matrix
+    title: Compatibility matrix
 
-  - caption: Reference
-    entries:
-      - file: reference/release-notes
-        title: Release notes
-      - file: reference/compatibility-matrix
-        title: Compatibility matrix
-      - file: reference/api-reference
-        title: Configuration and API reference
+- caption: Install
+  entries:
+    - file: install/install
+      title: Install AgentKernelArena
 
-  - caption: How to
-    entries:
-      - file: how-to/run-evaluation
-        title: Run an evaluation
-      - file: how-to/agents
-        title: Configure agents and models
-      - file: how-to/add-task
-        title: Add a task
-      - file: how-to/task-validator
-        title: Validate tasks
-      - file: how-to/visualization
-        title: Visualize and compare runs
+- caption: How to
+  entries:
+    - file: how-to/run-evaluation
+      title: Run an evaluation
+    - file: how-to/agents
+      title: Configure agents and models
+    - file: how-to/add-task
+      title: Add a task
+    - file: how-to/task-validator
+      title: Validate tasks
+    - file: how-to/visualization
+      title: Visualize and compare runs
 
-  - caption: Examples
-    entries:
-      - file: examples/examples
-        title: Examples
+- caption: Examples
+  entries:
+    - file: examples/examples
+      title: Examples
 
-  - caption: About
-    entries:
-      - file: about/license
-        title: License
+- caption: Reference
+  entries:
+    - file: reference/api-reference
+      title: Configuration and API reference
+
+- caption: About
+  entries:
+    - file: about/license
+      title: License

--- a/docs/what-is-aka.rst
+++ b/docs/what-is-aka.rst
@@ -1,0 +1,57 @@
+.. meta::
+   :description: Learn what AgentKernelArena is — a standardized AMD evaluation arena for measuring AI coding agent performance on GPU kernel optimization tasks on ROCm.
+   :keywords: AgentKernelArena, GPU kernel, optimization, AI agents, ROCm, HIP, Triton, LLM, AMD, evaluation
+
+*************************
+What is AgentKernelArena?
+*************************
+
+AgentKernelArena is a standardized evaluation arena, built by AMD, that measures
+how well AI coding agents perform on real GPU kernel optimization tasks. It runs
+LLM-powered agents side-by-side on the same tasks in isolated workspaces and
+scores them with objective, reproducible metrics for compilation, correctness,
+and GPU performance.
+
+The AgentKernelArena source code is hosted in the
+`AMD-AGI/AgentKernelArena <https://github.com/AMD-AGI/AgentKernelArena>`_ GitHub
+repository.
+
+What AgentKernelArena does
+==========================
+
+AgentKernelArena gives each agent the same kernel task, runs it in a siloed,
+timestamped workspace, then evaluates the result through a common pipeline:
+
+* **Compile** -- Build the agent's kernel and confirm it compiles cleanly.
+* **Validate** -- Run the task's correctness check against a reference.
+* **Profile** -- Measure GPU execution time and compute speedup over a baseline.
+* **Score** -- Combine the results into a single comparable score.
+
+Key features
+============
+
+* **Multi-agent arena**: Cursor, Claude Code, Codex, SWE-agent, OpenEvolve
+  (GEAK), GEAK HIP, single-LLM-call, and custom agents.
+* **Multi-model support**: OpenAI, Anthropic, and other models through OpenRouter or
+  a local vLLM server.
+* **Task categories**: HIP (``hip2hip``), CUDA-to-HIP (``cuda2hip``), Triton
+  (``triton2triton``, ``instruction2triton``), Torch-to-HIP (``torch2hip``), and
+  FlyDSL (``flydsl2flydsl``).
+* **Objective metrics**: Automated compilation, correctness, and real GPU
+  performance speedups.
+* **Workspace isolation**: Each task runs in its own timestamped workspace for
+  reproducibility.
+* **A/B testing**: Run the same task set with and without a new Model Context
+  Protocol (MCP) server, skill, prompt, or tool to measure its real impact.
+* **Task validator**: An agent that runs 10 automated checks on task quality
+  before tasks enter the leaderboard.
+* **Visualization dashboard**: A static dashboard for comparing run reports.
+
+Use cases
+=========
+
+* Compare AI coding agents head-to-head on GPU kernel optimization.
+* Rank models and agent configurations on a standardized leaderboard.
+* A/B test whether a new agent capability (MCP server, skill, prompt) improves
+  outcomes under identical conditions.
+* Curate and validate a high-quality, self-contained GPU kernel task suite.


### PR DESCRIPTION
Edited and restructured docs according to our [Style Guide](https://amd.atlassian.net/wiki/spaces/MLSE/pages/744166036/ROCm+style+guide) and [Diataxis ](https://diataxis.fr/)information architecture guidance.