### PR TITLE
Add multi-GPU parallel Docker runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help docker-shell docker-check-agents docker-smoke docker-run docker-setup-flydsl \
+.PHONY: help docker-shell docker-check-agents docker-smoke docker-run docker-parallel-run docker-setup-flydsl \
         sync-perf-helpers check-perf-helpers materialize-perf-workspace \
         materialize-perf-task cleanup-works install-cursor-agent vllm
 
@@ -18,6 +18,7 @@ help:
 	@echo "make docker-check-agents - Verify Codex, Claude Code, and Cursor Agent login reuse in Docker"
 	@echo "make docker-smoke        - Verify Docker Python, ROCm tools, imports, and GPU access"
 	@echo "make docker-run CONFIG=config.yaml RUN_ARGS=\"--run-suffix test\" - Run benchmark in Docker"
+	@echo "make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1 - Run benchmark across one worker container per GPU"
 	@echo "                         Images: gfx942->mi30x, gfx950->mi35x; override with AKA_DOCKER_IMAGE=..."
 	@echo "make docker-setup-flydsl - Install FlyDSL into the container (needed for flydsl2flydsl tasks)"
 	@echo ""
@@ -49,6 +50,9 @@ docker-smoke:
 
 docker-run:
 	@$(DOCKER_RUNNER) run --config_name $(CONFIG) $(RUN_ARGS)
+
+docker-parallel-run:
+	@GPU_IDS="$(GPU_IDS)" $(DOCKER_RUNNER) parallel-run --config_name $(CONFIG) $(RUN_ARGS)
 
 # Install FlyDSL into the container's persistent pip user-base (the base image does
 # not ship it). Run once per machine/image; needed only for flydsl2flydsl tasks.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ AgentKernelArena enables systematic evaluation of AI agents on GPU kernel optimi
 - **Designed for Fair Comparison**: Standardized tasks, environments, prompts, and scoring for leaderboard-style evaluation
 - **A/B Testing for Agent Tools**: Compare whether a new MCP server, skill, prompt, or agent-side tool actually improves outcomes by running the same task set with and without it and comparing standardized scores
 - **Workspace Isolation**: Each task runs in a timestamped duplicate workspace for reproducibility
+- **Multi-GPU Parallel Runs**: On multi-GPU servers, run one isolated Docker worker per GPU so idle GPUs immediately claim the next task from a shared queue
 - **Comprehensive Logging**: Detailed logs with timestamps, prompts, outputs, and results for every task execution
 - **Flexible Configuration**: YAML-based configuration for tasks, agents, and LLM parameters
 
@@ -87,6 +88,12 @@ AgentKernelArena/
 8. **Post-Processing**: Run compilation, correctness tests, performance profiling, and scoring
 9. **Report Generation**: Generate comprehensive evaluation report with metrics
 
+For multi-GPU runs, the host-side Docker runner creates a shared `.parallel/`
+queue under the run directory and starts one long-lived worker container per GPU.
+Each worker claims tasks with an atomic descriptor move, runs one task at a time
+with only one GPU visible, and then claims the next task. Final post-processing
+runs once after all workers finish.
+
 ## Installation
 
 ### Prerequisites
@@ -147,6 +154,30 @@ workspace_directory_prefix: workspace
 
 ```bash
 make docker-run CONFIG=config.yaml
+```
+
+Run the same task set in parallel across multiple GPUs:
+
+```bash
+# Use explicit GPU IDs
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3,4,5,6,7
+
+# Or omit GPU_IDS to discover GPUs with rocm-smi --showid
+make docker-parallel-run CONFIG=config.yaml
+
+# Label the run directory
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1 RUN_ARGS="--run-suffix parallel_smoke"
+```
+
+`docker-parallel-run` starts one Docker worker per GPU. Each worker gets isolated
+agent state and cache directories, and sees a single logical GPU (`0`) inside the
+container. It supports normal optimization agents and `task_validator`.
+
+Resume a parallel run the same way as a serial run:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3 RUN_ARGS="--resume-latest"
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3 RUN_ARGS="--resume-run run_20260702_041903_parallel8"
 ```
 
 

--- a/agents/claude_code/agent_config.yaml
+++ b/agents/claude_code/agent_config.yaml
@@ -2,7 +2,7 @@ max_iterations: 3
 timeout_seconds: 3600
 python_path: null
 # Optional: set explicit Claude model / effort so logs record exact runtime settings.
-model: claude-opus-4-8
+model: claude-sonnet-5
 # Reasoning effort maxed out. Passed as `--effort`.
-# Valid for Opus 4.8: low | medium | high | xhigh | max  (max is the maximum).
+# Valid for Sonnet 5: low | medium | high | xhigh | max  (max is the maximum).
 effort: max

--- a/agents/task_validator/agent_config.yaml
+++ b/agents/task_validator/agent_config.yaml
@@ -9,7 +9,7 @@ python_path: null
 # claude_code: model -> `claude --model`,      effort -> `claude --effort`.
 # Example Claude Sonnet config: backend: claude_code, model: sonnet, effort: max.
 # Valid claude_code effort: low | medium | high | xhigh | max  (max is the maximum).
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 effort: max
 
 # Per-command timeouts (seconds) for each validation check

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ python -m sphinx -T -b html docs docs/_build/html
 | `reference/api-reference.md` | Configuration and API reference | `config.yaml` schema, task `config.yaml` schema, CLI flags, scoring, and the agent registry. |
 | `reference/benchmark-methodology.md` | Reference | Timing methodology, benchmark helper materialization, and speedup interpretation. |
 | `how-to/run-evaluation.md` | How-to | Configure `config.yaml`, run through Docker, resume runs, and read results. |
+| `how-to/parallel-run.md` | How-to | Run one isolated Docker worker per GPU, use the shared `.parallel/` task queue, resume parallel runs, and parallelize `task_validator`. |
 | `how-to/agents.md` | How-to | Supported agents, model providers, and A/B testing. |
 | `how-to/add-task.md` | How-to | Task directory layout, `config.yaml` fields, and task types. |
 | `how-to/task-validator.md` | How-to | The task_validator agent and its 10 checks. |

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -8,8 +8,8 @@ myst:
 # AgentKernelArena examples
 
 These walkthroughs assume you have completed [installation](../install/install.md)
-and can run the Docker runner (`make docker-smoke` passes). All runs go through
-`make docker-run`.
+and can run the Docker runner (`make docker-smoke` passes). Serial examples use
+`make docker-run`; multi-GPU examples use `make docker-parallel-run`.
 
 ## Example 1: Evaluate one agent on one task
 
@@ -128,7 +128,78 @@ Open the generated `validation_report.yaml` in the task workspace. The task must
 reach **PASS** (or **WARN** with justification) before merging. See
 [Validate tasks](../how-to/task-validator.md) for more information.
 
-## Example 5: Resume an interrupted run
+## Example 5: Run eight GPU workers in parallel
+
+On an 8-GPU server, start one Docker worker per GPU and let the workers share the
+same task queue:
+
+```yaml
+agent:
+  template: claude_code
+
+tasks:
+  - hip2hip/gpumode
+
+target_gpu_model: MI355X
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--run-suffix claude_parallel8"
+```
+
+The run directory contains normal per-task workspaces plus a scheduler queue:
+
+```text
+workspace_MI355X_claude_code/
+└── run_<timestamp>_claude_parallel8/
+    ├── .parallel/
+    │   ├── pending/
+    │   ├── running/
+    │   ├── done/
+    │   └── failed/
+    ├── hip2hip_gpumode_GELU_<timestamp>/
+    │   └── task_result.yaml
+    └── reports/
+        └── overall_report.txt
+```
+
+Each worker sees one logical GPU inside its container (`HIP_VISIBLE_DEVICES=0`,
+`CUDA_VISIBLE_DEVICES=0`) while `ROCR_VISIBLE_DEVICES` selects the host GPU.
+Post-processing runs once after all worker containers finish.
+
+## Example 6: Validate tasks in parallel
+
+The same queue works for `task_validator`. This is useful before merging a large
+batch of tasks:
+
+```yaml
+agent:
+  template: task_validator
+
+tasks:
+  - hip2hip/gpumode
+
+target_gpu_model: MI355X
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--run-suffix validator_parallel8"
+```
+
+Each task workspace writes `validation_report.yaml`, and the run directory gets
+one final `validation_summary.yaml` after all workers complete.
+
+## Example 7: Resume an interrupted run
 
 If a long run is interrupted, resume it without repeating completed tasks:
 
@@ -138,4 +209,11 @@ make docker-run CONFIG=config.yaml RUN_ARGS="--resume-latest"
 
 # Or resume a specific run directory
 make docker-run CONFIG=config.yaml RUN_ARGS="--resume-run run_20260617_101500"
+```
+
+For a parallel run, use the same resume arguments with `docker-parallel-run`:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3 RUN_ARGS="--resume-latest"
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3 RUN_ARGS="--resume-run run_20260617_101500_parallel8"
 ```

--- a/docs/how-to/parallel-run.md
+++ b/docs/how-to/parallel-run.md
@@ -1,0 +1,149 @@
+---
+myst:
+    html_meta:
+        "description": "Run AgentKernelArena evaluations across multiple GPUs with one Docker worker container per GPU, dynamic task claiming, isolated caches, and shared post-processing."
+        "keywords": "AgentKernelArena, multi-GPU, parallel run, Docker worker, GPU isolation, task_validator, ROCm"
+---
+
+# Run tasks in parallel across multiple GPUs
+
+Use `make docker-parallel-run` when one machine has multiple GPUs and you want
+AgentKernelArena to keep all of them busy. The parallel runner starts one
+long-lived Docker worker container per GPU. Each worker sees exactly one GPU,
+claims one task at a time from a shared queue, runs it to completion, and then
+claims the next available task.
+
+This keeps the serial `make docker-run` workflow unchanged while adding a
+host-side scheduler for multi-GPU servers.
+
+## Start a parallel run
+
+List the GPUs to use with `GPU_IDS`:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3
+```
+
+On an 8-GPU server:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3,4,5,6,7
+```
+
+If `GPU_IDS` is omitted, the runner discovers GPUs with `rocm-smi --showid` and
+starts one worker for each discovered GPU:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml
+```
+
+Use `RUN_ARGS` the same way as `docker-run`:
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--run-suffix claude_parallel8"
+```
+
+## How scheduling works
+
+The runner creates a shared queue in the run directory:
+
+```text
+workspace_<gpu>_<agent>/
+└── run_<timestamp>[_suffix]/
+    └── .parallel/
+        ├── pending/
+        ├── running/
+        ├── done/
+        └── failed/
+```
+
+Each task has one descriptor file. Workers claim tasks by atomically renaming a
+descriptor from `pending/` to `running/`. After the task finishes, the descriptor
+moves to `done/` or `failed/`. This prevents duplicate task claims while allowing
+faster tasks to free a GPU and immediately claim more work.
+
+After all workers exit, the runner starts a single post-processing container to
+aggregate results for the whole run.
+
+## GPU isolation
+
+Each worker container is assigned one host GPU. The Docker runner configures the
+container so that ROCm masks to the host GPU, while framework code inside the
+masked container sees that GPU as logical device `0`:
+
+```text
+AGENT_KERNEL_ARENA_HOST_GPU_ID=<host_gpu_id>
+ROCR_VISIBLE_DEVICES=<host_gpu_id>
+HIP_VISIBLE_DEVICES=0
+CUDA_VISIBLE_DEVICES=0
+GPU_DEVICE_ORDINAL=0
+```
+
+The runner also gives each worker its own temporary `HOME`, `CODEX_HOME`, and
+cache directories for Torch extensions, Triton, MIOpen, Matplotlib, and agent
+state. Host Codex, Claude Code, and Cursor auth/config directories are mounted
+read-only and copied into the worker-local home before the agent starts.
+
+## Resume a parallel run
+
+Resume works the same way as serial runs. Completed tasks are skipped, and
+unfinished tasks are returned to the pending queue.
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--resume-run run_20260702_041903_parallel8"
+```
+
+You can also resume the most recent run:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1 RUN_ARGS="--resume-latest"
+```
+
+Completion is detected from the per-task workspace:
+
+- Normal optimization agents: `task_result.yaml`
+- `task_validator`: `validation_report.yaml`
+
+## Run the task validator in parallel
+
+The `task_validator` agent uses the same worker queue. This is useful when
+validating many tasks before a release or leaderboard run:
+
+```yaml
+agent:
+  template: task_validator
+
+tasks:
+  - hip2hip/gpumode
+
+target_gpu_model: MI355X
+log_directory: logs
+workspace_directory_prefix: workspace
+```
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--run-suffix validator_parallel8"
+```
+
+The final `validation_summary.yaml` is written once after all workers complete.
+
+## Failure behavior
+
+If one task fails, its descriptor moves to `.parallel/failed/` and that worker
+continues with the next task. Other GPU workers keep running. At the end of the
+run, the final command returns nonzero if any descriptor is left in `failed/`,
+`pending/`, or `running/`.
+
+Task-level failures are different from runner failures. For example, an agent can
+successfully produce `task_result.yaml` with `pass_correctness: false`; that task
+is still considered completed by the scheduler and will appear in the aggregate
+report.

--- a/docs/how-to/run-evaluation.md
+++ b/docs/how-to/run-evaluation.md
@@ -74,6 +74,36 @@ The Docker runner currently supports Codex, Claude Code, and Cursor Agent login
 reuse from the host. It preflights the selected config before starting the
 benchmark run.
 
+## Run across multiple GPUs
+
+Use `make docker-parallel-run` when a server has multiple GPUs and the task set
+is large enough to keep them busy. The parallel runner starts one Docker worker
+container per GPU, masks each worker to one GPU, and lets workers claim tasks
+from a shared queue:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3,4,5,6,7
+```
+
+If `GPU_IDS` is omitted, the runner discovers GPU IDs with `rocm-smi --showid`:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml
+```
+
+`RUN_ARGS` works the same way as `docker-run`:
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1 \
+  RUN_ARGS="--run-suffix parallel_smoke"
+```
+
+Parallel runs support optimization agents and `task_validator`. See
+[Run tasks in parallel across multiple GPUs](parallel-run.md) for scheduling,
+GPU isolation, resume behavior, and failure handling.
+
 ## What happens during a run
 
 ```mermaid
@@ -112,6 +142,12 @@ make docker-run CONFIG=config.yaml RUN_ARGS="--resume-run run_20260617_101500"
 make docker-run CONFIG=config.yaml RUN_ARGS="--resume-latest"
 ```
 
+For a parallel run, use the same `RUN_ARGS` with `docker-parallel-run`:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3 RUN_ARGS="--resume-latest"
+```
+
 ## Read the results
 
 A run produces this layout under the workspace directory:
@@ -119,6 +155,11 @@ A run produces this layout under the workspace directory:
 ```text
 workspace_<gpu>_<agent>/
 └── run_<timestamp>/
+    ├── .parallel/              # present for docker-parallel-run
+    │   ├── pending/
+    │   ├── running/
+    │   ├── done/
+    │   └── failed/
     └── <task_name>_<timestamp>/
         ├── task_result.yaml      # per-task result + score
         └── ...                   # agent output, modified kernel, logs

--- a/docs/how-to/task-validator.md
+++ b/docs/how-to/task-validator.md
@@ -38,6 +38,20 @@ Each task workspace receives a `validation_report.yaml` with per-check results,
 and a `validation_summary.yaml` with aggregated statistics is written to the
 workspace root.
 
+For large validation batches on a multi-GPU server, use the parallel Docker
+runner. It starts one validator worker container per GPU and writes the same
+reports:
+
+```bash
+make docker-parallel-run \
+  CONFIG=config.yaml \
+  GPU_IDS=0,1,2,3,4,5,6,7 \
+  RUN_ARGS="--run-suffix validator_parallel8"
+```
+
+Parallel resume skips validator tasks whose workspace already contains
+`validation_report.yaml`.
+
 ## Validator configuration
 
 The validator's own backend and limits are set in

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ repository.
    .. grid-item-card:: How to
 
       * :doc:`Run an evaluation <how-to/run-evaluation>`
+      * :doc:`Run tasks in parallel across multiple GPUs <how-to/parallel-run>`
       * :doc:`Configure agents and models <how-to/agents>`
       * :doc:`Add a task <how-to/add-task>`
       * :doc:`Validate tasks <how-to/task-validator>`

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -57,6 +57,14 @@ make docker-run CONFIG=config.yaml
 make docker-run CONFIG=config.yaml RUN_ARGS="--run-suffix cursor_docker"
 ```
 
+Run across multiple GPUs by starting one isolated worker container per GPU:
+
+```bash
+make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1,2,3
+```
+
+If `GPU_IDS` is omitted, the runner discovers GPUs with `rocm-smi --showid`.
+
 ## Install agent CLIs
 
 Install whichever agents you plan to evaluate. For example:

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -50,11 +50,48 @@ The in-container `main.py` entrypoint accepts these flags:
 | `--resume-latest` | Resume the most recent run in the workspace |
 
 These flags are passed to the in-container entrypoint via `make docker-run`
-(`CONFIG=` sets `--config_name`; `RUN_ARGS=` forwards the rest):
+or `make docker-parallel-run` (`CONFIG=` sets `--config_name`; `RUN_ARGS=`
+forwards the rest):
 
 ```bash
 make docker-run CONFIG=config_triton.yaml RUN_ARGS="--run-suffix with_mcp"
+make docker-parallel-run CONFIG=config_triton.yaml GPU_IDS=0,1 RUN_ARGS="--run-suffix with_mcp_parallel"
 ```
+
+The following flags are internal implementation details used by
+`docker-parallel-run` and should not be passed manually in normal use:
+
+| Flag | Description |
+| --- | --- |
+| `--run-name <run_dir>` | Explicit run directory shared by parallel init, workers, and post-processing |
+| `--parallel-init` | Initialize the shared `.parallel/` queue |
+| `--parallel-worker` | Claim and execute tasks from the shared queue |
+| `--worker-id <id>` | Worker identifier used in queue descriptors and logs |
+| `--postprocess-only` | Aggregate results once after all workers finish |
+
+## Docker runner Make targets
+
+| Target | Description |
+| --- | --- |
+| `make docker-run CONFIG=config.yaml` | Run tasks serially in one Docker container |
+| `make docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1` | Run one Docker worker per listed GPU, using a shared dynamic task queue |
+| `make docker-smoke` | Verify Docker, ROCm runtime visibility, Python imports, and GPU access |
+| `make docker-check-agents` | Verify host agent CLI login reuse inside Docker |
+| `make docker-shell` | Open an interactive shell in the benchmark Docker runtime |
+
+`docker-parallel-run` accepts these environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `GPU_IDS` | Comma- or space-separated host GPU IDs. If omitted, the runner uses `rocm-smi --showid` |
+| `RUN_ARGS` | Additional `main.py` flags, such as `--run-suffix`, `--resume-run`, or `--resume-latest` |
+| `AKA_LOGICAL_GPU` | Logical GPU index inside a masked worker container. Defaults to `0` and normally should not be changed |
+
+Each parallel worker sets `ROCR_VISIBLE_DEVICES` to the host GPU ID and sets
+`HIP_VISIBLE_DEVICES`, `CUDA_VISIBLE_DEVICES`, and `GPU_DEVICE_ORDINAL` to the
+logical GPU index inside the masked container. See
+[Run tasks in parallel across multiple GPUs](../how-to/parallel-run.md) for the
+full scheduling model.
 
 ## Task configuration
 

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -26,7 +26,7 @@ The following software versions are required or verified.
 
 | Component | Version | Notes |
 | --- | --- | --- |
-| Docker | Current stable release | Required; evaluations run through `make docker-run`. |
+| Docker | Current stable release | Required; serial evaluations run through `make docker-run`; multi-GPU evaluations run through `make docker-parallel-run`. |
 | SGLang benchmark image | `lmsysorg/sglang:v0.5.12-rocm720-mi30x` for `gfx942`; `lmsysorg/sglang:v0.5.12-rocm720-mi35x` for `gfx950` | Override with `AKA_DOCKER_IMAGE`, `AKA_DOCKER_IMAGE_GFX942`, or `AKA_DOCKER_IMAGE_GFX950`. |
 | ROCm | Bundled in the selected SGLang image | The default images are ROCm 7.2 based. |
 | Python | Provided by the image (e.g. 3.10) | Bundled in the SGLang image. |

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -35,6 +35,9 @@ AgentKernelArena 0.1.0 includes the following features.
   `src/tools/perf/` and materialize them into task workspaces at runtime.
 - **Resumable runs**: resume an interrupted run and skip completed tasks with
   `--resume-run` or `--resume-latest`.
+- **Multi-GPU parallel runs**: use `make docker-parallel-run` to start one
+  isolated Docker worker per GPU, claim tasks from a shared queue, and aggregate
+  results once after all workers finish.
 - **A/B testing**: run the same task set with and without an agent-side
   capability to measure its real impact.
 - **Task validator**: a dedicated agent that runs 10 automated quality checks on
@@ -46,6 +49,8 @@ AgentKernelArena 0.1.0 includes the following features.
 
 The following limitations are present in this release.
 
-- Agents can hang during task execution and block test completion.
+- A single agent task can still run until its configured timeout, but in
+  `docker-parallel-run` other GPU workers continue processing the remaining
+  queue.
 - The published leaderboard is forthcoming; the live demo is illustrative only.
 - Task suites for several categories are being expanded toward 100+ tasks each.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -25,6 +25,8 @@ subtrees:
   entries:
     - file: how-to/run-evaluation
       title: Run an evaluation
+    - file: how-to/parallel-run
+      title: Run tasks in parallel across multiple GPUs
     - file: how-to/agents
       title: Configure agents and models
     - file: how-to/add-task

--- a/docs/what-is-aka.rst
+++ b/docs/what-is-aka.rst
@@ -45,6 +45,8 @@ Key features
   baseline and optimized runs so mixed-method comparisons are visible.
 * **Workspace isolation**: Each task runs in its own timestamped workspace for
   reproducibility.
+* **Multi-GPU parallel runs**: On multi-GPU servers, start one isolated Docker
+  worker per GPU and keep idle GPUs busy with a shared task queue.
 * **A/B testing**: Run the same task set with and without a new Model Context
   Protocol (MCP) server, skill, prompt, or tool to measure its real impact.
 * **Task validator**: An agent that runs 10 automated checks on task quality
@@ -58,4 +60,6 @@ Use cases
 * Rank models and agent configurations on a standardized leaderboard.
 * A/B test whether a new agent capability (MCP server, skill, prompt) improves
   outcomes under identical conditions.
+* Run large task suites faster by distributing tasks across all GPUs on a
+  multi-GPU server.
 * Curate and validate a high-quality, self-contained GPU kernel task suite.

--- a/main.py
+++ b/main.py
@@ -1,279 +1,417 @@
 # Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
-import re
-import yaml
-import logging
 import argparse
-from pathlib import Path
+import logging
+import os
+import re
 from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
 from src.tasks import get_task_config
-from src.preprocessing import setup_workspace, setup_rocm_env, is_task_complete
+from src.preprocessing import (
+    get_task_workspace_path,
+    is_task_complete,
+    setup_rocm_env,
+    setup_workspace,
+)
 from src.module_registration import AgentType, load_agent_launcher, load_post_processing_handler
-from src.evaluator import measure_baseline, evaluate_kernel, write_task_result
+from src.evaluator import (
+    evaluate_compilation,
+    evaluate_kernel,
+    measure_baseline,
+    write_task_result,
+)
 from src.runtime_env import apply_subprocess_python_path
 from src.perf_helper_materialization import materialize_perf_helpers_in_workspace
 
 
+QUEUE_DIR_NAME = ".parallel"
+QUEUE_STATES = ("pending", "running", "done", "failed")
+
+
 parser = argparse.ArgumentParser(description="arguments for AgentKernelArena")
-parser.add_argument("--config_name", type=str, default="config.yaml",help="the config of AgentKernelArena, default set to config. \
-                    You can set different tasks in different config yaml file in order to run multi evaluation task in one folder.")
-parser.add_argument("--run-suffix", type=str, default=None,
-                    help="Suffix appended to the run directory name, e.g. --run-suffix composer2_hip → run_20260416_120000_composer2_hip")
-parser.add_argument("--resume-run", type=str, default=None,
-                    help="Resume an existing run by specifying the run directory name (e.g., run_20250115_143022)")
-parser.add_argument("--resume-latest", action="store_true",
-                    help="Resume the most recent run in the workspace")
+parser.add_argument(
+    "--config_name",
+    type=str,
+    default="config.yaml",
+    help=(
+        "the config of AgentKernelArena, default set to config. You can set "
+        "different tasks in different config yaml file in order to run multi "
+        "evaluation task in one folder."
+    ),
+)
+parser.add_argument(
+    "--run-suffix",
+    type=str,
+    default=None,
+    help="Suffix appended to the run directory name, e.g. --run-suffix composer2_hip -> run_20260416_120000_composer2_hip",
+)
+parser.add_argument(
+    "--resume-run",
+    type=str,
+    default=None,
+    help="Resume an existing run by specifying the run directory name (e.g., run_20250115_143022)",
+)
+parser.add_argument(
+    "--resume-latest",
+    action="store_true",
+    help="Resume the most recent run in the workspace",
+)
+parser.add_argument(
+    "--run-name",
+    type=str,
+    default=None,
+    help="Internal: explicit run directory name for parallel workers/post-processing",
+)
+parser.add_argument(
+    "--parallel-init",
+    action="store_true",
+    help="Internal: initialize a shared parallel task queue for --run-name",
+)
+parser.add_argument(
+    "--parallel-worker",
+    action="store_true",
+    help="Internal: run tasks claimed from the shared parallel queue",
+)
+parser.add_argument(
+    "--worker-id",
+    type=str,
+    default=None,
+    help="Internal: worker identifier used by --parallel-worker",
+)
+parser.add_argument(
+    "--postprocess-only",
+    action="store_true",
+    help="Internal: run only final post-processing for --run-name",
+)
 
-def main() -> None:
-    """Main entry point for AgentKernelArena framework."""
-    args = parser.parse_args()
 
-    # Load config.yaml
-    with open(args.config_name, 'r') as f:
-        config = yaml.safe_load(f)
+def _extract_timestamp(run_directory_name: str) -> str | None:
+    m = re.match(r"^run_(\d{8}_\d{6})", run_directory_name)
+    return m.group(1) if m else None
 
-    # Extract configuration
-    tasks = config['tasks']  # Now directly a list
-    agent_string = config['agent']['template']
-    target_gpu_model = config['target_gpu_model']
 
-    log_directory = config['log_directory']
-    workspace_directory_prefix = config['workspace_directory_prefix']
+def _run_suffix_from_name(run_directory_name: str) -> str:
+    m = re.match(r"^run_\d{8}_\d{6}(_[A-Za-z0-9._-]+)?$", run_directory_name)
+    return m.group(1) if m and m.group(1) else ""
 
-    # Convert agent string to AgentType enum
+
+def _validate_run_suffix(run_suffix: str | None) -> bool:
+    return run_suffix is None or bool(re.fullmatch(r"[A-Za-z0-9._-]+", run_suffix))
+
+
+def _load_config(config_name: str) -> dict[str, Any]:
+    with open(config_name, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _resolve_agent(agent_string: str) -> AgentType | None:
     try:
-        agent = AgentType.from_string(agent_string)
+        return AgentType.from_string(agent_string)
     except ValueError as e:
         print(f"Error: {e}")
-        return
+        return None
 
-    # Build workspace directory name
-    workspace_directory_name = f"{workspace_directory_prefix}_{target_gpu_model}_{agent.value}"    
-    project_root = Path(__file__).resolve().parent
-    workspace_directory = (project_root / workspace_directory_name).resolve()
 
-    if args.run_suffix and not re.fullmatch(r"[A-Za-z0-9._-]+", args.run_suffix):
-        print("Error: --run-suffix may only contain letters, numbers, dot, underscore, and dash")
-        return
+def _resolve_run(
+    args: argparse.Namespace,
+    workspace_directory: Path,
+) -> tuple[Path, str, str, bool] | None:
+    """Return (run_directory, run_directory_name, timestamp, resume_mode)."""
+    if args.run_name:
+        run_directory_name = args.run_name
+        timestamp = _extract_timestamp(run_directory_name)
+        if not timestamp:
+            print(
+                f"Error: Invalid run directory name format: {run_directory_name}. "
+                "Expected format: run_YYYYMMDD_HHMMSS[_suffix]"
+            )
+            return None
+        run_directory = workspace_directory / run_directory_name
+        resume_mode = run_directory.exists()
+        run_directory.mkdir(parents=True, exist_ok=True)
+        return run_directory, run_directory_name, timestamp, resume_mode
 
-    # Handle resume functionality
-    resume_mode = False
     if args.resume_run:
-        # Resume specific run
         run_directory_name = args.resume_run
         run_directory = workspace_directory / run_directory_name
         if not run_directory.exists():
             print(f"Error: Run directory does not exist: {run_directory}")
-            return
-        resume_mode = True
-        # Extract the YYYYMMDD_HHMMSS timestamp from run directory name.
-        # The name may include a suffix: run_20260429_194009_claude_opus_hip
-        # Task directories use only the timestamp portion, not the suffix.
-        m = re.match(r"^run_(\d{8}_\d{6})", run_directory_name)
-        if m:
-            timestamp = m.group(1)
-        else:
-            print(f"Error: Invalid run directory name format: {run_directory_name}. Expected format: run_YYYYMMDD_HHMMSS[_suffix]")
-            return
-    elif args.resume_latest:
-        # Resume latest run
-        # Find all run directories and get the most recent one
-        run_dirs = sorted([d for d in workspace_directory.iterdir()
-                          if d.is_dir()
-                          and d.name.startswith("run_")
-                          and not d.name.endswith("_heldout")],
-                         key=lambda x: x.name, reverse=True)
+            return None
+        timestamp = _extract_timestamp(run_directory_name)
+        if not timestamp:
+            print(
+                f"Error: Invalid run directory name format: {run_directory_name}. "
+                "Expected format: run_YYYYMMDD_HHMMSS[_suffix]"
+            )
+            return None
+        return run_directory, run_directory_name, timestamp, True
+
+    if args.resume_latest:
+        run_dirs = sorted(
+            [
+                d
+                for d in workspace_directory.iterdir()
+                if d.is_dir() and d.name.startswith("run_") and not d.name.endswith("_heldout")
+            ],
+            key=lambda x: x.name,
+            reverse=True,
+        )
         if not run_dirs:
             print(f"Error: No run directories found in {workspace_directory}")
-            return
+            return None
         run_directory = run_dirs[0]
         run_directory_name = run_directory.name
-        resume_mode = True
-        # Extract the YYYYMMDD_HHMMSS timestamp (same regex as --resume-run)
-        m = re.match(r"^run_(\d{8}_\d{6})", run_directory_name)
-        if m:
-            timestamp = m.group(1)
-        else:
-            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    else:
-        # Create new run
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        suffix = f"_{args.run_suffix}" if args.run_suffix else ""
-        run_directory_name = f"run_{timestamp}{suffix}"
-        run_directory = workspace_directory / run_directory_name
-        run_directory.mkdir(parents=True, exist_ok=True)
-    log_dir = Path(log_directory)
+        timestamp = _extract_timestamp(run_directory_name) or datetime.now().strftime("%Y%m%d_%H%M%S")
+        return run_directory, run_directory_name, timestamp, True
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = f"_{args.run_suffix}" if args.run_suffix else ""
+    run_directory_name = f"run_{timestamp}{suffix}"
+    run_directory = workspace_directory / run_directory_name
+    run_directory.mkdir(parents=True, exist_ok=True)
+    return run_directory, run_directory_name, timestamp, False
+
+
+def _configure_logging(
+    config: dict[str, Any],
+    agent: AgentType,
+    timestamp: str,
+    run_directory_name: str,
+    args: argparse.Namespace,
+    role: str | None = None,
+) -> logging.Logger:
+    log_dir = Path(config["log_directory"])
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_suffix = f"_{args.run_suffix}" if args.run_suffix else ""
-    log_filename = f"{target_gpu_model}_{agent.value}_{timestamp}{log_suffix}.log"
+
+    log_suffix = f"_{args.run_suffix}" if args.run_suffix else _run_suffix_from_name(run_directory_name)
+    role_suffix = f"_{role}" if role else ""
+    log_filename = f"{config['target_gpu_model']}_{agent.value}_{timestamp}{log_suffix}{role_suffix}.log"
     log_path = log_dir / log_filename
 
-    # Configure logging
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+        handler.close()
+
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s',
+        format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
             logging.FileHandler(log_path),
-            logging.StreamHandler()  # Also print to console
-        ]
+            logging.StreamHandler(),
+        ],
     )
     logger = logging.getLogger(__name__)
-
     logger.info("=" * 80)
     logger.info("AgentKernelArena Framework Started")
     logger.info("=" * 80)
     logger.info(f"Log file: {log_path}")
+    return logger
+
+
+def _discover_tasks(tasks: list[str]) -> dict[str, str]:
+    if "all" in tasks:
+        return get_task_config()
+
+    task_config_dict: dict[str, str] = {}
+    for category in tasks:
+        task_config_dict.update(get_task_config(category=category))
+    return task_config_dict
+
+
+def _build_context(
+    args: argparse.Namespace,
+    *,
+    need_agent_launcher: bool,
+    role: str | None = None,
+) -> dict[str, Any] | None:
+    if not _validate_run_suffix(args.run_suffix):
+        print("Error: --run-suffix may only contain letters, numbers, dot, underscore, and dash")
+        return None
+
+    config = _load_config(args.config_name)
+    tasks = config["tasks"]
+    agent = _resolve_agent(config["agent"]["template"])
+    if agent is None:
+        return None
+
+    project_root = Path(__file__).resolve().parent
+    workspace_directory_name = (
+        f"{config['workspace_directory_prefix']}_{config['target_gpu_model']}_{agent.value}"
+    )
+    workspace_directory = (project_root / workspace_directory_name).resolve()
+    resolved_run = _resolve_run(args, workspace_directory)
+    if resolved_run is None:
+        return None
+    run_directory, run_directory_name, timestamp, resume_mode = resolved_run
+
+    logger = _configure_logging(config, agent, timestamp, run_directory_name, args, role=role)
     logger.info(f"Agent: {agent.value}")
-    logger.info(f"Target Architecture: {target_gpu_model}")
+    logger.info(f"Target Architecture: {config['target_gpu_model']}")
     logger.info(f"Workspace Directory: {workspace_directory}")
     logger.info(f"Run Directory: {run_directory}")
-    if resume_mode:
-        logger.info(f"RESUME MODE: Resuming existing run {run_directory_name}")
-    else:
-        logger.info(f"NEW RUN: Creating new run {run_directory_name}")
+    logger.info(f"{'RESUME' if resume_mode else 'NEW'} RUN: {run_directory_name}")
+    if args.worker_id is not None:
+        logger.info(f"Parallel Worker ID: {args.worker_id}")
+    for env_name in (
+        "AGENT_KERNEL_ARENA_HOST_GPU_ID",
+        "ROCR_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+        "GPU_DEVICE_ORDINAL",
+    ):
+        if os.environ.get(env_name):
+            logger.info(f"{env_name}={os.environ[env_name]}")
 
     python_path = apply_subprocess_python_path()
     logger.info(f"Subprocess Python environment: {python_path}")
+    setup_rocm_env(config["target_gpu_model"], logger)
 
-    # Set PYTORCH_ROCM_ARCH based on target_gpu_model before any task runs
-    setup_rocm_env(target_gpu_model, logger)
+    agent_launcher = None
+    if need_agent_launcher:
+        try:
+            agent_launcher = load_agent_launcher(agent, logger)
+        except Exception as e:
+            logger.error(f"Failed to load agent launcher: {e}")
+            return None
 
-    # Load agent launcher
-    try:
-        agent_launcher = load_agent_launcher(agent, logger)
-    except Exception as e:
-        logger.error(f"Failed to load agent launcher: {e}")
-        return
-
-
-    # Get task config
-    if 'all' in tasks:
-        task_config_dict = get_task_config()
-    else:
-        task_config_dict = {}
-        for category in tasks:
-            task_config_dict.update(get_task_config(category=category))
-
-    # Filter out completed tasks if resuming
-    if resume_mode:
-        original_task_count = len(task_config_dict)
-        tasks_to_run = {}
-        skipped_tasks = []
-        
-        for task_name, task_config_dir in task_config_dict.items():
-            if is_task_complete(run_directory, task_name, timestamp):
-                skipped_tasks.append(task_name)
-                logger.info(f"Skipping completed task: {task_name}")
-            else:
-                tasks_to_run[task_name] = task_config_dir
-        
-        task_config_dict = tasks_to_run
-        
-        logger.info(f"Resume mode: {len(skipped_tasks)} tasks already completed, {len(task_config_dict)} tasks remaining")
-        if skipped_tasks:
-            logger.info(f"Skipped tasks: {skipped_tasks}")
-        if len(task_config_dict) == 0:
-            logger.info("All tasks are already completed. Nothing to run.")
-            return
-
-    logger.info(f"Found {len(task_config_dict)} tasks to execute")
+    task_config_dict = _discover_tasks(tasks)
+    logger.info(f"Found {len(task_config_dict)} configured task(s)")
     logger.info(f"Tasks: {list(task_config_dict.keys())}")
 
-    # Collect workspace paths for post-processing
-    workspace_paths = []
+    return {
+        "args": args,
+        "config": config,
+        "agent": agent,
+        "agent_launcher": agent_launcher,
+        "workspace_directory": workspace_directory,
+        "run_directory": run_directory,
+        "run_directory_name": run_directory_name,
+        "timestamp": timestamp,
+        "resume_mode": resume_mode,
+        "logger": logger,
+        "task_config_dict": task_config_dict,
+    }
 
-    # Run tasks
-    for idx, (task_name, task_config_dir) in enumerate(task_config_dict.items(), 1):
-        logger.info("=" * 80)
-        logger.info(f"Task {idx}/{len(task_config_dict)}: {task_name}")
-        logger.info("=" * 80)
-        
-        try:
-            # Setup workspace
-            workspace_path = setup_workspace(task_config_dir, run_directory, timestamp, logger, task_name=task_name)
-            
-            # Load task config for evaluation
-            with open(task_config_dir, 'r') as f:
-                task_config = yaml.safe_load(f)
-            
-            task_type = task_config.get('task_type', '')
 
-            # The task_validator inspects the task and writes its own
-            # validation_report.yaml; it does not optimize the kernel. Skip the whole
-            # benchmark pipeline for it (baseline compile/measure, optimized
-            # evaluation, and perf plots) — those would only re-measure the unchanged
-            # kernel and emit a meaningless ~1.0x task_result.yaml plus plots. The
-            # validator runs its own compile/correctness/performance checks.
-            is_validator = (agent == AgentType.TASK_VALIDATOR)
+def _filter_completed_tasks(
+    task_config_dict: dict[str, str],
+    run_directory: Path,
+    timestamp: str,
+    agent: AgentType,
+    logger: logging.Logger,
+) -> dict[str, str]:
+    tasks_to_run: dict[str, str] = {}
+    skipped_tasks = []
 
-            baseline_cases = []
-            if is_validator:
-                logger.info("task_validator run: skipping baseline/evaluation/perf-plot benchmark pipeline")
-            elif task_type == 'torch2hip':
-                logger.info("torch2hip task: skipping baseline compilation, measuring PyTorch baseline directly...")
-                baseline_cases = measure_baseline(workspace_path, task_config, logger)
+    for task_name, task_config_dir in task_config_dict.items():
+        if is_task_complete(run_directory, task_name, timestamp, agent.value):
+            skipped_tasks.append(task_name)
+            logger.info(f"Skipping completed task: {task_name}")
+        else:
+            tasks_to_run[task_name] = task_config_dir
+
+    logger.info(
+        f"Resume mode: {len(skipped_tasks)} task(s) already completed, "
+        f"{len(tasks_to_run)} task(s) remaining"
+    )
+    if skipped_tasks:
+        logger.info(f"Skipped tasks: {skipped_tasks}")
+    return tasks_to_run
+
+
+def run_task(
+    *,
+    eval_config: dict[str, Any],
+    agent: AgentType,
+    agent_launcher: Any,
+    task_name: str,
+    task_config_dir: str,
+    run_directory: Path,
+    timestamp: str,
+    logger: logging.Logger,
+    task_index: int,
+    total_tasks: int,
+) -> tuple[bool, Path | None]:
+    workspace_path: Path | None = None
+    logger.info("=" * 80)
+    logger.info(f"Task {task_index}/{total_tasks}: {task_name}")
+    logger.info("=" * 80)
+
+    try:
+        workspace_path = setup_workspace(
+            task_config_dir,
+            run_directory,
+            timestamp,
+            logger,
+            task_name=task_name,
+        )
+
+        with open(task_config_dir, "r") as f:
+            task_config = yaml.safe_load(f) or {}
+
+        task_type = task_config.get("task_type", "")
+        is_validator = agent == AgentType.TASK_VALIDATOR
+
+        baseline_cases = []
+        if is_validator:
+            logger.info("task_validator run: skipping baseline/evaluation/perf-plot benchmark pipeline")
+        elif task_type == "torch2hip":
+            logger.info("torch2hip task: skipping baseline compilation, measuring PyTorch baseline directly...")
+            baseline_cases = measure_baseline(workspace_path, task_config, logger)
+        else:
+            logger.info("Compiling original kernel for baseline measurement...")
+            pass_compilation, comp_error = evaluate_compilation(workspace_path, task_config, logger)
+            if not pass_compilation:
+                logger.warning(f"Baseline compilation failed: {comp_error}")
+                logger.warning("Baseline measurement will be skipped")
+                baseline_cases = []
             else:
-                from src.evaluator import evaluate_compilation
-                logger.info("Compiling original kernel for baseline measurement...")
-                pass_compilation, comp_error = evaluate_compilation(workspace_path, task_config, logger)
-                if not pass_compilation:
-                    logger.warning(f"Baseline compilation failed: {comp_error}")
-                    logger.warning("Baseline measurement will be skipped")
-                    baseline_cases = []
-                else:
-                    logger.info("Measuring baseline performance...")
-                    baseline_cases = measure_baseline(workspace_path, task_config, logger)
+                logger.info("Measuring baseline performance...")
+                baseline_cases = measure_baseline(workspace_path, task_config, logger)
 
-            # Launch agent (agent should only generate optimized kernel)
-            logger.info(f"Launching agent: {agent.value}")
+        logger.info(f"Launching agent: {agent.value}")
+        agent_launcher(
+            eval_config=eval_config,
+            task_config_dir=task_config_dir,
+            workspace=str(workspace_path),
+        )
+        logger.info("Agent execution completed")
 
-            # For agentic approaches (cursor, claude_code, etc.)
-            result = agent_launcher(
-                eval_config=config,
-                task_config_dir=task_config_dir,
-                workspace=str(workspace_path)
+        if not is_validator:
+            materialize_perf_helpers_in_workspace(workspace_path, logger=logger)
+            logger.info("Running centralized evaluation...")
+            evaluation_results = evaluate_kernel(
+                workspace_path,
+                task_config,
+                baseline_cases,
+                logger,
+            )
+            write_task_result(
+                workspace_path,
+                evaluation_results,
+                baseline_cases,
+                task_name,
+                agent.value,
+                logger,
             )
 
-            logger.info(f"Agent execution completed")
+        if not is_task_complete(run_directory, task_name, timestamp, agent.value):
+            expected_report = "validation_report.yaml" if is_validator else "task_result.yaml"
+            logger.error(f"Task {task_name} did not produce expected completion report: {expected_report}")
+            return False, workspace_path
 
-            if not is_validator:
-                # Agents work inside the task workspace and could accidentally
-                # modify generated perf helpers. Re-materialize from src/tools/perf/
-                # immediately before scoring so benchmark methodology stays
-                # canonical.
-                materialize_perf_helpers_in_workspace(workspace_path, logger=logger)
+        logger.info(f"Task {task_name} completed successfully")
+        return True, workspace_path
+    except Exception as e:
+        logger.error(f"Task {task_name} failed with error: {e}", exc_info=True)
+        return False, workspace_path
 
-                # Centralized evaluation of optimized kernel
-                logger.info("Running centralized evaluation...")
-                evaluation_results = evaluate_kernel(
-                    workspace_path,
-                    task_config,
-                    baseline_cases,
-                    logger
-                )
 
-                # Write standardized task_result.yaml
-                write_task_result(
-                    workspace_path,
-                    evaluation_results,
-                    baseline_cases,
-                    task_name,
-                    agent.value,
-                    logger
-                )
-
-            logger.info(f"Task {task_name} completed successfully")
-
-            # Add workspace path to list for post-processing
-            workspace_paths.append(str(workspace_path))
-
-        except Exception as e:
-            logger.error(f"Task {task_name} failed with error: {e}", exc_info=True)
-            # Still add workspace path even if task failed (for post-processing to record failure)
-            if 'workspace_path' in locals():
-                workspace_paths.append(str(workspace_path))
-            continue
-
-    # Run post-processing to generate report
+def run_post_processing(agent: AgentType, workspace_paths: list[str], logger: logging.Logger) -> None:
     logger.info("=" * 80)
     logger.info("Running Post-Processing")
     logger.info("=" * 80)
@@ -286,10 +424,264 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Post-processing failed: {e}", exc_info=True)
 
-    logger.info("=" * 80)
-    logger.info("AgentKernelArena Framework Completed")
-    logger.info("=" * 80)
 
+def _queue_root(run_directory: Path) -> Path:
+    return run_directory / QUEUE_DIR_NAME
+
+
+def _queue_state_dir(run_directory: Path, state: str) -> Path:
+    return _queue_root(run_directory) / state
+
+
+def _descriptor_name(index: int, task_name: str) -> str:
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", task_name).strip("_")
+    return f"{index:06d}_{safe_name or 'task'}.yaml"
+
+
+def _write_descriptor(path: Path, payload: dict[str, Any]) -> None:
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    with tmp_path.open("w") as f:
+        yaml.safe_dump(payload, f, default_flow_style=False, sort_keys=False)
+    tmp_path.replace(path)
+
+
+def _read_descriptor(path: Path) -> dict[str, Any]:
+    with path.open("r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def initialize_parallel_queue(context: dict[str, Any]) -> None:
+    run_directory: Path = context["run_directory"]
+    task_config_dict: dict[str, str] = context["task_config_dict"]
+    timestamp: str = context["timestamp"]
+    agent: AgentType = context["agent"]
+    logger: logging.Logger = context["logger"]
+
+    for state in QUEUE_STATES:
+        _queue_state_dir(run_directory, state).mkdir(parents=True, exist_ok=True)
+
+    for state in QUEUE_STATES:
+        for descriptor in _queue_state_dir(run_directory, state).glob("*.yaml"):
+            descriptor.unlink()
+
+    total_tasks = len(task_config_dict)
+    queued = 0
+    completed = 0
+    for index, (task_name, task_config_dir) in enumerate(task_config_dict.items(), 1):
+        workspace_path = get_task_workspace_path(run_directory, task_name, timestamp)
+        payload = {
+            "index": index,
+            "total_tasks": total_tasks,
+            "task_name": task_name,
+            "task_config_dir": task_config_dir,
+            "workspace_path": str(workspace_path),
+        }
+        if is_task_complete(run_directory, task_name, timestamp, agent.value):
+            payload["status"] = "already_complete"
+            state = "done"
+            completed += 1
+        else:
+            payload["status"] = "pending"
+            state = "pending"
+            queued += 1
+        _write_descriptor(_queue_state_dir(run_directory, state) / _descriptor_name(index, task_name), payload)
+
+    logger.info(
+        f"Parallel queue initialized: queued={queued}, already_complete={completed}, "
+        f"total={total_tasks}"
+    )
+
+
+def claim_next_descriptor(run_directory: Path, worker_id: str, logger: logging.Logger) -> Path | None:
+    pending_dir = _queue_state_dir(run_directory, "pending")
+    running_dir = _queue_state_dir(run_directory, "running")
+    running_dir.mkdir(parents=True, exist_ok=True)
+
+    for descriptor in sorted(pending_dir.glob("*.yaml")):
+        claimed = running_dir / f"worker_{worker_id}__{descriptor.name}"
+        try:
+            descriptor.rename(claimed)
+            logger.info(f"Claimed task descriptor: {claimed.name}")
+            return claimed
+        except FileNotFoundError:
+            continue
+    return None
+
+
+def finish_descriptor(
+    descriptor: Path,
+    state: str,
+    *,
+    workspace_path: Path | None,
+    worker_id: str,
+) -> None:
+    payload = _read_descriptor(descriptor)
+    payload["status"] = state
+    payload["worker_id"] = worker_id
+    if workspace_path is not None:
+        payload["workspace_path"] = str(workspace_path)
+    _write_descriptor(descriptor, payload)
+    final_dir = descriptor.parent.parent / state
+    final_dir.mkdir(parents=True, exist_ok=True)
+    descriptor.rename(final_dir / descriptor.name)
+
+
+def collect_existing_workspace_paths(
+    run_directory: Path,
+    task_config_dict: dict[str, str],
+    timestamp: str,
+) -> list[str]:
+    workspace_paths = []
+    for task_name in task_config_dict:
+        workspace_path = get_task_workspace_path(run_directory, task_name, timestamp)
+        if workspace_path.exists():
+            workspace_paths.append(str(workspace_path))
+    return workspace_paths
+
+
+def run_serial(args: argparse.Namespace) -> int:
+    context = _build_context(args, need_agent_launcher=True)
+    if context is None:
+        return 1
+
+    task_config_dict = context["task_config_dict"]
+    if context["resume_mode"]:
+        task_config_dict = _filter_completed_tasks(
+            task_config_dict,
+            context["run_directory"],
+            context["timestamp"],
+            context["agent"],
+            context["logger"],
+        )
+
+    if not task_config_dict:
+        context["logger"].info("All tasks are already completed. Nothing to run.")
+        return 0
+
+    workspace_paths: list[str] = []
+    total_tasks = len(task_config_dict)
+    for index, (task_name, task_config_dir) in enumerate(task_config_dict.items(), 1):
+        _, workspace_path = run_task(
+            eval_config=context["config"],
+            agent=context["agent"],
+            agent_launcher=context["agent_launcher"],
+            task_name=task_name,
+            task_config_dir=task_config_dir,
+            run_directory=context["run_directory"],
+            timestamp=context["timestamp"],
+            logger=context["logger"],
+            task_index=index,
+            total_tasks=total_tasks,
+        )
+        if workspace_path is not None:
+            workspace_paths.append(str(workspace_path))
+
+    run_post_processing(context["agent"], workspace_paths, context["logger"])
+    context["logger"].info("=" * 80)
+    context["logger"].info("AgentKernelArena Framework Completed")
+    context["logger"].info("=" * 80)
+    return 0
+
+
+def run_parallel_init(args: argparse.Namespace) -> int:
+    context = _build_context(args, need_agent_launcher=False, role="parallel_init")
+    if context is None:
+        return 1
+    initialize_parallel_queue(context)
+    context["logger"].info(f"Parallel run name: {context['run_directory_name']}")
+    context["logger"].info("Parallel queue initialization completed")
+    return 0
+
+
+def run_parallel_worker(args: argparse.Namespace) -> int:
+    worker_id = args.worker_id or "0"
+    context = _build_context(
+        args,
+        need_agent_launcher=True,
+        role=f"worker{worker_id}",
+    )
+    if context is None:
+        return 1
+
+    failures = 0
+    processed = 0
+    while True:
+        descriptor = claim_next_descriptor(context["run_directory"], worker_id, context["logger"])
+        if descriptor is None:
+            break
+
+        payload = _read_descriptor(descriptor)
+        success, workspace_path = run_task(
+            eval_config=context["config"],
+            agent=context["agent"],
+            agent_launcher=context["agent_launcher"],
+            task_name=payload["task_name"],
+            task_config_dir=payload["task_config_dir"],
+            run_directory=context["run_directory"],
+            timestamp=context["timestamp"],
+            logger=context["logger"],
+            task_index=int(payload.get("index", processed + 1)),
+            total_tasks=int(payload.get("total_tasks", len(context["task_config_dict"]))),
+        )
+        processed += 1
+        if success:
+            finish_descriptor(descriptor, "done", workspace_path=workspace_path, worker_id=worker_id)
+        else:
+            failures += 1
+            finish_descriptor(descriptor, "failed", workspace_path=workspace_path, worker_id=worker_id)
+
+    context["logger"].info(
+        f"Parallel worker {worker_id} completed: processed={processed}, failures={failures}"
+    )
+    return 1 if failures else 0
+
+
+def run_postprocess_only(args: argparse.Namespace) -> int:
+    context = _build_context(args, need_agent_launcher=False, role="postprocess")
+    if context is None:
+        return 1
+
+    workspace_paths = collect_existing_workspace_paths(
+        context["run_directory"],
+        context["task_config_dict"],
+        context["timestamp"],
+    )
+    context["logger"].info(f"Post-processing {len(workspace_paths)} workspace(s)")
+    run_post_processing(context["agent"], workspace_paths, context["logger"])
+
+    pending_descriptors = list(_queue_state_dir(context["run_directory"], "pending").glob("*.yaml"))
+    running_descriptors = list(_queue_state_dir(context["run_directory"], "running").glob("*.yaml"))
+    failed_descriptors = list(_queue_state_dir(context["run_directory"], "failed").glob("*.yaml"))
+    if pending_descriptors or running_descriptors:
+        context["logger"].error(
+            "Parallel run has unfinished task descriptor(s): "
+            f"pending={len(pending_descriptors)}, running={len(running_descriptors)}"
+        )
+        return 1
+    if failed_descriptors:
+        context["logger"].error(f"Parallel run has {len(failed_descriptors)} failed task(s)")
+        return 1
+
+    context["logger"].info("=" * 80)
+    context["logger"].info("AgentKernelArena Framework Completed")
+    context["logger"].info("=" * 80)
+    return 0
+
+
+def main() -> None:
+    args = parser.parse_args()
+    mode_count = sum([args.parallel_init, args.parallel_worker, args.postprocess_only])
+    if mode_count > 1:
+        print("Error: choose only one of --parallel-init, --parallel-worker, --postprocess-only")
+        raise SystemExit(1)
+
+    if args.parallel_init:
+        raise SystemExit(run_parallel_init(args))
+    if args.parallel_worker:
+        raise SystemExit(run_parallel_worker(args))
+    if args.postprocess_only:
+        raise SystemExit(run_postprocess_only(args))
+    raise SystemExit(run_serial(args))
 
 
 if __name__ == "__main__":

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -241,7 +241,18 @@ def _sanitize_task_name(task_name: str) -> str:
     return task_name.replace("/", "_")
 
 
-def is_task_complete(run_directory: Path, task_name: str, timestamp: str) -> bool:
+def get_task_workspace_path(run_directory: Path, task_name: str, timestamp: str) -> Path:
+    """Return the expected task workspace path for a run."""
+    sanitized = _sanitize_task_name(task_name)
+    return run_directory / f"{sanitized}_{timestamp}"
+
+
+def is_task_complete(
+    run_directory: Path,
+    task_name: str,
+    timestamp: str,
+    agent_name: str | None = None,
+) -> bool:
     """
     Check if a task is already completed.
 
@@ -249,13 +260,15 @@ def is_task_complete(run_directory: Path, task_name: str, timestamp: str) -> boo
         run_directory: Run-level directory (e.g., workspace_MI300_cursor/run_20250115_143022/)
         task_name: Full task name (e.g., "hip2hip/gpumode/SiLU")
         timestamp: Timestamp string used in task directory name
+        agent_name: Agent name. task_validator uses validation_report.yaml;
+            all other agents use task_result.yaml.
 
     Returns:
-        True if task directory exists and task_result.yaml exists, False otherwise
+        True if the expected completion report exists, False otherwise
     """
-    sanitized = _sanitize_task_name(task_name)
-    task_dir = run_directory / f"{sanitized}_{timestamp}"
-    result_file = task_dir / "task_result.yaml"
+    task_dir = get_task_workspace_path(run_directory, task_name, timestamp)
+    report_name = "validation_report.yaml" if agent_name == "task_validator" else "task_result.yaml"
+    result_file = task_dir / report_name
     return result_file.exists()
 
 

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -10,6 +10,7 @@ HOST_UID="$(id -u)"
 HOST_GID="$(id -g)"
 SELECTED_GPU_ARCH=""
 SELECTED_IMAGE=""
+AGENT_STATE_MOUNT_ROOT="${AKA_AGENT_STATE_MOUNT_ROOT:-/opt/aka-agent-state}"
 
 # /opt/venv/bin is placed before /usr/local/bin and /usr/bin so that a bare
 # `python3` / `pytest` resolves to the torch-enabled venv interpreter rather than
@@ -21,12 +22,15 @@ usage() {
     cat <<'EOF'
 Usage:
   src/scripts/docker_benchmark.sh run [main.py args...]
+  src/scripts/docker_benchmark.sh parallel-run [main.py args...]
   src/scripts/docker_benchmark.sh preflight [--config_name config.yaml]
   src/scripts/docker_benchmark.sh shell
   src/scripts/docker_benchmark.sh check-agents
   src/scripts/docker_benchmark.sh smoke
 
 Environment overrides:
+  GPU_IDS                 Comma/space separated GPU indices for parallel-run.
+  AKA_LOGICAL_GPU         Logical GPU index inside a masked worker container (default: 0).
   AKA_DOCKER_IMAGE        Absolute Docker image override.
   AKA_GPU_ARCH            GPU arch override for shell/smoke, or run configs without target_gpu_model.
   AKA_DOCKER_IMAGE_<ARCH> Per-arch image override, e.g. AKA_DOCKER_IMAGE_GFX950=...
@@ -268,6 +272,7 @@ resolve_required_agents() {
 # Mount one agent's CLI install + auth dirs. $2=strict (1 require, 0 best-effort).
 mount_agent() {
     local agent="$1" strict="${2:-1}"
+    local isolate="${AGENT_HOME_ISOLATION:-0}"
     case "$agent" in
         codex)
             if ! command -v node >/dev/null 2>&1; then
@@ -281,7 +286,11 @@ mount_agent() {
             need_path "$node_prefix/bin/codex" "host codex" "$strict" || return 0
             need_path "$HOST_HOME/.codex" "Codex auth/config directory" "$strict" || return 0
             add_mount "$node_prefix" /opt/node ro
-            add_mount "$HOST_HOME/.codex" "$HOST_HOME/.codex"
+            if [[ "$isolate" == "1" ]]; then
+                add_mount "$HOST_HOME/.codex" "$AGENT_STATE_MOUNT_ROOT/.codex" ro
+            else
+                add_mount "$HOST_HOME/.codex" "$HOST_HOME/.codex"
+            fi
             ;;
         claude_code)
             need_path "$HOST_HOME/.local/bin" "host local bin directory" "$strict" || return 0
@@ -290,8 +299,13 @@ mount_agent() {
             need_path "$HOST_HOME/.claude.json" "Claude Code auth/config file" "$strict" || return 0
             add_mount "$HOST_HOME/.local/bin" "$HOST_HOME/.local/bin" ro
             add_mount "$HOST_HOME/.local/share/claude" "$HOST_HOME/.local/share/claude" ro
-            add_mount "$HOST_HOME/.claude" "$HOST_HOME/.claude"
-            add_mount "$HOST_HOME/.claude.json" "$HOST_HOME/.claude.json"
+            if [[ "$isolate" == "1" ]]; then
+                add_mount "$HOST_HOME/.claude" "$AGENT_STATE_MOUNT_ROOT/.claude" ro
+                add_mount "$HOST_HOME/.claude.json" "$AGENT_STATE_MOUNT_ROOT/.claude.json" ro
+            else
+                add_mount "$HOST_HOME/.claude" "$HOST_HOME/.claude"
+                add_mount "$HOST_HOME/.claude.json" "$HOST_HOME/.claude.json"
+            fi
             ;;
         cursor)
             need_path "$HOST_HOME/.local/bin" "host local bin directory" "$strict" || return 0
@@ -300,8 +314,13 @@ mount_agent() {
             need_path "$HOST_HOME/.config/cursor" "Cursor Agent config directory" "$strict" || return 0
             add_mount "$HOST_HOME/.local/bin" "$HOST_HOME/.local/bin" ro
             add_mount "$HOST_HOME/.local/share/cursor-agent" "$HOST_HOME/.local/share/cursor-agent" ro
-            add_mount "$HOST_HOME/.cursor" "$HOST_HOME/.cursor"
-            add_mount "$HOST_HOME/.config/cursor" "$HOST_HOME/.config/cursor"
+            if [[ "$isolate" == "1" ]]; then
+                add_mount "$HOST_HOME/.cursor" "$AGENT_STATE_MOUNT_ROOT/.cursor" ro
+                add_mount "$HOST_HOME/.config/cursor" "$AGENT_STATE_MOUNT_ROOT/.config/cursor" ro
+            else
+                add_mount "$HOST_HOME/.cursor" "$HOST_HOME/.cursor"
+                add_mount "$HOST_HOME/.config/cursor" "$HOST_HOME/.config/cursor"
+            fi
             ;;
         *)
             warn "Unknown agent '$agent'; not provisioning any CLI for it"
@@ -327,6 +346,15 @@ build_docker_args() {
 # (e.g. setup-flydsl), while unset falls back to all three.
     local agents="${REQUIRED_AGENTS-codex claude_code cursor}"
     local strict="${AGENTS_STRICT:-0}"
+    local container_home="${AKA_CONTAINER_HOME:-$HOST_HOME}"
+    local codex_home="${AKA_CODEX_HOME:-$container_home/.codex}"
+    local cache_suffix="${AKA_CACHE_SUFFIX:-}"
+    local cache_postfix=""
+
+    if [[ -n "$cache_suffix" ]]; then
+        cache_suffix="${cache_suffix//[^A-Za-z0-9_.-]/_}"
+        cache_postfix="-$cache_suffix"
+    fi
 
     [[ -n "$SELECTED_IMAGE" ]] || select_runtime_for_host
 
@@ -345,23 +373,41 @@ build_docker_args() {
         --cap-add=SYS_PTRACE
         --security-opt=seccomp=unconfined
         --user "${HOST_UID}:${HOST_GID}"
-        -e "HOME=${HOST_HOME}"
-        -e "CODEX_HOME=${HOST_HOME}/.codex"
-        -e "XDG_CACHE_HOME=/tmp/agent-cache"
-        -e "MPLCONFIGDIR=/tmp/matplotlib"
-        -e "TORCH_EXTENSIONS_DIR=/tmp/torch-extensions"
-        -e "TRITON_CACHE_DIR=/tmp/triton-cache"
+        -e "HOME=${container_home}"
+        -e "CODEX_HOME=${codex_home}"
+        -e "XDG_CACHE_HOME=/tmp/agent-cache${cache_postfix}"
+        -e "MPLCONFIGDIR=/tmp/matplotlib${cache_postfix}"
+        -e "TORCH_EXTENSIONS_DIR=/tmp/torch-extensions${cache_postfix}"
+        -e "TRITON_CACHE_DIR=/tmp/triton-cache${cache_postfix}"
         -e "PYTHONUSERBASE=${CONTAINER_WORKDIR}/.aka-pyuserbase"
-        -e "MIOPEN_USER_DB_PATH=/tmp/miopen-cache"
-        -e "MIOPEN_CACHE_DIR=/tmp/miopen-cache"
-        -e "MIOPEN_CUSTOM_CACHE_DIR=/tmp/miopen-cache"
+        -e "MIOPEN_USER_DB_PATH=/tmp/miopen-cache${cache_postfix}"
+        -e "MIOPEN_CACHE_DIR=/tmp/miopen-cache${cache_postfix}"
+        -e "MIOPEN_CUSTOM_CACHE_DIR=/tmp/miopen-cache${cache_postfix}"
         -e "AGENT_KERNEL_ARENA_DOCKER=1"
         -e "AGENT_KERNEL_ARENA_WORKDIR=${CONTAINER_WORKDIR}"
         -e "AGENT_KERNEL_ARENA_GPU_ARCH=${SELECTED_GPU_ARCH}"
         -e "PYTORCH_ROCM_ARCH=${SELECTED_GPU_ARCH}"
+        -e "AGENT_STATE_MOUNT_ROOT=${AGENT_STATE_MOUNT_ROOT}"
         -e "PATH=${container_path}"
         -w "$CONTAINER_WORKDIR"
     )
+
+    if [[ -n "${AKA_VISIBLE_GPU:-}" ]]; then
+        local logical_gpu="${AKA_LOGICAL_GPU:-0}"
+        docker_args+=(
+            -e "AGENT_KERNEL_ARENA_HOST_GPU_ID=${AKA_VISIBLE_GPU}"
+            -e "ROCR_VISIBLE_DEVICES=${AKA_VISIBLE_GPU}"
+            -e "HIP_VISIBLE_DEVICES=${logical_gpu}"
+            -e "CUDA_VISIBLE_DEVICES=${logical_gpu}"
+            -e "GPU_DEVICE_ORDINAL=${logical_gpu}"
+        )
+    fi
+    if [[ -n "${AKA_WORKER_ID:-}" ]]; then
+        docker_args+=(-e "AGENT_KERNEL_ARENA_WORKER_ID=${AKA_WORKER_ID}")
+    fi
+    if [[ "${AGENT_HOME_ISOLATION:-0}" == "1" ]]; then
+        docker_args+=(-e "AGENT_KERNEL_ARENA_ISOLATED_HOME=1")
+    fi
 
     # GPU device nodes are group-owned (ROCm): /dev/dri/renderD* by `render` and
     # /dev/kfd by `render` or `video` depending on the host's udev rules. Add the
@@ -408,7 +454,7 @@ docker_exec() {
     local interactive="${1:-0}"
     shift
     build_docker_args "$interactive"
-    docker "${docker_args[@]}" -lc 'cd "$AGENT_KERNEL_ARENA_WORKDIR" && exec "$@"' _ "$@"
+    docker "${docker_args[@]}" -lc 'cd "$AGENT_KERNEL_ARENA_WORKDIR" && if [[ "${AGENT_KERNEL_ARENA_ISOLATED_HOME:-0}" == "1" ]]; then bash src/scripts/docker_benchmark.sh _container_prepare_worker_home; fi && exec "$@"' _ "$@"
 }
 
 extract_config_name() {
@@ -570,6 +616,239 @@ container_setup_flydsl() {
     python -c 'import flydsl; print("flydsl=" + str(getattr(flydsl, "__version__", "unknown")) + " setup OK")'
 }
 
+container_prepare_worker_home() {
+    local state_root="${AGENT_STATE_MOUNT_ROOT:-/opt/aka-agent-state}"
+    mkdir -p "$HOME"
+
+    if [[ -d "$state_root/.codex" && ! -e "$HOME/.codex" ]]; then
+        cp -a "$state_root/.codex" "$HOME/.codex"
+        chmod -R u+rwX "$HOME/.codex" 2>/dev/null || true
+    fi
+
+    if [[ -d "$state_root/.claude" && ! -e "$HOME/.claude" ]]; then
+        cp -a "$state_root/.claude" "$HOME/.claude"
+        chmod -R u+rwX "$HOME/.claude" 2>/dev/null || true
+    fi
+    if [[ -f "$state_root/.claude.json" && ! -e "$HOME/.claude.json" ]]; then
+        cp -a "$state_root/.claude.json" "$HOME/.claude.json"
+        chmod u+rw "$HOME/.claude.json" 2>/dev/null || true
+    fi
+
+    if [[ -d "$state_root/.cursor" && ! -e "$HOME/.cursor" ]]; then
+        cp -a "$state_root/.cursor" "$HOME/.cursor"
+        chmod -R u+rwX "$HOME/.cursor" 2>/dev/null || true
+    fi
+    if [[ -d "$state_root/.config/cursor" && ! -e "$HOME/.config/cursor" ]]; then
+        mkdir -p "$HOME/.config"
+        cp -a "$state_root/.config/cursor" "$HOME/.config/cursor"
+        chmod -R u+rwX "$HOME/.config/cursor" 2>/dev/null || true
+    fi
+}
+
+read_workspace_prefix() {
+    local config="$1"
+    sed -nE "s/^[[:space:]]*workspace_directory_prefix[[:space:]]*:[[:space:]]*['\"]?([^'\"#[:space:]]+).*/\1/p" "$config" | head -n 1
+}
+
+extract_run_suffix_arg() {
+    local arg
+    while [[ $# -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --run-suffix)
+                shift
+                [[ $# -gt 0 ]] || die "--run-suffix requires a value"
+                printf '%s\n' "$1"
+                return
+                ;;
+            --run-suffix=*)
+                printf '%s\n' "${arg#--run-suffix=}"
+                return
+                ;;
+        esac
+        shift || true
+    done
+}
+
+extract_resume_run_arg() {
+    local arg
+    while [[ $# -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --resume-run)
+                shift
+                [[ $# -gt 0 ]] || die "--resume-run requires a value"
+                printf '%s\n' "$1"
+                return
+                ;;
+            --resume-run=*)
+                printf '%s\n' "${arg#--resume-run=}"
+                return
+                ;;
+        esac
+        shift || true
+    done
+}
+
+has_arg() {
+    local needle="$1"
+    shift
+    local arg
+    for arg in "$@"; do
+        [[ "$arg" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+resolve_workspace_dir_for_config() {
+    local config="$1"
+    local prefix model agent
+    prefix="$(read_workspace_prefix "$config")"
+    model="$(read_target_gpu_model "$config")"
+    agent="$(read_agent_template "$config")"
+    [[ -n "$prefix" ]] || die "workspace_directory_prefix not found in $config"
+    [[ -n "$model" ]] || die "target_gpu_model not found in $config"
+    [[ -n "$agent" ]] || die "agent.template not found in $config"
+    printf '%s/%s_%s_%s\n' "$HOST_ROOT" "$prefix" "$model" "$agent"
+}
+
+resolve_latest_run_name() {
+    local config="$1"
+    local workspace_dir
+    workspace_dir="$(resolve_workspace_dir_for_config "$config")"
+    [[ -d "$workspace_dir" ]] || die "No workspace directory found for resume-latest: $workspace_dir"
+    find "$workspace_dir" -maxdepth 1 -mindepth 1 -type d -name 'run_*' ! -name '*_heldout' \
+        -printf '%f\n' | sort -r | head -n 1
+}
+
+resolve_parallel_run_name() {
+    local config="$1"
+    shift
+    local resume_run suffix latest
+    resume_run="$(extract_resume_run_arg "$@" || true)"
+    if [[ -n "$resume_run" ]]; then
+        printf '%s\n' "$resume_run"
+        return
+    fi
+
+    if has_arg --resume-latest "$@"; then
+        latest="$(resolve_latest_run_name "$config")"
+        [[ -n "$latest" ]] || die "No run directories found for --resume-latest"
+        printf '%s\n' "$latest"
+        return
+    fi
+
+    suffix="$(extract_run_suffix_arg "$@" || true)"
+    if [[ -n "$suffix" ]]; then
+        [[ "$suffix" =~ ^[A-Za-z0-9._-]+$ ]] || die "--run-suffix may only contain letters, numbers, dot, underscore, and dash"
+        printf 'run_%s_%s\n' "$(date +%Y%m%d_%H%M%S)" "$suffix"
+    else
+        printf 'run_%s\n' "$(date +%Y%m%d_%H%M%S)"
+    fi
+}
+
+resolve_gpu_ids() {
+    if [[ -n "${GPU_IDS:-}" ]]; then
+        printf '%s\n' "${GPU_IDS//,/ }" | tr ' ' '\n' | sed '/^$/d'
+        return
+    fi
+
+    if command -v rocm-smi >/dev/null 2>&1; then
+        rocm-smi --showid 2>/dev/null \
+            | sed -nE 's/.*GPU\[([0-9]+)\].*/\1/p' \
+            | sort -n \
+            | uniq
+        return
+    fi
+
+    die "GPU_IDS is not set and rocm-smi is not available for GPU discovery"
+}
+
+safe_label() {
+    local value="$1"
+    value="${value//[^A-Za-z0-9_.-]/_}"
+    printf '%s\n' "$value"
+}
+
+run_parallel() {
+    local config_name
+    config_name="$(extract_config_name "$@")"
+    select_runtime_for_config "$config_name"
+
+    REQUIRED_AGENTS="$(resolve_required_agents "$config_name")"
+    AGENTS_STRICT=1
+
+    local run_name safe_run_name
+    run_name="$(resolve_parallel_run_name "$config_name" "$@")"
+    safe_run_name="$(safe_label "$run_name")"
+
+    local -a gpu_ids=()
+    local gpu_id
+    while IFS= read -r gpu_id; do
+        [[ -n "$gpu_id" ]] && gpu_ids+=("$gpu_id")
+    done < <(resolve_gpu_ids)
+    [[ "${#gpu_ids[@]}" -gt 0 ]] || die "No GPU IDs available; set GPU_IDS=0,1,..."
+
+    echo "Parallel run: run_name=${run_name} workers=${#gpu_ids[@]} gpu_ids=${gpu_ids[*]}" >&2
+
+    (
+        export AKA_VISIBLE_GPU="${gpu_ids[0]}"
+        export AKA_WORKER_ID="preflight"
+        export AKA_CONTAINER_HOME="/tmp/aka-home-${safe_run_name}-preflight"
+        export AKA_CACHE_SUFFIX="${safe_run_name}-preflight"
+        export AGENT_HOME_ISOLATION=1
+        docker_exec 0 bash src/scripts/docker_benchmark.sh _container_preflight "$config_name"
+    )
+
+    (
+        export AKA_VISIBLE_GPU="${gpu_ids[0]}"
+        export AKA_WORKER_ID="init"
+        export AKA_CONTAINER_HOME="/tmp/aka-home-${safe_run_name}-init"
+        export AKA_CACHE_SUFFIX="${safe_run_name}-init"
+        export AGENT_HOME_ISOLATION=1
+        docker_exec 0 python main.py "$@" --parallel-init --run-name "$run_name"
+    )
+
+    local -a pids=()
+    local worker_id
+    for worker_id in "${!gpu_ids[@]}"; do
+        gpu_id="${gpu_ids[$worker_id]}"
+        (
+            export AKA_VISIBLE_GPU="$gpu_id"
+            export AKA_WORKER_ID="$worker_id"
+            export AKA_CONTAINER_HOME="/tmp/aka-home-${safe_run_name}-worker-${worker_id}"
+            export AKA_CACHE_SUFFIX="${safe_run_name}-worker-${worker_id}"
+            export AGENT_HOME_ISOLATION=1
+            docker_exec 0 python main.py "$@" --parallel-worker --worker-id "$worker_id" --run-name "$run_name"
+        ) &
+        pids+=("$!")
+    done
+
+    local worker_failed=0
+    local pid
+    for pid in "${pids[@]}"; do
+        if ! wait "$pid"; then
+            worker_failed=1
+        fi
+    done
+
+    local postprocess_failed=0
+    if ! (
+        export AKA_VISIBLE_GPU="${gpu_ids[0]}"
+        export AKA_WORKER_ID="postprocess"
+        export AKA_CONTAINER_HOME="/tmp/aka-home-${safe_run_name}-postprocess"
+        export AKA_CACHE_SUFFIX="${safe_run_name}-postprocess"
+        export AGENT_HOME_ISOLATION=1
+        docker_exec 0 python main.py "$@" --postprocess-only --run-name "$run_name"
+    ); then
+        postprocess_failed=1
+    fi
+
+    if [[ "$worker_failed" != "0" || "$postprocess_failed" != "0" ]]; then
+        return 1
+    fi
+}
+
 case "${1:-}" in
     run)
         shift
@@ -580,6 +859,10 @@ case "${1:-}" in
         AGENTS_STRICT=1
         docker_exec 0 bash src/scripts/docker_benchmark.sh _container_preflight "$config_name"
         docker_exec 0 python main.py "$@"
+        ;;
+    parallel-run)
+        shift
+        run_parallel "$@"
         ;;
     preflight)
         shift
@@ -631,6 +914,9 @@ case "${1:-}" in
     _container_preflight)
         shift
         container_preflight "$@"
+        ;;
+    _container_prepare_worker_home)
+        container_prepare_worker_home
         ;;
     ""|-h|--help|help)
         usage


### PR DESCRIPTION
## Summary

Adds a multi-GPU parallel execution path for AgentKernelArena using one long-lived Docker worker container per GPU. Workers claim tasks from a shared run-local queue, execute tasks with single-GPU visibility, and then continue claiming work until the queue is empty. Final post-processing runs once after all workers finish.

## Key Changes

- Add `make docker-parallel-run CONFIG=... GPU_IDS=...`
- Add `src/scripts/docker_benchmark.sh parallel-run`
- Add internal `main.py` modes:
  - `--parallel-init`
  - `--parallel-worker`
  - `--worker-id`
  - `--run-name`
  - `--postprocess-only`
- Add shared `.parallel/{pending,running,done,failed}` queue with atomic descriptor claiming
- Add per-worker GPU masking and isolated HOME/cache/agent state
- Add `task_validator` completion detection via `validation_report.yaml`
- Keep existing serial `make docker-run` behavior unchanged
- Add README and docs coverage with examples

## Validation

- `python3 -m py_compile main.py src/preprocessing.py`
- `bash -n src/scripts/docker_benchmark.sh`
- `git diff --check`
- `python3 main.py --help`
- `bash src/scripts/docker_benchmark.sh help`
- `make -n docker-parallel-run CONFIG=config.yaml GPU_IDS=0,1 RUN_ARGS="--run-suffix dryrun"`
- End-to-end 8-worker `task_validator` smoke completed
- End-to-end 8-worker `claude_code` run completed with 8/8 task results and final post-processing