### PR TITLE
feat(agents): add task quality loop auditor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ traj.json
 # Generated held-out test data (methodology is in src/held_out/, data is private)
 held_out_tests/
 
+# Repository-level quality_loop audit state and isolated git worktrees
+quality_loop_runs/
+.quality_loop_worktrees/
+
 # Documentation build environment and output
 .docvenv/
 docs/_build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,11 @@ help:
 	@echo "make docker-smoke        - Verify Docker Python, ROCm tools, imports, and GPU access"
 	@echo "make docker-run CONFIG=example_configs/quickstart_claude_mi300.yaml RUN_ARGS=\"--run-suffix test\" - Run an experiment in Docker"
 	@echo "make docker-parallel-run CONFIG=example_configs/benchmark_cursor_mi355x.yaml GPU_IDS=0,1 - Run an experiment across one worker container per GPU"
-	@echo "make docker-quality-loop QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml - Audit and harden tasks with Codex, then open one draft PR"
 	@echo "                         Default CONFIG is the MI300/MI300X Claude quickstart"
 	@echo "                         On other GPUs, pass a matching CONFIG explicitly"
 	@echo "                         Images: gfx942->mi30x, gfx950->mi35x; override with AKA_DOCKER_IMAGE=..."
+	@echo "make docker-quality-loop CONFIG=example_configs/quality_loop_mi300.yaml - Audit and harden config-selected tasks, then open at most one draft PR"
+	@echo "                         Default quality-loop CONFIG is agents/quality_loop/agent_config.yaml"
 	@echo "make docker-setup-flydsl - Install FlyDSL when absent (for flydsl2flydsl, torch2flydsl, and triton2flydsl)"
 	@echo "make docker-setup-geak   - Install the Claude Agent SDK when absent (for the geak_v4 agent)"
 	@echo "make check-docker-runner - Check Docker runner syntax and runtime-specific arguments"
@@ -46,7 +47,6 @@ help:
 DOCKER_RUNNER := src/scripts/docker_benchmark.sh
 CONFIG ?= example_configs/quickstart_claude_mi300.yaml
 RUN_ARGS ?=
-QUALITY_LOOP_CONFIG ?= agents/quality_loop/agent_config.yaml
 QUALITY_LOOP_ARGS ?=
 AGENTS ?=
 WORKSPACES ?= $(WORKSPACE)
@@ -73,8 +73,9 @@ docker-run:
 docker-parallel-run:
 	@GPU_IDS="$(GPU_IDS)" $(DOCKER_RUNNER) parallel-run --config_name $(CONFIG) $(RUN_ARGS)
 
+docker-quality-loop: CONFIG = agents/quality_loop/agent_config.yaml
 docker-quality-loop:
-	@$(DOCKER_RUNNER) quality-loop --config $(QUALITY_LOOP_CONFIG) $(QUALITY_LOOP_ARGS)
+	@$(DOCKER_RUNNER) quality-loop --config $(CONFIG) $(QUALITY_LOOP_ARGS)
 
 # Install FlyDSL into the container's persistent pip user-base when the selected
 # image does not ship it. Needed by all three FlyDSL task types.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help docker-shell docker-check-agents docker-smoke docker-run docker-parallel-run docker-setup-flydsl docker-setup-geak \
+.PHONY: help docker-shell docker-check-agents docker-smoke docker-run docker-parallel-run docker-quality-loop docker-setup-flydsl docker-setup-geak \
         check-docker-runner check-evaluator check-held-out check-visualization \
         visualization-build visualization-serve visualization-run \
         sync-perf-helpers check-perf-helpers materialize-perf-workspace \
@@ -23,6 +23,7 @@ help:
 	@echo "make docker-smoke        - Verify Docker Python, ROCm tools, imports, and GPU access"
 	@echo "make docker-run CONFIG=example_configs/quickstart_claude_mi300.yaml RUN_ARGS=\"--run-suffix test\" - Run an experiment in Docker"
 	@echo "make docker-parallel-run CONFIG=example_configs/benchmark_cursor_mi355x.yaml GPU_IDS=0,1 - Run an experiment across one worker container per GPU"
+	@echo "make docker-quality-loop QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml - Audit and harden tasks with Codex, then open one draft PR"
 	@echo "                         Default CONFIG is the MI300/MI300X Claude quickstart"
 	@echo "                         On other GPUs, pass a matching CONFIG explicitly"
 	@echo "                         Images: gfx942->mi30x, gfx950->mi35x; override with AKA_DOCKER_IMAGE=..."
@@ -45,6 +46,8 @@ help:
 DOCKER_RUNNER := src/scripts/docker_benchmark.sh
 CONFIG ?= example_configs/quickstart_claude_mi300.yaml
 RUN_ARGS ?=
+QUALITY_LOOP_CONFIG ?= agents/quality_loop/agent_config.yaml
+QUALITY_LOOP_ARGS ?=
 AGENTS ?=
 WORKSPACES ?= $(WORKSPACE)
 TASKS ?= $(TASK)
@@ -69,6 +72,9 @@ docker-run:
 
 docker-parallel-run:
 	@GPU_IDS="$(GPU_IDS)" $(DOCKER_RUNNER) parallel-run --config_name $(CONFIG) $(RUN_ARGS)
+
+docker-quality-loop:
+	@$(DOCKER_RUNNER) quality-loop --config $(QUALITY_LOOP_CONFIG) $(QUALITY_LOOP_ARGS)
 
 # Install FlyDSL into the container's persistent pip user-base when the selected
 # image does not ship it. Needed by all three FlyDSL task types.

--- a/agents/quality_loop/README.md
+++ b/agents/quality_loop/README.md
@@ -1,0 +1,97 @@
+# quality_loop agent
+
+`quality_loop` is a repository-level task curator. It audits every selected task,
+attempts one repair for blocking validator failures, runs exactly one Codex
+optimization iteration, sends the result to an independent Codex reviewer, and
+optionally hardens an easy baseline or task cases behind fail-closed correctness
+gates. It files idempotent GitHub issues for unrepairable task defects and bundles
+all accepted task changes into one draft pull request.
+
+Unlike normal Arena agents, `quality_loop` is not registered in `AgentType`.
+Normal launchers operate once inside one copied task workspace; this workflow owns
+the full repository campaign, isolated git worktree, issue deduplication, resume
+manifest, and final PR.
+
+## Hard preflight
+
+A real run stops before creating a branch or modifying a task unless all of these
+pass:
+
+- `gh auth status -h github.com`
+- the authenticated account has repository write permission
+- GitHub Issues are enabled
+- `git`, `gh`, and `codex` are installed
+- Git has a usable author identity for task commits
+- the source worktree is clean
+- the configured GPU/runtime is available through the Docker runner
+
+Only the host-side deterministic publisher uses `gh`. The Docker runner performs
+GitHub preflight and creates the audit worktree on the host, runs Codex/GPU work
+without mounting GitHub credentials, then returns to the host to create issues,
+commit accepted task changes, push, and open the draft PR. The main checkout is
+read-only inside that container; only this run's artifact and isolated worktree
+directories are writable. Codex login state is copied into an ephemeral container
+home instead of being writable in place.
+
+## Run
+
+Inspect task selection without credentials, GPU work, or mutations:
+
+```bash
+python3 -m agents.quality_loop \
+  --config example_configs/quality_loop_mi300.yaml \
+  --plan
+```
+
+Run through the supported Docker environment:
+
+```bash
+make docker-quality-loop QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml
+```
+
+Use `example_configs/quality_loop_mi355x.yaml` on MI355X (`gfx950`).
+
+Limit a smoke run to several tasks:
+
+```bash
+make docker-quality-loop \
+  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  QUALITY_LOOP_ARGS="--tasks hip2hip/gpumode/GELU triton2triton/vllm/triton_rms_norm"
+```
+
+Resume after interruption:
+
+```bash
+make docker-quality-loop \
+  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  QUALITY_LOOP_ARGS="--resume 20260803_120000"
+```
+
+`--no-publish` still requires the GitHub login/write preflight, but suppresses
+issues, push, and PR creation. `--plan` is the only intentionally offline mode.
+
+## Per-task gates
+
+1. Run the existing 10-check validator in a fresh workspace.
+2. Record WARN findings without repairing them.
+3. For FAIL, allow one task-local repair and re-run the full validator in another
+   fresh workspace. File one fingerprinted issue if it still fails.
+4. Measure the baseline, run one Codex optimization candidate, protect the
+   harness, and use the centralized compile/correctness/performance evaluator.
+5. Run an independent read-only Codex review. Deterministic evaluator failures
+   always override an agent acceptance.
+6. Treat the task as easy only when three measurements of the single candidate
+   have median speedup at least 5x, use consistent benchmark methods and case
+   counts, and the reviewer accepts logic equivalence.
+7. Promote only committed standalone optimization kernels. Translation/generation
+   tasks report 5x hardening as not applicable.
+8. Case changes may touch only test/harness paths and are accepted only when both
+   the pre-audit kernel and candidate pass the updated cases.
+9. Before any host commit, the complete worktree diff must exactly match the
+   accepted per-task paths recorded in `state.yaml`; unexpected edits abort
+   publication.
+
+Run artifacts are written under `quality_loop_runs/<run-id>/`; the isolated audit
+branch lives under `.quality_loop_worktrees/<run-id>/`. Both are ignored by Git.
+Tasks pinned to another GPU architecture are reported as `platform_deferred`; run
+the matching MI300/MI355X campaign to audit those tasks.

--- a/agents/quality_loop/README.md
+++ b/agents/quality_loop/README.md
@@ -4,13 +4,12 @@
 attempts one repair for blocking validator failures, runs exactly one Codex
 optimization iteration, sends the result to an independent Codex reviewer, and
 optionally hardens an easy baseline or task cases behind fail-closed correctness
-gates. It files idempotent GitHub issues for unrepairable task defects and bundles
-all accepted task changes into one draft pull request.
+gates. It records unrepairable task defects locally and bundles all accepted task
+changes into at most one draft pull request. It never creates GitHub issues.
 
 Unlike normal Arena agents, `quality_loop` is not registered in `AgentType`.
 Normal launchers operate once inside one copied task workspace; this workflow owns
-the full repository campaign, isolated git worktree, issue deduplication, resume
-manifest, and final PR.
+the full repository campaign, isolated git worktree, resume manifest, and final PR.
 
 ## Hard preflight
 
@@ -19,7 +18,6 @@ pass:
 
 - `gh auth status -h github.com`
 - the authenticated account has repository write permission
-- GitHub Issues are enabled
 - `git`, `gh`, and `codex` are installed
 - Git has a usable author identity for task commits
 - the source worktree is clean
@@ -27,8 +25,8 @@ pass:
 
 Only the host-side deterministic publisher uses `gh`. The Docker runner performs
 GitHub preflight and creates the audit worktree on the host, runs Codex/GPU work
-without mounting GitHub credentials, then returns to the host to create issues,
-commit accepted task changes, push, and open the draft PR. The main checkout is
+without mounting GitHub credentials, then returns to the host to commit accepted
+task changes, push, and open the draft PR. The main checkout is
 read-only inside that container; only this run's artifact and isolated worktree
 directories are writable. Codex login state is copied into an ephemeral container
 home instead of being writable in place.
@@ -46,7 +44,7 @@ python3 -m agents.quality_loop \
 Run through the supported Docker environment:
 
 ```bash
-make docker-quality-loop QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml
+make docker-quality-loop CONFIG=example_configs/quality_loop_mi300.yaml
 ```
 
 Use `example_configs/quality_loop_mi355x.yaml` on MI355X (`gfx950`).
@@ -55,7 +53,7 @@ Limit a smoke run to several tasks:
 
 ```bash
 make docker-quality-loop \
-  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  CONFIG=example_configs/quality_loop_mi300.yaml \
   QUALITY_LOOP_ARGS="--tasks hip2hip/gpumode/GELU triton2triton/vllm/triton_rms_norm"
 ```
 
@@ -63,19 +61,19 @@ Resume after interruption:
 
 ```bash
 make docker-quality-loop \
-  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  CONFIG=example_configs/quality_loop_mi300.yaml \
   QUALITY_LOOP_ARGS="--resume 20260803_120000"
 ```
 
 `--no-publish` still requires the GitHub login/write preflight, but suppresses
-issues, push, and PR creation. `--plan` is the only intentionally offline mode.
+push and PR creation. `--plan` is the only intentionally offline mode.
 
 ## Per-task gates
 
 1. Run the existing 10-check validator in a fresh workspace.
 2. Record WARN findings without repairing them.
 3. For FAIL, allow one task-local repair and re-run the full validator in another
-   fresh workspace. File one fingerprinted issue if it still fails.
+   fresh workspace. Record an unresolved failure locally if it still fails.
 4. Measure the baseline, run one Codex optimization candidate, protect the
    harness, and use the centralized compile/correctness/performance evaluator.
 5. Run an independent read-only Codex review. Deterministic evaluator failures
@@ -83,8 +81,9 @@ issues, push, and PR creation. `--plan` is the only intentionally offline mode.
 6. Treat the task as easy only when three measurements of the single candidate
    have median speedup at least 5x, use consistent benchmark methods and case
    counts, and the reviewer accepts logic equivalence.
-7. Promote only committed standalone optimization kernels. Translation/generation
-   tasks report 5x hardening as not applicable.
+7. Attempt promotion for every task selected by the run config. Capability checks,
+   rather than task-type names, reject candidates without a committed source
+   baseline that can pass fresh validation and the dual correctness gate.
 8. Case changes may touch only test/harness paths and are accepted only when both
    the pre-audit kernel and candidate pass the updated cases.
 9. Before any host commit, the complete worktree diff must exactly match the
@@ -94,4 +93,5 @@ issues, push, and PR creation. `--plan` is the only intentionally offline mode.
 Run artifacts are written under `quality_loop_runs/<run-id>/`; the isolated audit
 branch lives under `.quality_loop_worktrees/<run-id>/`. Both are ignored by Git.
 Tasks pinned to another GPU architecture are reported as `platform_deferred`; run
-the matching MI300/MI355X campaign to audit those tasks.
+the matching MI300/MI355X campaign to audit those tasks. If a run produces no
+accepted file changes, it writes the local report without opening an empty PR.

--- a/agents/quality_loop/__init__.py
+++ b/agents/quality_loop/__init__.py
@@ -1,0 +1,6 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""Repository-level task quality audit and hardening workflow."""
+
+from .config import QualityLoopConfig, load_config
+
+__all__ = ["QualityLoopConfig", "load_config"]

--- a/agents/quality_loop/__main__.py
+++ b/agents/quality_loop/__main__.py
@@ -35,7 +35,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--no-publish",
         action="store_true",
-        help="Run all hard preflights and audits but do not create issues, push, or open a PR",
+        help="Run all hard preflights and audits but do not push or open a PR",
     )
     parser.add_argument("--defer-github", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--skip-preflight", action="store_true", help=argparse.SUPPRESS)

--- a/agents/quality_loop/__main__.py
+++ b/agents/quality_loop/__main__.py
@@ -1,0 +1,80 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+from pathlib import Path
+
+import yaml
+
+from .config import load_config
+from .orchestrator import QualityLoop
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = Path(__file__).with_name("agent_config.yaml")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit, repair, harden, and publish AgentKernelArena tasks"
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        help="Override task selectors from the config (paths relative to tasks/)",
+    )
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="List runnable/deferred tasks without GitHub, GPU, or agent execution",
+    )
+    parser.add_argument("--resume", metavar="RUN_ID", help="Resume a prior run")
+    parser.add_argument(
+        "--no-publish",
+        action="store_true",
+        help="Run all hard preflights and audits but do not create issues, push, or open a PR",
+    )
+    parser.add_argument("--defer-github", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--skip-preflight", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def configure_logging() -> logging.Logger:
+    logger = logging.getLogger("quality_loop")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+        logger.addHandler(handler)
+    return logger
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config_path = args.config if args.config.is_absolute() else REPO_ROOT / args.config
+    config = load_config(config_path)
+    if args.tasks:
+        config = dataclasses.replace(config, tasks=tuple(args.tasks))
+    if args.no_publish:
+        config = dataclasses.replace(
+            config,
+            github=dataclasses.replace(config.github, publish=False),
+        )
+    logger = configure_logging()
+    workflow = QualityLoop(REPO_ROOT, config, logger=logger, defer_github=args.defer_github)
+    if args.plan:
+        print(yaml.safe_dump(workflow.plan(), sort_keys=False, allow_unicode=True))
+        return 0
+    report = workflow.run(
+        resume_run_id=args.resume,
+        skip_preflight=args.skip_preflight,
+    )
+    logger.info("quality_loop report: %s", report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/quality_loop/agent_config.yaml
+++ b/agents/quality_loop/agent_config.yaml
@@ -22,20 +22,10 @@ quality_loop:
   easy_confirmation_runs: 3
   case_enhancement: true
 
-  # Only optimization tasks with a committed runnable baseline can promote a
-  # first-iteration 5x candidate into the new task baseline. Translation and
-  # authoring tasks still receive validation, optimization, review, and case audit.
-  promotion_task_types:
-    - hip2hip
-    - triton2triton
-    - flydsl2flydsl
-
   artifact_root: quality_loop_runs
   worktree_root: .quality_loop_worktrees
 
   github:
     publish: true
-    draft_pr: true
     branch_prefix: quality-loop
     base_branch: null           # null resolves the repository default branch
-    issue_labels: []            # labels must already exist in the repository

--- a/agents/quality_loop/agent_config.yaml
+++ b/agents/quality_loop/agent_config.yaml
@@ -1,0 +1,41 @@
+# quality_loop is a repository-level audit workflow. It defaults to auditing all
+# tasks that are runnable on the selected target GPU.
+tasks:
+  - all
+target_gpu_model: MI300
+
+quality_loop:
+  backend:
+    name: codex
+    model: null                 # null uses the Codex CLI default/config
+    effort: xhigh
+    timeout_seconds: 3600
+  reviewer:
+    name: codex                 # independent, read-only Codex session
+    model: null
+    effort: xhigh
+    timeout_seconds: 1800
+
+  max_repair_attempts: 1
+  optimization_iterations: 1  # enforced; any other value is rejected
+  easy_speedup_threshold: 5.0
+  easy_confirmation_runs: 3
+  case_enhancement: true
+
+  # Only optimization tasks with a committed runnable baseline can promote a
+  # first-iteration 5x candidate into the new task baseline. Translation and
+  # authoring tasks still receive validation, optimization, review, and case audit.
+  promotion_task_types:
+    - hip2hip
+    - triton2triton
+    - flydsl2flydsl
+
+  artifact_root: quality_loop_runs
+  worktree_root: .quality_loop_worktrees
+
+  github:
+    publish: true
+    draft_pr: true
+    branch_prefix: quality-loop
+    base_branch: null           # null resolves the repository default branch
+    issue_labels: []            # labels must already exist in the repository

--- a/agents/quality_loop/backend.py
+++ b/agents/quality_loop/backend.py
@@ -1,0 +1,107 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+from .config import BackendConfig
+
+
+class AgentBackend(Protocol):
+    def run(self, prompt: str, workspace: Path, *, role: str) -> str: ...
+
+
+def _format_event(line: str) -> str:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return line
+    if not isinstance(payload, dict):
+        return line
+    if payload.get("type") in {"item.completed", "item.updated"}:
+        item = payload.get("item") or {}
+        if isinstance(item, dict) and item.get("type") == "agent_message":
+            return str(item.get("text") or "")
+    if payload.get("type") in {"turn.failed", "error"}:
+        return str(payload.get("error") or payload.get("message") or line)
+    return line
+
+
+class CodexBackend:
+    """Role-scoped Codex runner with GitHub credentials removed from children."""
+
+    def __init__(self, config: BackendConfig, logger: logging.Logger):
+        self.config = config
+        self.logger = logger
+
+    def run(self, prompt: str, workspace: Path, *, role: str) -> str:
+        if not shutil.which("codex"):
+            raise RuntimeError("codex CLI is required for quality_loop")
+        workspace = workspace.resolve()
+        no_gh_dir = workspace / ".quality_loop_no_gh"
+        no_gh_dir.mkdir(exist_ok=True)
+        env = os.environ.copy()
+        for key in (
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "SSH_AUTH_SOCK",
+            "GIT_ASKPASS",
+            "GIT_SSH_COMMAND",
+        ):
+            env.pop(key, None)
+        env["GH_CONFIG_DIR"] = str(no_gh_dir)
+        env["GIT_CONFIG_GLOBAL"] = os.devnull
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+
+        command = [
+            "codex",
+            "exec",
+            "--json",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "-c",
+            "features.memories=false",
+            "--cd",
+            str(workspace),
+        ]
+        if self.config.model:
+            command.extend(["--model", self.config.model])
+        if self.config.effort:
+            command.extend(["-c", f'model_reasoning_effort="{self.config.effort}"'])
+        command.append(prompt)
+
+        self.logger.info(
+            "Starting Codex role=%s model=%s effort=%s workspace=%s",
+            role,
+            self.config.model or "<default>",
+            self.config.effort,
+            workspace,
+        )
+        try:
+            result = subprocess.run(
+                command,
+                cwd=workspace,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self.config.timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Codex role {role} timed out after {self.config.timeout_seconds}s"
+            ) from exc
+        output = "\n".join(
+            _format_event(line) for line in result.stdout.splitlines() if line.strip()
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or output).strip()
+            raise RuntimeError(f"Codex role {role} failed ({result.returncode}): {detail[-4000:]}")
+        if result.stderr.strip():
+            self.logger.warning("Codex role=%s stderr: %s", role, result.stderr[-1000:])
+        return output

--- a/agents/quality_loop/config.py
+++ b/agents/quality_loop/config.py
@@ -1,0 +1,151 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _runtime_root(value: Any, name: str) -> str:
+    path = Path(str(value))
+    if path.is_absolute() or not path.parts or any(part == ".." for part in path.parts):
+        raise ValueError(f"{name} must be a repository-relative path without '..'")
+    return path.as_posix()
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    name: str = "codex"
+    model: str | None = None
+    effort: str = "xhigh"
+    timeout_seconds: int = 3600
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> "BackendConfig":
+        raw = raw or {}
+        name = str(raw.get("name", "codex")).strip().lower()
+        if name != "codex":
+            raise ValueError("quality_loop currently supports only the codex backend")
+        timeout = int(raw.get("timeout_seconds", 3600))
+        if timeout <= 0:
+            raise ValueError("backend.timeout_seconds must be positive")
+        model = raw.get("model")
+        return cls(
+            name=name,
+            model=str(model) if model else None,
+            effort=str(raw.get("effort", "xhigh")),
+            timeout_seconds=timeout,
+        )
+
+
+@dataclass(frozen=True)
+class GitHubConfig:
+    publish: bool = True
+    draft_pr: bool = True
+    issue_labels: tuple[str, ...] = ()
+    branch_prefix: str = "quality-loop"
+    base_branch: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> "GitHubConfig":
+        raw = raw or {}
+        labels = raw.get("issue_labels", [])
+        if isinstance(labels, str):
+            labels = [labels]
+        prefix = str(raw.get("branch_prefix", "quality-loop")).strip(" /-")
+        if not prefix:
+            raise ValueError("github.branch_prefix must not be empty")
+        base = raw.get("base_branch")
+        return cls(
+            publish=bool(raw.get("publish", True)),
+            draft_pr=bool(raw.get("draft_pr", True)),
+            issue_labels=tuple(str(label) for label in labels),
+            branch_prefix=prefix,
+            base_branch=str(base) if base else None,
+        )
+
+
+@dataclass(frozen=True)
+class QualityLoopConfig:
+    tasks: tuple[str, ...] = ("all",)
+    target_gpu_model: str = "MI300"
+    backend: BackendConfig = field(default_factory=BackendConfig)
+    reviewer: BackendConfig = field(default_factory=BackendConfig)
+    github: GitHubConfig = field(default_factory=GitHubConfig)
+    max_repair_attempts: int = 1
+    optimization_iterations: int = 1
+    easy_speedup_threshold: float = 5.0
+    easy_confirmation_runs: int = 3
+    case_enhancement: bool = True
+    artifact_root: str = "quality_loop_runs"
+    worktree_root: str = ".quality_loop_worktrees"
+    promotion_task_types: tuple[str, ...] = (
+        "hip2hip",
+        "triton2triton",
+        "flydsl2flydsl",
+    )
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "QualityLoopConfig":
+        tasks = raw.get("tasks", ["all"])
+        if isinstance(tasks, str):
+            tasks = [tasks]
+        if not isinstance(tasks, list) or not tasks:
+            raise ValueError("tasks must be a non-empty string or list")
+        target = str(raw.get("target_gpu_model", "")).strip()
+        if not target:
+            raise ValueError("target_gpu_model is required")
+
+        audit = raw.get("quality_loop", {}) or {}
+        if not isinstance(audit, dict):
+            raise ValueError("quality_loop must be a mapping")
+        iterations = int(audit.get("optimization_iterations", 1))
+        if iterations != 1:
+            raise ValueError(
+                "quality_loop enforces exactly one optimization iteration; "
+                "optimization_iterations must be 1"
+            )
+        repair_attempts = int(audit.get("max_repair_attempts", 1))
+        if repair_attempts < 0 or repair_attempts > 1:
+            raise ValueError("max_repair_attempts must be 0 or 1")
+        confirmations = int(audit.get("easy_confirmation_runs", 3))
+        if confirmations < 1:
+            raise ValueError("easy_confirmation_runs must be at least 1")
+        threshold = float(audit.get("easy_speedup_threshold", 5.0))
+        if threshold <= 1.0:
+            raise ValueError("easy_speedup_threshold must be greater than 1.0")
+
+        promotion_types = audit.get(
+            "promotion_task_types",
+            ["hip2hip", "triton2triton", "flydsl2flydsl"],
+        )
+        return cls(
+            tasks=tuple(str(task) for task in tasks),
+            target_gpu_model=target,
+            backend=BackendConfig.from_dict(audit.get("backend")),
+            reviewer=BackendConfig.from_dict(audit.get("reviewer", audit.get("backend"))),
+            github=GitHubConfig.from_dict(audit.get("github")),
+            max_repair_attempts=repair_attempts,
+            optimization_iterations=iterations,
+            easy_speedup_threshold=threshold,
+            easy_confirmation_runs=confirmations,
+            case_enhancement=bool(audit.get("case_enhancement", True)),
+            artifact_root=_runtime_root(
+                audit.get("artifact_root", "quality_loop_runs"),
+                "quality_loop.artifact_root",
+            ),
+            worktree_root=_runtime_root(
+                audit.get("worktree_root", ".quality_loop_worktrees"),
+                "quality_loop.worktree_root",
+            ),
+            promotion_task_types=tuple(str(value) for value in promotion_types),
+        )
+
+
+def load_config(path: Path) -> QualityLoopConfig:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"quality_loop config must be a mapping: {path}")
+    return QualityLoopConfig.from_dict(raw)

--- a/agents/quality_loop/config.py
+++ b/agents/quality_loop/config.py
@@ -43,25 +43,22 @@ class BackendConfig:
 @dataclass(frozen=True)
 class GitHubConfig:
     publish: bool = True
-    draft_pr: bool = True
-    issue_labels: tuple[str, ...] = ()
     branch_prefix: str = "quality-loop"
     base_branch: str | None = None
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any] | None) -> "GitHubConfig":
         raw = raw or {}
-        labels = raw.get("issue_labels", [])
-        if isinstance(labels, str):
-            labels = [labels]
+        if raw.get("draft_pr", True) is not True:
+            raise ValueError("quality_loop pull requests are always drafts")
+        if raw.get("issue_labels") not in (None, [], ()):
+            raise ValueError("quality_loop never creates GitHub issues")
         prefix = str(raw.get("branch_prefix", "quality-loop")).strip(" /-")
         if not prefix:
             raise ValueError("github.branch_prefix must not be empty")
         base = raw.get("base_branch")
         return cls(
             publish=bool(raw.get("publish", True)),
-            draft_pr=bool(raw.get("draft_pr", True)),
-            issue_labels=tuple(str(label) for label in labels),
             branch_prefix=prefix,
             base_branch=str(base) if base else None,
         )
@@ -81,11 +78,7 @@ class QualityLoopConfig:
     case_enhancement: bool = True
     artifact_root: str = "quality_loop_runs"
     worktree_root: str = ".quality_loop_worktrees"
-    promotion_task_types: tuple[str, ...] = (
-        "hip2hip",
-        "triton2triton",
-        "flydsl2flydsl",
-    )
+    evaluation_tools: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "QualityLoopConfig":
@@ -108,8 +101,8 @@ class QualityLoopConfig:
                 "optimization_iterations must be 1"
             )
         repair_attempts = int(audit.get("max_repair_attempts", 1))
-        if repair_attempts < 0 or repair_attempts > 1:
-            raise ValueError("max_repair_attempts must be 0 or 1")
+        if repair_attempts != 1:
+            raise ValueError("quality_loop requires exactly one repair attempt")
         confirmations = int(audit.get("easy_confirmation_runs", 3))
         if confirmations < 1:
             raise ValueError("easy_confirmation_runs must be at least 1")
@@ -117,10 +110,14 @@ class QualityLoopConfig:
         if threshold <= 1.0:
             raise ValueError("easy_speedup_threshold must be greater than 1.0")
 
-        promotion_types = audit.get(
-            "promotion_task_types",
-            ["hip2hip", "triton2triton", "flydsl2flydsl"],
-        )
+        if "promotion_task_types" in audit:
+            raise ValueError(
+                "quality_loop no longer restricts baseline promotion by task type; "
+                "select the intended tasks with the top-level tasks field"
+            )
+        evaluation_tools = raw.get("evaluation_tools") or {}
+        if not isinstance(evaluation_tools, dict):
+            raise ValueError("evaluation_tools must be a mapping")
         return cls(
             tasks=tuple(str(task) for task in tasks),
             target_gpu_model=target,
@@ -140,7 +137,7 @@ class QualityLoopConfig:
                 audit.get("worktree_root", ".quality_loop_worktrees"),
                 "quality_loop.worktree_root",
             ),
-            promotion_task_types=tuple(str(value) for value in promotion_types),
+            evaluation_tools=dict(evaluation_tools),
         )
 
 

--- a/agents/quality_loop/filesystem.py
+++ b/agents/quality_loop/filesystem.py
@@ -1,0 +1,144 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.perf_helper_materialization import (
+    MARK_END,
+    MARK_STARTS,
+    ROCMBENCH_HELPER_STUB,
+    VLLM_HELPER_STUB_BLOCK,
+    replace_marked_region,
+)
+
+
+GENERATED_NAMES = {
+    "validation_report.yaml",
+    "task_result.yaml",
+    "baseline_perf.yaml",
+    "optimized_perf.yaml",
+    "quality_loop_review.yaml",
+    "performance_report.json",
+    "compile_report.json",
+}
+GENERATED_DIRS = {
+    ".git",
+    ".pytest_cache",
+    ".quality_loop_no_gh",
+    ".quality_loop_original_sources",
+    ".rocprofv3",
+    "__pycache__",
+    "build",
+}
+
+
+def _digest(path: Path) -> str:
+    if path.is_symlink():
+        return "link:" + str(path.readlink())
+    value = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            value.update(chunk)
+    return value.hexdigest()
+
+
+def snapshot_tree(root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        rel = path.relative_to(root)
+        if any(part in GENERATED_DIRS for part in rel.parts):
+            continue
+        if path.is_file() or path.is_symlink():
+            result[rel.as_posix()] = _digest(path)
+    return result
+
+
+@dataclass(frozen=True)
+class TreeChanges:
+    added: tuple[str, ...]
+    modified: tuple[str, ...]
+    deleted: tuple[str, ...]
+
+    @property
+    def paths(self) -> tuple[str, ...]:
+        return self.added + self.modified + self.deleted
+
+    @property
+    def empty(self) -> bool:
+        return not self.paths
+
+
+def diff_trees(before: dict[str, str], after: dict[str, str]) -> TreeChanges:
+    return TreeChanges(
+        added=tuple(sorted(set(after) - set(before))),
+        modified=tuple(sorted(k for k in set(before) & set(after) if before[k] != after[k])),
+        deleted=tuple(sorted(set(before) - set(after))),
+    )
+
+
+def is_generated_path(relative: str, *, repo_subdir: str | None = None) -> bool:
+    path = Path(relative)
+    if path.name in GENERATED_NAMES:
+        return True
+    if any(part in GENERATED_DIRS for part in path.parts):
+        return True
+    if repo_subdir and path.parts and path.parts[0] == repo_subdir:
+        return True
+    return False
+
+
+def is_case_path(relative: str) -> bool:
+    path = Path(relative)
+    parts = set(path.parts[:-1])
+    name = path.name
+    return bool(
+        parts & {"script", "scripts", "test", "tests"}
+        or name.startswith("test_")
+        or name.endswith(("_test.py", "_harness.py"))
+    )
+
+
+def apply_changes(source: Path, destination: Path, changes: TreeChanges) -> None:
+    """Apply an already-validated, root-relative change set."""
+    source = source.resolve()
+    destination = destination.resolve()
+    for relative in changes.added + changes.modified:
+        src = (source / relative).resolve()
+        dst = (destination / relative).resolve()
+        if not src.is_relative_to(source) or not dst.is_relative_to(destination):
+            raise ValueError(f"unsafe quality_loop path: {relative}")
+        if not src.is_file() and not src.is_symlink():
+            raise ValueError(f"changed path is not a file: {relative}")
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_symlink():
+            if dst.exists() or dst.is_symlink():
+                dst.unlink()
+            dst.symlink_to(src.readlink())
+        else:
+            shutil.copy2(src, dst)
+    for relative in changes.deleted:
+        dst = (destination / relative).resolve()
+        if not dst.is_relative_to(destination):
+            raise ValueError(f"unsafe quality_loop deletion: {relative}")
+        if dst.is_file() or dst.is_symlink():
+            dst.unlink()
+
+
+def restore_committed_perf_stubs(task_root: Path) -> None:
+    """Undo runtime helper materialization before a task diff is committed."""
+    for helper in task_root.rglob("performance_utils_pytest.py"):
+        if helper.is_file():
+            helper.write_text(ROCMBENCH_HELPER_STUB, encoding="utf-8")
+    for runner in task_root.rglob("task_runner.py"):
+        if not runner.is_file():
+            continue
+        current = runner.read_text(encoding="utf-8")
+        if not (any(marker in current for marker in MARK_STARTS) or MARK_END in current):
+            continue
+        replaced = replace_marked_region(current, VLLM_HELPER_STUB_BLOCK)
+        if replaced is None:
+            raise RuntimeError(f"invalid AKA-GENERATED markers after audit: {runner}")
+        runner.write_text(replaced, encoding="utf-8")

--- a/agents/quality_loop/github.py
+++ b/agents/quality_loop/github.py
@@ -102,9 +102,6 @@ class GitHubPublisher:
                 f"authenticated GitHub user lacks write permission for {slug} "
                 f"(viewer_permission={permission or 'unknown'})"
             )
-        if repo_data.get("has_issues") is False:
-            raise RuntimeError(f"GitHub issues are disabled for {slug}")
-
         default_branch = self.config.base_branch or repo_data.get("default_branch")
         if not default_branch:
             raise RuntimeError(f"could not determine the default branch for {slug}")
@@ -202,65 +199,6 @@ class GitHubPublisher:
                 f"unexpected={unexpected}, missing={missing}"
             )
 
-    @staticmethod
-    def issue_marker(task_id: str, fingerprint: str) -> str:
-        return f"<!-- quality-loop task={task_id} fingerprint={fingerprint} -->"
-
-    def ensure_issue(
-        self,
-        *,
-        repo_slug: str,
-        task_id: str,
-        fingerprint: str,
-        title: str,
-        body: str,
-        artifact_dir: Path,
-    ) -> str:
-        marker = self.issue_marker(task_id, fingerprint)
-        existing_raw = run_command(
-            [
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                repo_slug,
-                "--state",
-                "all",
-                "--limit",
-                "1000",
-                "--json",
-                "number,body,state,url",
-            ],
-            cwd=self.repo_root,
-        ).stdout
-        for issue in json.loads(existing_raw or "[]"):
-            if marker not in str(issue.get("body") or ""):
-                continue
-            if str(issue.get("state", "")).upper() == "CLOSED":
-                run_command(
-                    ["gh", "issue", "reopen", str(issue["number"]), "--repo", repo_slug],
-                    cwd=self.repo_root,
-                )
-            return str(issue.get("url") or "")
-
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-        body_path = artifact_dir / "issue_body.md"
-        body_path.write_text(f"{marker}\n\n{body.rstrip()}\n", encoding="utf-8")
-        args = [
-            "gh",
-            "issue",
-            "create",
-            "--repo",
-            repo_slug,
-            "--title",
-            title,
-            "--body-file",
-            str(body_path),
-        ]
-        for label in self.config.issue_labels:
-            args.extend(["--label", label])
-        return run_command(args, cwd=self.repo_root).stdout.strip()
-
     def publish_draft_pr(
         self,
         *,
@@ -317,9 +255,8 @@ class GitHubPublisher:
             title,
             "--body-file",
             str(body_path),
+            "--draft",
         ]
-        if self.config.draft_pr:
-            args.append("--draft")
         existing = json.loads(
             run_command(
                 [

--- a/agents/quality_loop/github.py
+++ b/agents/quality_loop/github.py
@@ -1,0 +1,346 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .config import GitHubConfig
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def run_command(
+    args: Sequence[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        rendered = " ".join(args)
+        detail = (result.stderr or result.stdout).strip()
+        raise CommandError(f"command failed ({result.returncode}): {rendered}\n{detail}")
+    return result
+
+
+def parse_github_slug(remote: str) -> str:
+    remote = remote.strip()
+    patterns = (
+        r"^git@github\.com:([^/]+/[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+        r"^https?://github\.com/([^/]+/[^/]+?)(?:\.git)?/?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, remote)
+        if match:
+            return match.group(1)
+    raise ValueError(f"origin is not a supported GitHub remote: {remote!r}")
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    repo_slug: str
+    default_branch: str
+    base_sha: str
+    viewer_permission: str
+
+
+class GitHubPublisher:
+    """The only quality_loop component allowed to use GitHub credentials."""
+
+    def __init__(self, repo_root: Path, config: GitHubConfig, logger: logging.Logger):
+        self.repo_root = repo_root.resolve()
+        self.config = config
+        self.logger = logger
+
+    def preflight(self) -> PreflightResult:
+        for command in ("git", "gh", "codex"):
+            if not shutil.which(command):
+                raise RuntimeError(f"required command not found: {command}")
+
+        status = run_command(["git", "status", "--porcelain"], cwd=self.repo_root)
+        if status.stdout.strip():
+            raise RuntimeError(
+                "quality_loop requires a clean source worktree before creating "
+                "its isolated audit worktree"
+            )
+        run_command(["git", "var", "GIT_AUTHOR_IDENT"], cwd=self.repo_root)
+
+        run_command(["gh", "auth", "status", "-h", "github.com"], cwd=self.repo_root)
+        remote = run_command(
+            ["git", "remote", "get-url", "origin"], cwd=self.repo_root
+        ).stdout.strip()
+        slug = parse_github_slug(remote)
+        repo_data = json.loads(
+            run_command(["gh", "api", f"repos/{slug}"], cwd=self.repo_root).stdout
+        )
+        permissions = repo_data.get("permissions") or {}
+        permission = str(repo_data.get("viewer_permission") or "").upper()
+        push_allowed = bool(permissions.get("push")) or permission in {
+            "WRITE",
+            "MAINTAIN",
+            "ADMIN",
+        }
+        if not push_allowed:
+            raise RuntimeError(
+                f"authenticated GitHub user lacks write permission for {slug} "
+                f"(viewer_permission={permission or 'unknown'})"
+            )
+        if repo_data.get("has_issues") is False:
+            raise RuntimeError(f"GitHub issues are disabled for {slug}")
+
+        default_branch = self.config.base_branch or repo_data.get("default_branch")
+        if not default_branch:
+            raise RuntimeError(f"could not determine the default branch for {slug}")
+        run_command(["git", "fetch", "origin", default_branch], cwd=self.repo_root, timeout=600)
+        base_sha = run_command(
+            ["git", "rev-parse", f"origin/{default_branch}"], cwd=self.repo_root
+        ).stdout.strip()
+        return PreflightResult(slug, str(default_branch), base_sha, permission or "WRITE")
+
+    def create_worktree(
+        self,
+        *,
+        path: Path,
+        branch: str,
+        base_branch: str,
+    ) -> None:
+        if path.exists():
+            raise RuntimeError(f"quality_loop worktree already exists: {path}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        run_command(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(path),
+                f"origin/{base_branch}",
+            ],
+            cwd=self.repo_root,
+            timeout=600,
+        )
+
+    def commit_task(self, worktree: Path, task_id: str) -> str | None:
+        relative = f"tasks/{task_id}"
+        run_command(["git", "add", "--", relative], cwd=worktree)
+        staged = run_command(
+            ["git", "diff", "--cached", "--quiet", "--", relative],
+            cwd=worktree,
+            check=False,
+        )
+        if staged.returncode == 0:
+            return None
+        if staged.returncode != 1:
+            raise CommandError(f"could not inspect staged changes for {task_id}")
+        run_command(
+            ["git", "commit", "-m", f"fix(tasks): quality audit {task_id}"],
+            cwd=worktree,
+            timeout=600,
+        )
+        return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).stdout.strip()
+
+    def verify_pending_changes(
+        self,
+        *,
+        worktree: Path,
+        branch: str,
+        base_sha: str,
+        expected_paths: set[str],
+    ) -> None:
+        top = Path(
+            run_command(["git", "rev-parse", "--show-toplevel"], cwd=worktree)
+            .stdout.strip()
+        ).resolve()
+        if top != worktree.resolve():
+            raise RuntimeError(f"quality_loop worktree identity changed: {top}")
+        current_branch = run_command(
+            ["git", "branch", "--show-current"], cwd=worktree
+        ).stdout.strip()
+        if current_branch != branch:
+            raise RuntimeError(
+                f"quality_loop worktree branch changed: expected {branch}, got {current_branch}"
+            )
+        ancestor = run_command(
+            ["git", "merge-base", "--is-ancestor", base_sha, "HEAD"],
+            cwd=worktree,
+            check=False,
+        )
+        if ancestor.returncode != 0:
+            raise RuntimeError("quality_loop worktree no longer descends from its recorded base")
+
+        changed: set[str] = set()
+        for args in (
+            ["git", "diff", "--name-only", "HEAD"],
+            ["git", "diff", "--cached", "--name-only"],
+            ["git", "ls-files", "--others", "--exclude-standard"],
+        ):
+            output = run_command(args, cwd=worktree).stdout
+            changed.update(line for line in output.splitlines() if line)
+        if changed != expected_paths:
+            unexpected = sorted(changed - expected_paths)
+            missing = sorted(expected_paths - changed)
+            raise RuntimeError(
+                "quality_loop worktree diff does not match accepted task changes; "
+                f"unexpected={unexpected}, missing={missing}"
+            )
+
+    @staticmethod
+    def issue_marker(task_id: str, fingerprint: str) -> str:
+        return f"<!-- quality-loop task={task_id} fingerprint={fingerprint} -->"
+
+    def ensure_issue(
+        self,
+        *,
+        repo_slug: str,
+        task_id: str,
+        fingerprint: str,
+        title: str,
+        body: str,
+        artifact_dir: Path,
+    ) -> str:
+        marker = self.issue_marker(task_id, fingerprint)
+        existing_raw = run_command(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo_slug,
+                "--state",
+                "all",
+                "--limit",
+                "1000",
+                "--json",
+                "number,body,state,url",
+            ],
+            cwd=self.repo_root,
+        ).stdout
+        for issue in json.loads(existing_raw or "[]"):
+            if marker not in str(issue.get("body") or ""):
+                continue
+            if str(issue.get("state", "")).upper() == "CLOSED":
+                run_command(
+                    ["gh", "issue", "reopen", str(issue["number"]), "--repo", repo_slug],
+                    cwd=self.repo_root,
+                )
+            return str(issue.get("url") or "")
+
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        body_path = artifact_dir / "issue_body.md"
+        body_path.write_text(f"{marker}\n\n{body.rstrip()}\n", encoding="utf-8")
+        args = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo_slug,
+            "--title",
+            title,
+            "--body-file",
+            str(body_path),
+        ]
+        for label in self.config.issue_labels:
+            args.extend(["--label", label])
+        return run_command(args, cwd=self.repo_root).stdout.strip()
+
+    def publish_draft_pr(
+        self,
+        *,
+        worktree: Path,
+        repo_slug: str,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+        artifact_dir: Path,
+    ) -> str | None:
+        ahead = int(
+            run_command(
+                ["git", "rev-list", "--count", f"origin/{base_branch}..HEAD"],
+                cwd=worktree,
+            ).stdout.strip()
+            or "0"
+        )
+        if ahead == 0:
+            self.logger.info("No accepted task changes; skipping empty pull request")
+            return None
+
+        # Use gh's credential helper explicitly so an SSH origin does not require
+        # forwarding private SSH keys into the GPU container.
+        https_remote = f"https://github.com/{repo_slug}.git"
+        run_command(
+            [
+                "git",
+                "-c",
+                "credential.helper=!gh auth git-credential",
+                "push",
+                "--set-upstream",
+                https_remote,
+                branch,
+            ],
+            cwd=worktree,
+            timeout=1200,
+        )
+
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        body_path = artifact_dir / "pull_request_body.md"
+        body_path.write_text(body.rstrip() + "\n", encoding="utf-8")
+        args = [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            repo_slug,
+            "--head",
+            branch,
+            "--base",
+            base_branch,
+            "--title",
+            title,
+            "--body-file",
+            str(body_path),
+        ]
+        if self.config.draft_pr:
+            args.append("--draft")
+        existing = json.loads(
+            run_command(
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--repo",
+                    repo_slug,
+                    "--head",
+                    branch,
+                    "--state",
+                    "all",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "url",
+                ],
+                cwd=worktree,
+            ).stdout
+            or "[]"
+        )
+        if existing:
+            return str(existing[0].get("url") or "")
+        return run_command(args, cwd=worktree, timeout=300).stdout.strip()

--- a/agents/quality_loop/host.py
+++ b/agents/quality_loop/host.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from .config import QualityLoopConfig, load_config
 from .github import GitHubPublisher
-from .orchestrator import QualityLoop, _task_slug
+from .orchestrator import QualityLoop
 from .state import AuditState, resolve_worktree, stable_fingerprint, validate_run_id
 
 
@@ -144,21 +144,6 @@ def finalize(config: QualityLoopConfig, run_id: str, logger: logging.Logger) -> 
         record["commit"] = commit
         record["commit_pending"] = False
         state.save()
-
-    if config.github.publish:
-        for task_id, record in state.data.get("tasks", {}).items():
-            if record.get("state") != "issue_pending":
-                continue
-            request = record.get("issue_request") or {}
-            issue_url = publisher.ensure_issue(
-                repo_slug=str(state.data["repo_slug"]),
-                task_id=task_id,
-                fingerprint=str(request["fingerprint"]),
-                title=str(request["title"]),
-                body=str(request["body"]),
-                artifact_dir=artifact / "tasks" / _task_slug(task_id),
-            )
-            state.transition(task_id, "issue_filed", issue_url=issue_url)
 
     workflow = QualityLoop(REPO_ROOT, config, logger=logger, publisher=publisher)
     workflow.state = state

--- a/agents/quality_loop/host.py
+++ b/agents/quality_loop/host.py
@@ -1,0 +1,212 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+"""Host-side GitHub preflight and publication for credential isolation."""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .config import QualityLoopConfig, load_config
+from .github import GitHubPublisher
+from .orchestrator import QualityLoop, _task_slug
+from .state import AuditState, resolve_worktree, stable_fingerprint, validate_run_id
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = Path(__file__).with_name("agent_config.yaml")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="quality_loop host publication boundary")
+    parser.add_argument("action", choices=("start", "check", "paths", "finalize"))
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--tasks", nargs="+")
+    parser.add_argument("--no-publish", action="store_true")
+    parser.add_argument("--resume")
+    parser.add_argument("--run-id")
+    return parser
+
+
+def _effective_config(args: argparse.Namespace) -> QualityLoopConfig:
+    path = args.config if args.config.is_absolute() else REPO_ROOT / args.config
+    config = load_config(path)
+    if args.tasks:
+        config = dataclasses.replace(config, tasks=tuple(args.tasks))
+    if args.no_publish:
+        config = dataclasses.replace(
+            config,
+            github=dataclasses.replace(config.github, publish=False),
+        )
+    return config
+
+
+def _logger() -> logging.Logger:
+    logger = logging.getLogger("quality_loop.host")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+        logger.addHandler(handler)
+    return logger
+
+
+def _paths(config: QualityLoopConfig, run_id: str) -> tuple[Path, Path, Path]:
+    artifact = (REPO_ROOT / config.artifact_root / run_id).resolve()
+    worktree = (REPO_ROOT / config.worktree_root / run_id).resolve()
+    return artifact, worktree, artifact / "state.yaml"
+
+
+def start(config: QualityLoopConfig, run_id: str, logger: logging.Logger) -> str:
+    validate_run_id(run_id)
+    publisher = GitHubPublisher(REPO_ROOT, config.github, logger)
+    preflight = publisher.preflight()
+    artifact, worktree, state_path = _paths(config, run_id)
+    if artifact.exists() or worktree.exists():
+        raise RuntimeError(f"quality_loop run already exists: {run_id}")
+    branch = f"{config.github.branch_prefix}/{run_id}"
+    publisher.create_worktree(
+        path=worktree,
+        branch=branch,
+        base_branch=preflight.default_branch,
+    )
+    AuditState.create(
+        state_path,
+        run_id=run_id,
+        config_fingerprint=stable_fingerprint(config),
+        repo_slug=preflight.repo_slug,
+        base_sha=preflight.base_sha,
+        base_branch=preflight.default_branch,
+        branch=branch,
+        worktree=worktree.relative_to(REPO_ROOT),
+    )
+    return run_id
+
+
+def check(config: QualityLoopConfig, run_id: str, logger: logging.Logger) -> str:
+    validate_run_id(run_id)
+    publisher = GitHubPublisher(REPO_ROOT, config.github, logger)
+    preflight = publisher.preflight()
+    _, worktree, state_path = _paths(config, run_id)
+    state = AuditState.load(state_path)
+    if state.data.get("config_fingerprint") != stable_fingerprint(config):
+        raise RuntimeError("resume config does not match the original quality_loop run")
+    if state.data.get("repo_slug") != preflight.repo_slug:
+        raise RuntimeError("resume repository does not match the original quality_loop run")
+    if (
+        resolve_worktree(REPO_ROOT, str(state.data.get("worktree"))) != worktree
+        or not worktree.is_dir()
+    ):
+        raise RuntimeError(f"resume worktree is missing or changed: {worktree}")
+    return run_id
+
+
+def finalize(config: QualityLoopConfig, run_id: str, logger: logging.Logger) -> str:
+    validate_run_id(run_id)
+    publisher = GitHubPublisher(REPO_ROOT, config.github, logger)
+    preflight = publisher.preflight()
+    artifact, worktree, state_path = _paths(config, run_id)
+    state = AuditState.load(state_path)
+    if state.data.get("status") != "awaiting_publication":
+        raise RuntimeError(
+            f"quality_loop run is not ready for publication: {state.data.get('status')}"
+        )
+    if state.data.get("config_fingerprint") != stable_fingerprint(config):
+        raise RuntimeError("publication config does not match the original quality_loop run")
+    if state.data.get("repo_slug") != preflight.repo_slug:
+        raise RuntimeError("publication repository does not match the original quality_loop run")
+    if (
+        resolve_worktree(REPO_ROOT, str(state.data.get("worktree"))) != worktree
+        or not worktree.is_dir()
+    ):
+        raise RuntimeError(f"publication worktree is missing or changed: {worktree}")
+
+    expected_paths = {
+        f"tasks/{task_id}/{relative}"
+        for task_id, record in state.data.get("tasks", {}).items()
+        if record.get("state") == "completed" and record.get("commit_pending")
+        for relative in record.get("changes", [])
+    }
+    publisher.verify_pending_changes(
+        worktree=worktree,
+        branch=str(state.data["branch"]),
+        base_sha=str(state.data["base_sha"]),
+        expected_paths=expected_paths,
+    )
+
+    for task_id, record in state.data.get("tasks", {}).items():
+        if record.get("state") != "completed" or not record.get("commit_pending"):
+            continue
+        commit = publisher.commit_task(worktree, task_id)
+        if not commit:
+            raise RuntimeError(f"accepted changes disappeared before commit: {task_id}")
+        record["commit"] = commit
+        record["commit_pending"] = False
+        state.save()
+
+    if config.github.publish:
+        for task_id, record in state.data.get("tasks", {}).items():
+            if record.get("state") != "issue_pending":
+                continue
+            request = record.get("issue_request") or {}
+            issue_url = publisher.ensure_issue(
+                repo_slug=str(state.data["repo_slug"]),
+                task_id=task_id,
+                fingerprint=str(request["fingerprint"]),
+                title=str(request["title"]),
+                body=str(request["body"]),
+                artifact_dir=artifact / "tasks" / _task_slug(task_id),
+            )
+            state.transition(task_id, "issue_filed", issue_url=issue_url)
+
+    workflow = QualityLoop(REPO_ROOT, config, logger=logger, publisher=publisher)
+    workflow.state = state
+    workflow.artifact_dir = artifact
+    workflow.worktree = worktree
+    workflow.preflight = preflight
+    report_path = workflow._write_report()
+    pr_url = None
+    if config.github.publish:
+        pr_url = publisher.publish_draft_pr(
+            worktree=worktree,
+            repo_slug=str(state.data["repo_slug"]),
+            branch=str(state.data["branch"]),
+            base_branch=str(state.data["base_branch"]),
+            title="audit(tasks): quality_loop task quality pass",
+            body=workflow._pull_request_body(report_path),
+            artifact_dir=artifact,
+        )
+    state.finish("completed", pull_request_url=pr_url)
+    return pr_url or "no pull request (no accepted changes or publication disabled)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args, unknown = _parser().parse_known_args(argv)
+    if unknown:
+        raise ValueError(f"unknown quality_loop host arguments: {unknown}")
+    config = _effective_config(args)
+    run_id = args.run_id or args.resume
+    if args.action == "start":
+        run_id = run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        print(start(config, run_id, _logger()))
+    elif args.action == "check":
+        if not run_id:
+            raise ValueError("check requires --resume or --run-id")
+        print(check(config, run_id, _logger()))
+    elif args.action == "paths":
+        if not run_id:
+            raise ValueError("paths requires --resume or --run-id")
+        validate_run_id(run_id)
+        artifact, worktree, _ = _paths(config, run_id)
+        print(artifact.relative_to(REPO_ROOT))
+        print(worktree.relative_to(REPO_ROOT))
+    else:
+        if not run_id:
+            raise ValueError("finalize requires --run-id")
+        print(finalize(config, run_id, _logger()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/quality_loop/orchestrator.py
+++ b/agents/quality_loop/orchestrator.py
@@ -1,0 +1,899 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agents.quality_loop.backend import AgentBackend, CodexBackend
+from agents.quality_loop.config import QualityLoopConfig
+from agents.quality_loop.filesystem import (
+    TreeChanges,
+    apply_changes,
+    diff_trees,
+    is_case_path,
+    is_generated_path,
+    restore_committed_perf_stubs,
+    snapshot_tree,
+)
+from agents.quality_loop.github import GitHubPublisher, PreflightResult
+from agents.quality_loop.prompts import (
+    case_enhancement_prompt,
+    optimizer_prompt,
+    repair_prompt,
+    reviewer_prompt,
+)
+from agents.quality_loop.state import (
+    AuditState,
+    resolve_worktree,
+    stable_fingerprint,
+    validate_run_id,
+)
+from agents.task_validator.validation_prompt import build_validation_prompt
+from src.evaluator import (
+    evaluate_compilation,
+    evaluate_correctness,
+    evaluate_kernel,
+    measure_baseline,
+    write_task_result,
+)
+from src.harness_guard import snapshot_workspace_harness, verify_workspace_harness
+from src.perf_helper_materialization import materialize_perf_helpers_in_workspace
+from src.preprocessing import _resolve_gfx_arch, setup_workspace
+from src.prompt_builder import prompt_builder
+from src.testcases import collect_benchmark_methods
+
+
+def _task_slug(task_id: str) -> str:
+    return task_id.replace("/", "__")
+
+
+def _source_paths(config: dict[str, Any]) -> tuple[str, ...]:
+    raw = config.get("source_file_path", [])
+    if isinstance(raw, str):
+        raw = [raw]
+    return tuple(str(path) for path in raw if str(path).strip())
+
+
+def _repo_subdir(config: dict[str, Any]) -> str | None:
+    if config.get("repo_subdir"):
+        return str(config["repo_subdir"])
+    if config.get("image_repo_path"):
+        return Path(str(config["image_repo_path"])).name
+    if config.get("repo_url"):
+        name = str(config["repo_url"]).rstrip("/").rsplit("/", 1)[-1]
+        return name[:-4] if name.endswith(".git") else name
+    return None
+
+
+def _filtered_changes(
+    before: dict[str, str],
+    after: dict[str, str],
+    *,
+    repo_subdir: str | None,
+) -> TreeChanges:
+    changes = diff_trees(before, after)
+    return TreeChanges(
+        added=tuple(p for p in changes.added if not is_generated_path(p, repo_subdir=repo_subdir)),
+        modified=tuple(
+            p for p in changes.modified if not is_generated_path(p, repo_subdir=repo_subdir)
+        ),
+        deleted=tuple(
+            p for p in changes.deleted if not is_generated_path(p, repo_subdir=repo_subdir)
+        ),
+    )
+
+
+def _validation_warnings(report: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    for name, check in (report.get("checks") or {}).items():
+        if isinstance(check, dict) and str(check.get("status", "")).upper() == "WARN":
+            warnings.append(f"{name}: {check.get('details') or check.get('analysis') or 'warning'}")
+    return warnings
+
+
+def _review_is_valid(review: Any) -> bool:
+    if not isinstance(review, dict):
+        return False
+    for key in (
+        "accepted",
+        "logic_equivalent",
+        "evidence_sufficient",
+        "case_enhancement_needed",
+    ):
+        if not isinstance(review.get(key), bool):
+            return False
+    return isinstance(review.get("summary"), str) and isinstance(
+        review.get("case_rationale"), str
+    )
+
+
+def difficulty_is_easy(
+    *,
+    task_type: str,
+    speedups: list[float],
+    result: dict[str, Any],
+    review: dict[str, Any],
+    config: QualityLoopConfig,
+) -> bool:
+    """Return true only for a reproducible, review-approved first-iteration 5x gain."""
+    return bool(
+        task_type in config.promotion_task_types
+        and len(speedups) == config.easy_confirmation_runs
+        and all(value > 0 for value in speedups)
+        and statistics.median(speedups) >= config.easy_speedup_threshold
+        and result.get("pass_compilation") is True
+        and result.get("pass_correctness") is True
+        and result.get("benchmark_method_consistent") is True
+        and int(result.get("valid_baseline_cases", 0)) > 0
+        and result.get("valid_baseline_cases") == result.get("valid_optimized_cases")
+        and review.get("accepted") is True
+        and review.get("logic_equivalent") is True
+        and review.get("evidence_sufficient") is True
+    )
+
+
+class QualityLoop:
+    def __init__(
+        self,
+        repo_root: Path,
+        config: QualityLoopConfig,
+        *,
+        logger: logging.Logger,
+        backend: AgentBackend | None = None,
+        reviewer_backend: AgentBackend | None = None,
+        publisher: GitHubPublisher | None = None,
+        defer_github: bool = False,
+    ):
+        self.repo_root = repo_root.resolve()
+        self.config = config
+        self.logger = logger
+        self.backend = backend or CodexBackend(config.backend, logger)
+        self.reviewer_backend = reviewer_backend or CodexBackend(config.reviewer, logger)
+        self.publisher = publisher or GitHubPublisher(self.repo_root, config.github, logger)
+        self.defer_github = defer_github
+        self.state: AuditState | None = None
+        self.artifact_dir: Path | None = None
+        self.worktree: Path | None = None
+        self.preflight: PreflightResult | None = None
+
+    def discover_tasks(self, root: Path | None = None) -> dict[str, Path]:
+        tasks_root = (root or self.repo_root) / "tasks"
+        discovered = {
+            str(path.parent.relative_to(tasks_root)): path
+            for path in tasks_root.rglob("config.yaml")
+        }
+        if "all" in self.config.tasks:
+            return dict(sorted(discovered.items()))
+        selected: dict[str, Path] = {}
+        missing: list[str] = []
+        for selector in self.config.tasks:
+            matches = {
+                task_id: path
+                for task_id, path in discovered.items()
+                if task_id == selector or task_id.startswith(selector.rstrip("/") + "/")
+            }
+            if not matches:
+                missing.append(selector)
+            selected.update(matches)
+        if missing:
+            raise ValueError(f"task selector(s) matched nothing: {missing}")
+        return dict(sorted(selected.items()))
+
+    def plan(self) -> dict[str, Any]:
+        tasks = self.discover_tasks()
+        gfx_arch = _resolve_gfx_arch(self.config.target_gpu_model)
+        runnable: list[str] = []
+        deferred: list[str] = []
+        for task_id, config_path in tasks.items():
+            task_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            if self._platform_matches(task_config, gfx_arch):
+                runnable.append(task_id)
+            else:
+                deferred.append(task_id)
+        return {
+            "total": len(tasks),
+            "runnable": runnable,
+            "platform_deferred": deferred,
+            "target_gpu_model": self.config.target_gpu_model,
+            "gfx_arch": gfx_arch,
+            "backend": self.config.backend.name,
+            "optimization_iterations": self.config.optimization_iterations,
+        }
+
+    @staticmethod
+    def _platform_matches(task_config: dict[str, Any], gfx_arch: str | None) -> bool:
+        platform = task_config.get("platform_support")
+        if not isinstance(platform, dict):
+            return True
+        if str(platform.get("status", "active")).strip().lower() == "skip":
+            return False
+        required = platform.get("required_arch")
+        return not required or (gfx_arch is not None and str(required).strip() == gfx_arch)
+
+    def run(
+        self,
+        *,
+        resume_run_id: str | None = None,
+        skip_preflight: bool = False,
+    ) -> Path:
+        run_id = resume_run_id or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        validate_run_id(run_id)
+        self.artifact_dir = (self.repo_root / self.config.artifact_root / run_id).resolve()
+        state_path = self.artifact_dir / "state.yaml"
+        fingerprint = stable_fingerprint(self.config)
+
+        if resume_run_id:
+            self.state = AuditState.load(state_path)
+            if self.state.data.get("config_fingerprint") != fingerprint:
+                raise RuntimeError("resume config does not match the original quality_loop run")
+            self.worktree = resolve_worktree(
+                self.repo_root, str(self.state.data["worktree"])
+            )
+            if not self.worktree.is_dir():
+                raise RuntimeError(f"resume worktree is missing: {self.worktree}")
+            if skip_preflight:
+                self.preflight = PreflightResult(
+                    repo_slug=str(self.state.data["repo_slug"]),
+                    default_branch=str(self.state.data["base_branch"]),
+                    base_sha=str(self.state.data["base_sha"]),
+                    viewer_permission="WRITE",
+                )
+            else:
+                self.preflight = self.publisher.preflight()
+        else:
+            if skip_preflight:
+                raise ValueError("skip_preflight is only valid for a host-initialized resume run")
+            self.preflight = self.publisher.preflight()
+            branch = f"{self.config.github.branch_prefix}/{run_id}"
+            self.worktree = (self.repo_root / self.config.worktree_root / run_id).resolve()
+            self.publisher.create_worktree(
+                path=self.worktree,
+                branch=branch,
+                base_branch=self.preflight.default_branch,
+            )
+            self.state = AuditState.create(
+                state_path,
+                run_id=run_id,
+                config_fingerprint=fingerprint,
+                repo_slug=self.preflight.repo_slug,
+                base_sha=self.preflight.base_sha,
+                base_branch=self.preflight.default_branch,
+                branch=branch,
+                worktree=self.worktree.relative_to(self.repo_root),
+            )
+
+        assert self.state is not None and self.worktree is not None
+        tasks = self.discover_tasks(self.worktree)
+        gfx_arch = _resolve_gfx_arch(self.config.target_gpu_model)
+        for index, (task_id, config_path) in enumerate(tasks.items(), 1):
+            if self.state.is_terminal(task_id):
+                self.logger.info("Resume: skipping terminal task %s", task_id)
+                continue
+            task_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            if not self._platform_matches(task_config, gfx_arch):
+                self.state.transition(
+                    task_id,
+                    "platform_deferred",
+                    reason=f"requires a different platform than {gfx_arch or 'unknown'}",
+                )
+                continue
+            self.logger.info("quality_loop task %d/%d: %s", index, len(tasks), task_id)
+            try:
+                self._process_task(task_id, config_path.parent)
+            except Exception as exc:
+                self.logger.exception("quality_loop task failed: %s", task_id)
+                # Tooling/agent/runtime failures are not evidence that the task is
+                # defective. Keep them resumable and never file a task issue.
+                self.state.transition(task_id, "infrastructure_failed", error=str(exc))
+
+        report_path = self._write_report()
+        infrastructure_failures = [
+            task_id
+            for task_id, record in self.state.data.get("tasks", {}).items()
+            if record.get("state") == "infrastructure_failed"
+        ]
+        if infrastructure_failures:
+            self.state.finish("incomplete")
+            raise RuntimeError(
+                "quality_loop cannot publish until infrastructure failures are resumed: "
+                + ", ".join(infrastructure_failures)
+            )
+        if self.defer_github:
+            self.state.finish("awaiting_publication")
+            return report_path
+        pr_url = None
+        if self.config.github.publish and not self.defer_github:
+            pr_url = self.publisher.publish_draft_pr(
+                worktree=self.worktree,
+                repo_slug=str(self.state.data["repo_slug"]),
+                branch=str(self.state.data["branch"]),
+                base_branch=str(self.state.data["base_branch"]),
+                title="audit(tasks): quality_loop task quality pass",
+                body=self._pull_request_body(report_path),
+                artifact_dir=self.artifact_dir,
+            )
+        self.state.finish("completed", pull_request_url=pr_url)
+        return report_path
+
+    def _process_task(self, task_id: str, canonical_task: Path) -> None:
+        assert self.state is not None
+        assert self.artifact_dir is not None
+        assert self.worktree is not None
+        task_artifacts = self.artifact_dir / "tasks" / _task_slug(task_id)
+        original_task = task_artifacts / "original_task"
+        candidate_task = task_artifacts / "candidate_task"
+        self._reset_path(task_artifacts)
+        task_artifacts.mkdir(parents=True)
+        shutil.copytree(canonical_task, original_task)
+        shutil.copytree(canonical_task, candidate_task)
+        original_tree = snapshot_tree(original_task)
+        original_validation_status = "FAIL"
+
+        self.state.transition(task_id, "validating")
+        validation_workspace, validation = self._validate(
+            task_id, candidate_task, task_artifacts / "validation_initial"
+        )
+        original_validation_status = str(validation.get("overall_status", "FAIL")).upper()
+        warnings = _validation_warnings(validation)
+
+        if original_validation_status == "FAIL":
+            if self.config.max_repair_attempts == 0:
+                self._handle_unrepairable(task_id, validation, task_artifacts)
+                return
+            self.state.transition(task_id, "repairing", warnings=warnings)
+            task_config = self._load_task_config(candidate_task)
+            before = snapshot_tree(validation_workspace)
+            self.backend.run(
+                repair_prompt(validation, task_id), validation_workspace, role="repair"
+            )
+            after = snapshot_tree(validation_workspace)
+            changes = _filtered_changes(
+                before, after, repo_subdir=_repo_subdir(task_config)
+            )
+            if changes.empty:
+                self._handle_unrepairable(task_id, validation, task_artifacts)
+                return
+            apply_changes(validation_workspace, candidate_task, changes)
+            restore_committed_perf_stubs(candidate_task)
+            _, validation = self._validate(
+                task_id, candidate_task, task_artifacts / "validation_repaired"
+            )
+            warnings = _validation_warnings(validation)
+            if str(validation.get("overall_status", "FAIL")).upper() == "FAIL":
+                self._handle_unrepairable(task_id, validation, task_artifacts)
+                return
+
+        self.state.transition(task_id, "optimizing", warnings=warnings)
+        optimization_workspace, baseline_cases, result = self._optimize_once(
+            task_id, candidate_task, task_artifacts / "optimization"
+        )
+        review = self._review(task_id, optimization_workspace, result)
+        speedups = [float(result.get("speedup_ratio") or 0.0)]
+        if speedups[0] >= self.config.easy_speedup_threshold and review.get("accepted"):
+            for _ in range(1, self.config.easy_confirmation_runs):
+                eval_result = evaluate_kernel(
+                    optimization_workspace,
+                    self._load_task_config(candidate_task),
+                    baseline_cases,
+                    self.logger,
+                )
+                baseline_methods = set(collect_benchmark_methods(baseline_cases))
+                optimized_methods = set(eval_result.get("optimized_benchmark_methods") or [])
+                repeated_valid = bool(
+                    eval_result.get("pass_compilation")
+                    and eval_result.get("pass_correctness")
+                    and baseline_methods
+                    and baseline_methods == optimized_methods
+                    and int(eval_result.get("valid_baseline_cases", 0)) > 0
+                    and eval_result.get("valid_baseline_cases")
+                    == eval_result.get("valid_optimized_cases")
+                )
+                speedups.append(
+                    float(eval_result.get("average_speedup") or 0.0)
+                    if repeated_valid
+                    else 0.0
+                )
+
+        hardened = False
+        task_config = self._load_task_config(candidate_task)
+        if difficulty_is_easy(
+            task_type=str(task_config.get("task_type", "")),
+            speedups=speedups,
+            result=result,
+            review=review,
+            config=self.config,
+        ):
+            hardened = self._promote_baseline(
+                task_id,
+                original_task,
+                candidate_task,
+                optimization_workspace,
+                task_artifacts,
+            )
+
+        cases_enhanced = False
+        if (
+            self.config.case_enhancement
+            and review.get("accepted") is True
+            and review.get("case_enhancement_needed") is True
+            and original_validation_status in {"PASS", "WARN"}
+        ):
+            cases_enhanced = self._enhance_cases(
+                task_id,
+                original_task,
+                candidate_task,
+                str(review.get("case_rationale", "")),
+                task_artifacts,
+            )
+
+        restore_committed_perf_stubs(candidate_task)
+        candidate_tree = snapshot_tree(candidate_task)
+        final_changes = _filtered_changes(
+            original_tree,
+            candidate_tree,
+            repo_subdir=_repo_subdir(task_config),
+        )
+        commit = None
+        commit_pending = False
+        if not final_changes.empty:
+            apply_changes(candidate_task, canonical_task, final_changes)
+            restore_committed_perf_stubs(canonical_task)
+            if self.defer_github:
+                # A linked worktree's .git file contains a host-absolute path,
+                # which is intentionally unavailable inside the GPU container.
+                # The credential-bearing host finalizer verifies and commits it.
+                commit_pending = True
+            else:
+                commit = self.publisher.commit_task(self.worktree, task_id)
+        self.state.transition(
+            task_id,
+            "completed",
+            warnings=warnings,
+            changes=list(final_changes.paths),
+            commit=commit,
+            commit_pending=commit_pending,
+            speedups=speedups,
+            reviewer=review,
+            baseline_hardened=hardened,
+            cases_enhanced=cases_enhanced,
+        )
+
+    def _validate(
+        self, task_id: str, task_dir: Path, stage_dir: Path
+    ) -> tuple[Path, dict[str, Any]]:
+        workspace = self._make_workspace(task_id, task_dir, stage_dir)
+        prompt = build_validation_prompt(
+            str(task_dir / "config.yaml"),
+            str(workspace),
+            self._eval_config(),
+        )
+        self.backend.run(prompt, workspace, role="validator")
+        report_path = workspace / "validation_report.yaml"
+        if not report_path.exists():
+            report = {
+                "task_name": task_id,
+                "overall_status": "FAIL",
+                "checks": {},
+                "summary": "validator backend did not produce validation_report.yaml",
+            }
+            report_path.write_text(yaml.safe_dump(report), encoding="utf-8")
+            return workspace, report
+        report = yaml.safe_load(report_path.read_text(encoding="utf-8")) or {}
+        if not isinstance(report, dict) or str(report.get("overall_status", "")).upper() not in {
+            "PASS",
+            "WARN",
+            "FAIL",
+        }:
+            raise RuntimeError(f"invalid validator report for {task_id}: {report_path}")
+        return workspace, report
+
+    def _optimize_once(
+        self, task_id: str, task_dir: Path, stage_dir: Path
+    ) -> tuple[Path, list[Any], dict[str, Any]]:
+        workspace = self._make_workspace(task_id, task_dir, stage_dir)
+        task_config = self._load_task_config(task_dir)
+        original_sources = stage_dir / "original_sources"
+        original_sources.mkdir()
+        source_manifest: dict[str, str] = {}
+        for relative in _source_paths(task_config):
+            source = (workspace / relative).resolve()
+            if not source.is_relative_to(workspace.resolve()) or not source.is_file():
+                source_manifest[relative] = "missing"
+                continue
+            destination = original_sources / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            source_manifest[relative] = "copied"
+        (original_sources / "manifest.yaml").write_text(
+            yaml.safe_dump(source_manifest, sort_keys=True), encoding="utf-8"
+        )
+        original_source_tree = snapshot_tree(original_sources)
+        task_type = str(task_config.get("task_type", ""))
+        if task_type == "torch2hip":
+            baseline_cases = measure_baseline(workspace, task_config, self.logger)
+        else:
+            compiled, error = evaluate_compilation(workspace, task_config, self.logger)
+            if not compiled:
+                raise RuntimeError(f"baseline compilation failed after validation: {error}")
+            baseline_cases = measure_baseline(workspace, task_config, self.logger)
+
+        harness = snapshot_workspace_harness(workspace)
+        base_prompt = prompt_builder(
+            str(task_dir / "config.yaml"),
+            str(workspace),
+            self._eval_config(),
+            self.logger,
+        )
+        self.backend.run(
+            optimizer_prompt(base_prompt, task_id), workspace, role="optimizer"
+        )
+        verify_workspace_harness(harness)
+        if snapshot_tree(original_sources) != original_source_tree:
+            raise RuntimeError("optimizer modified the protected original-source snapshot")
+        materialize_perf_helpers_in_workspace(workspace, logger=self.logger)
+        evaluation = evaluate_kernel(workspace, task_config, baseline_cases, self.logger)
+        write_task_result(
+            workspace,
+            evaluation,
+            baseline_cases,
+            task_id,
+            "quality_loop/codex",
+            self.logger,
+            create_plots=False,
+        )
+        shutil.copytree(
+            original_sources,
+            workspace / ".quality_loop_original_sources",
+        )
+        return workspace, baseline_cases, yaml.safe_load(
+            (workspace / "task_result.yaml").read_text(encoding="utf-8")
+        )
+
+    def _review(
+        self, task_id: str, workspace: Path, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        output_name = "quality_loop_review.yaml"
+        before = snapshot_tree(workspace)
+        evidence_names = (
+            "task_result.yaml",
+            "baseline_perf.yaml",
+            "optimized_perf.yaml",
+        )
+        evidence_before = {
+            name: (workspace / name).read_bytes()
+            for name in evidence_names
+            if (workspace / name).is_file()
+        }
+        original_sources = workspace / ".quality_loop_original_sources"
+        original_before = snapshot_tree(original_sources)
+        self.reviewer_backend.run(
+            reviewer_prompt(task_id, workspace / "task_result.yaml", output_name),
+            workspace,
+            role="reviewer",
+        )
+        after = snapshot_tree(workspace)
+        evidence_after = {
+            name: (workspace / name).read_bytes()
+            for name in evidence_names
+            if (workspace / name).is_file()
+        }
+        if (
+            evidence_after != evidence_before
+            or snapshot_tree(original_sources) != original_before
+        ):
+            raise RuntimeError("reviewer modified protected evaluation evidence")
+        changes = diff_trees(before, after)
+        unexpected = [path for path in changes.paths if path != output_name]
+        if unexpected:
+            raise RuntimeError(f"reviewer modified non-review files: {unexpected}")
+        review_path = workspace / output_name
+        review = (
+            yaml.safe_load(review_path.read_text(encoding="utf-8"))
+            if review_path.exists()
+            else None
+        )
+        if not _review_is_valid(review):
+            raise RuntimeError(f"reviewer returned an invalid decision for {task_id}")
+        if not (
+            result.get("pass_compilation")
+            and result.get("pass_correctness")
+            and result.get("benchmark_method_consistent")
+        ):
+            review["accepted"] = False
+            review["evidence_sufficient"] = False
+            review["summary"] = (
+                "Deterministic evaluator gate rejected the candidate. "
+                + review["summary"]
+            )
+        return review
+
+    def _promote_baseline(
+        self,
+        task_id: str,
+        original_task: Path,
+        candidate_task: Path,
+        optimized_workspace: Path,
+        task_artifacts: Path,
+    ) -> bool:
+        task_config = self._load_task_config(candidate_task)
+        sources = _source_paths(task_config)
+        if not sources or any(not (candidate_task / path).is_file() for path in sources):
+            self.logger.warning("Task %s has no promotable committed source baseline", task_id)
+            return False
+        if any(not (optimized_workspace / path).is_file() for path in sources):
+            self.logger.warning("Task %s optimizer omitted a declared source file", task_id)
+            return False
+        source_backup = task_artifacts / "baseline_before_promotion"
+        self._reset_path(source_backup)
+        source_backup.mkdir(parents=True)
+        for relative in sources:
+            backup_file = source_backup / relative
+            backup_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(candidate_task / relative, backup_file)
+        for relative in sources:
+            source = optimized_workspace / relative
+            if not source.is_file():
+                return False
+            destination = candidate_task / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+        restore_committed_perf_stubs(candidate_task)
+
+        _, validation = self._validate(
+            task_id, candidate_task, task_artifacts / "validation_hardened"
+        )
+        if str(validation.get("overall_status", "FAIL")).upper() == "FAIL":
+            # Restore the previously accepted source files; an unverified faster
+            # candidate must never become the task baseline.
+            for relative in sources:
+                shutil.copy2(source_backup / relative, candidate_task / relative)
+            return False
+        accepted = self._dual_correctness_gate(
+            task_id, original_task, candidate_task, task_artifacts / "hardening_gate"
+        )
+        if not accepted:
+            for relative in sources:
+                shutil.copy2(source_backup / relative, candidate_task / relative)
+        return accepted
+
+    def _enhance_cases(
+        self,
+        task_id: str,
+        original_task: Path,
+        candidate_task: Path,
+        rationale: str,
+        task_artifacts: Path,
+    ) -> bool:
+        case_workspace = self._make_workspace(
+            task_id, candidate_task, task_artifacts / "case_candidate"
+        )
+        task_config = self._load_task_config(candidate_task)
+        before = snapshot_tree(case_workspace)
+        self.backend.run(
+            case_enhancement_prompt(task_id, rationale),
+            case_workspace,
+            role="case_enhancer",
+        )
+        after = snapshot_tree(case_workspace)
+        changes = _filtered_changes(
+            before, after, repo_subdir=_repo_subdir(task_config)
+        )
+        if changes.empty:
+            return False
+        if any(
+            not is_case_path(path) or Path(path).name == "performance_utils_pytest.py"
+            for path in changes.paths
+        ):
+            self.logger.warning("Rejecting non-case changes from case enhancer: %s", changes.paths)
+            return False
+
+        backup = task_artifacts / "candidate_before_cases"
+        shutil.copytree(candidate_task, backup)
+        apply_changes(case_workspace, candidate_task, changes)
+        restore_committed_perf_stubs(candidate_task)
+        if not self._dual_correctness_gate(
+            task_id, original_task, candidate_task, task_artifacts / "case_gate"
+        ):
+            self._replace_directory(candidate_task, backup)
+            return False
+        _, validation = self._validate(
+            task_id, candidate_task, task_artifacts / "validation_cases"
+        )
+        if str(validation.get("overall_status", "FAIL")).upper() == "FAIL":
+            self._replace_directory(candidate_task, backup)
+            return False
+        return True
+
+    def _dual_correctness_gate(
+        self, task_id: str, original_task: Path, candidate_task: Path, stage_dir: Path
+    ) -> bool:
+        task_config = self._load_task_config(candidate_task)
+        sources = _source_paths(task_config)
+        if not sources or any(not (original_task / path).is_file() for path in sources):
+            self.logger.warning(
+                "Cannot prove new cases/baseline against a committed original kernel for %s",
+                task_id,
+            )
+            return False
+        original_with_cases = stage_dir / "original_with_cases"
+        self._reset_path(stage_dir)
+        shutil.copytree(candidate_task, original_with_cases)
+        for relative in sources:
+            destination = original_with_cases / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(original_task / relative, destination)
+
+        for label, task_dir in (
+            ("original", original_with_cases),
+            ("candidate", candidate_task),
+        ):
+            workspace = self._make_workspace(task_id, task_dir, stage_dir / label)
+            config = self._load_task_config(task_dir)
+            compiled, _ = evaluate_compilation(workspace, config, self.logger)
+            correct, _ = evaluate_correctness(workspace, config, self.logger)
+            if not compiled or not correct:
+                self.logger.warning(
+                    "Dual correctness gate rejected %s (%s): compile=%s correctness=%s",
+                    task_id,
+                    label,
+                    compiled,
+                    correct,
+                )
+                return False
+        return True
+
+    def _handle_unrepairable(
+        self, task_id: str, report: dict[str, Any], task_artifacts: Path
+    ) -> None:
+        assert self.state is not None
+        fingerprint = stable_fingerprint(
+            {
+                "task": task_id,
+                "base_sha": self.state.data["base_sha"],
+                "checks": report.get("checks"),
+            }
+        )
+        body = (
+            f"`quality_loop` could not repair task `{task_id}`.\n\n"
+            f"Base commit: `{self.state.data['base_sha']}`\n\n"
+            "Validator report:\n\n```yaml\n"
+            + yaml.safe_dump(report, sort_keys=False)
+            + "```"
+        )
+        issue_url = None
+        if self.defer_github and self.config.github.publish:
+            state = "issue_pending"
+        elif self.config.github.publish:
+            issue_url = self.publisher.ensure_issue(
+                repo_slug=str(self.state.data["repo_slug"]),
+                task_id=task_id,
+                fingerprint=fingerprint,
+                title=f"[quality_loop] Invalid task: {task_id}",
+                body=body,
+                artifact_dir=task_artifacts,
+            )
+            state = "issue_filed"
+        else:
+            state = "reported_failure"
+        self.state.transition(
+            task_id,
+            state,
+            issue_url=issue_url,
+            validation_report=report,
+            issue_request={
+                "task_id": task_id,
+                "fingerprint": fingerprint,
+                "title": f"[quality_loop] Invalid task: {task_id}",
+                "body": body,
+            }
+            if state == "issue_pending"
+            else None,
+        )
+
+    def _make_workspace(self, task_id: str, task_dir: Path, stage_dir: Path) -> Path:
+        self._reset_path(stage_dir)
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        return setup_workspace(
+            str(task_dir / "config.yaml"),
+            stage_dir,
+            "qualityloop",
+            self.logger,
+            task_name=task_id,
+        )
+
+    def _eval_config(self) -> dict[str, Any]:
+        return {
+            "target_gpu_model": self.config.target_gpu_model,
+            "agent": {
+                "template": "codex",
+                "python_path": os.environ.get("AGENT_KERNEL_ARENA_PYTHON"),
+                "compile_timeout": 600,
+                "correctness_timeout": 600,
+                "performance_timeout": 600,
+                "max_iterations": 1,
+            },
+        }
+
+    @staticmethod
+    def _load_task_config(task_dir: Path) -> dict[str, Any]:
+        value = yaml.safe_load((task_dir / "config.yaml").read_text(encoding="utf-8")) or {}
+        if not isinstance(value, dict):
+            raise ValueError(f"invalid task config: {task_dir / 'config.yaml'}")
+        return value
+
+    @staticmethod
+    def _reset_path(path: Path) -> None:
+        if not path.exists() and not path.is_symlink():
+            return
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+
+    @classmethod
+    def _replace_directory(cls, destination: Path, source: Path) -> None:
+        cls._reset_path(destination)
+        shutil.copytree(source, destination)
+
+    def _write_report(self) -> Path:
+        assert self.state is not None and self.artifact_dir is not None
+        records = self.state.data.get("tasks", {})
+        counts: dict[str, int] = {}
+        warning_count = 0
+        for record in records.values():
+            status = str(record.get("state", "unknown"))
+            counts[status] = counts.get(status, 0) + 1
+            warning_count += len(record.get("warnings") or [])
+        report = {
+            "run_id": self.state.data["run_id"],
+            "repo": self.state.data["repo_slug"],
+            "base_sha": self.state.data["base_sha"],
+            "target_gpu_model": self.config.target_gpu_model,
+            "backend": self.config.backend.name,
+            "optimization_iterations": 1,
+            "counts": counts,
+            "warning_count": warning_count,
+            "tasks": records,
+        }
+        path = self.artifact_dir / "audit_report.yaml"
+        path.write_text(
+            yaml.safe_dump(report, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        return path
+
+    def _pull_request_body(self, report_path: Path) -> str:
+        assert self.state is not None
+        records = self.state.data.get("tasks", {})
+        completed = [task for task, value in records.items() if value.get("state") == "completed"]
+        changed = [task for task in completed if records[task].get("changes")]
+        issues = [value.get("issue_url") for value in records.values() if value.get("issue_url")]
+        warnings = sum(len(value.get("warnings") or []) for value in records.values())
+        return f"""## Summary
+
+- Audited tasks: {len(records)}
+- Accepted task changes: {len(changed)}
+- Validator warnings recorded: {warnings}
+- Unrepairable task issues: {len(issues)}
+- Optimizer: Codex, exactly one iteration per task
+- Easy-task threshold: reproducible {self.config.easy_speedup_threshold:.1f}x
+
+## Changed tasks
+
+{chr(10).join(f'- `{task}`' for task in changed) or '- None'}
+
+## Issues
+
+{chr(10).join(f'- {url}' for url in issues) or '- None'}
+
+The full machine-readable report is stored in the local run artifact
+`{report_path}`. Every promoted baseline and case change passed the fail-closed
+dual correctness gate against the pre-audit kernel.
+"""

--- a/agents/quality_loop/orchestrator.py
+++ b/agents/quality_loop/orchestrator.py
@@ -48,6 +48,9 @@ from src.perf_helper_materialization import materialize_perf_helpers_in_workspac
 from src.preprocessing import _resolve_gfx_arch, setup_workspace
 from src.prompt_builder import prompt_builder
 from src.testcases import collect_benchmark_methods
+from src.eval_tools.config import EvalToolsConfig
+from src.eval_tools.contracts import SourceEvidence
+from src.eval_tools.evidence import capture_submission_evidence
 
 
 def _task_slug(task_id: str) -> str:
@@ -128,6 +131,8 @@ def difficulty_is_easy(
         and statistics.median(speedups) >= config.easy_speedup_threshold
         and result.get("pass_compilation") is True
         and result.get("pass_correctness") is True
+        and result.get("pass_tool_gate", True) is True
+        and result.get("tool_policy_satisfied", True) is True
         and result.get("benchmark_method_consistent") is True
         and int(result.get("valid_baseline_cases", 0)) > 0
         and result.get("valid_baseline_cases") == result.get("valid_optimized_cases")
@@ -495,6 +500,14 @@ class QualityLoop:
     ) -> tuple[Path, list[Any], dict[str, Any]]:
         workspace = self._make_workspace(task_id, task_dir, stage_dir)
         task_config = self._load_task_config(task_dir)
+        eval_tools_config = EvalToolsConfig.from_mapping(self._eval_config())
+        submission_evidence = None
+        if eval_tools_config.enabled:
+            submission_evidence = capture_submission_evidence(
+                workspace,
+                task_config,
+                stage_dir / "submission_evidence",
+            )
         original_sources = stage_dir / "original_sources"
         original_sources.mkdir()
         source_manifest: dict[str, str] = {}
@@ -534,7 +547,40 @@ class QualityLoop:
         if snapshot_tree(original_sources) != original_source_tree:
             raise RuntimeError("optimizer modified the protected original-source snapshot")
         materialize_perf_helpers_in_workspace(workspace, logger=self.logger)
-        evaluation = evaluate_kernel(workspace, task_config, baseline_cases, self.logger)
+        tool_manager = None
+        tool_source_evidence = None
+        if eval_tools_config.enabled:
+            assert submission_evidence is not None
+            submission_evidence.verify()
+            tool_source_evidence = SourceEvidence(
+                original_root=str(submission_evidence.files_dir),
+                original_fingerprint=submission_evidence.fingerprint,
+                candidate_fingerprint=submission_evidence.candidate_fingerprint(),
+                metadata={
+                    "manifest": str(submission_evidence.storage_dir / "manifest.json"),
+                    "quality_loop_task": task_id,
+                },
+            )
+            from src.eval_tools.factory import (
+                create_default_manager,
+                task_artifact_root,
+            )
+
+            tool_manager = create_default_manager()
+            tool_report_root = task_artifact_root(workspace)
+        else:
+            tool_report_root = None
+        evaluation = evaluate_kernel(
+            workspace,
+            task_config,
+            baseline_cases,
+            self.logger,
+            tool_manager=tool_manager,
+            eval_tools_config=eval_tools_config,
+            tool_source_evidence=tool_source_evidence,
+            tool_artifact_root=tool_report_root,
+            gpu_arch=_resolve_gfx_arch(self.config.target_gpu_model),
+        )
         write_task_result(
             workspace,
             evaluation,
@@ -769,7 +815,7 @@ class QualityLoop:
         )
 
     def _eval_config(self) -> dict[str, Any]:
-        return {
+        result = {
             "target_gpu_model": self.config.target_gpu_model,
             "agent": {
                 "template": "codex",
@@ -780,6 +826,9 @@ class QualityLoop:
                 "max_iterations": 1,
             },
         }
+        if self.config.evaluation_tools:
+            result["evaluation_tools"] = dict(self.config.evaluation_tools)
+        return result
 
     @staticmethod
     def _load_task_config(task_dir: Path) -> dict[str, Any]:

--- a/agents/quality_loop/orchestrator.py
+++ b/agents/quality_loop/orchestrator.py
@@ -116,7 +116,6 @@ def _review_is_valid(review: Any) -> bool:
 
 def difficulty_is_easy(
     *,
-    task_type: str,
     speedups: list[float],
     result: dict[str, Any],
     review: dict[str, Any],
@@ -124,8 +123,7 @@ def difficulty_is_easy(
 ) -> bool:
     """Return true only for a reproducible, review-approved first-iteration 5x gain."""
     return bool(
-        task_type in config.promotion_task_types
-        and len(speedups) == config.easy_confirmation_runs
+        len(speedups) == config.easy_confirmation_runs
         and all(value > 0 for value in speedups)
         and statistics.median(speedups) >= config.easy_speedup_threshold
         and result.get("pass_compilation") is True
@@ -290,7 +288,7 @@ class QualityLoop:
             except Exception as exc:
                 self.logger.exception("quality_loop task failed: %s", task_id)
                 # Tooling/agent/runtime failures are not evidence that the task is
-                # defective. Keep them resumable and never file a task issue.
+                # defective. Keep them resumable without publishing task changes.
                 self.state.transition(task_id, "infrastructure_failed", error=str(exc))
 
         report_path = self._write_report()
@@ -344,9 +342,6 @@ class QualityLoop:
         warnings = _validation_warnings(validation)
 
         if original_validation_status == "FAIL":
-            if self.config.max_repair_attempts == 0:
-                self._handle_unrepairable(task_id, validation, task_artifacts)
-                return
             self.state.transition(task_id, "repairing", warnings=warnings)
             task_config = self._load_task_config(candidate_task)
             before = snapshot_tree(validation_workspace)
@@ -358,7 +353,7 @@ class QualityLoop:
                 before, after, repo_subdir=_repo_subdir(task_config)
             )
             if changes.empty:
-                self._handle_unrepairable(task_id, validation, task_artifacts)
+                self._handle_unrepairable(task_id, validation)
                 return
             apply_changes(validation_workspace, candidate_task, changes)
             restore_committed_perf_stubs(candidate_task)
@@ -367,7 +362,7 @@ class QualityLoop:
             )
             warnings = _validation_warnings(validation)
             if str(validation.get("overall_status", "FAIL")).upper() == "FAIL":
-                self._handle_unrepairable(task_id, validation, task_artifacts)
+                self._handle_unrepairable(task_id, validation)
                 return
 
         self.state.transition(task_id, "optimizing", warnings=warnings)
@@ -402,15 +397,15 @@ class QualityLoop:
                 )
 
         hardened = False
+        hardening_reason = "candidate did not meet the configured easy-task gate"
         task_config = self._load_task_config(candidate_task)
         if difficulty_is_easy(
-            task_type=str(task_config.get("task_type", "")),
             speedups=speedups,
             result=result,
             review=review,
             config=self.config,
         ):
-            hardened = self._promote_baseline(
+            hardened, hardening_reason = self._promote_baseline(
                 task_id,
                 original_task,
                 candidate_task,
@@ -462,6 +457,7 @@ class QualityLoop:
             speedups=speedups,
             reviewer=review,
             baseline_hardened=hardened,
+            baseline_hardening_reason=hardening_reason,
             cases_enhanced=cases_enhanced,
         )
 
@@ -621,15 +617,17 @@ class QualityLoop:
         candidate_task: Path,
         optimized_workspace: Path,
         task_artifacts: Path,
-    ) -> bool:
+    ) -> tuple[bool, str | None]:
         task_config = self._load_task_config(candidate_task)
         sources = _source_paths(task_config)
         if not sources or any(not (candidate_task / path).is_file() for path in sources):
-            self.logger.warning("Task %s has no promotable committed source baseline", task_id)
-            return False
+            reason = "task has no promotable committed source baseline"
+            self.logger.warning("Task %s %s", task_id, reason)
+            return False, reason
         if any(not (optimized_workspace / path).is_file() for path in sources):
-            self.logger.warning("Task %s optimizer omitted a declared source file", task_id)
-            return False
+            reason = "optimizer omitted a declared source file"
+            self.logger.warning("Task %s %s", task_id, reason)
+            return False, reason
         source_backup = task_artifacts / "baseline_before_promotion"
         self._reset_path(source_backup)
         source_backup.mkdir(parents=True)
@@ -640,7 +638,7 @@ class QualityLoop:
         for relative in sources:
             source = optimized_workspace / relative
             if not source.is_file():
-                return False
+                return False, f"optimizer omitted declared source file {relative}"
             destination = candidate_task / relative
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)
@@ -654,14 +652,15 @@ class QualityLoop:
             # candidate must never become the task baseline.
             for relative in sources:
                 shutil.copy2(source_backup / relative, candidate_task / relative)
-            return False
+            return False, "promoted baseline failed fresh task validation"
         accepted = self._dual_correctness_gate(
             task_id, original_task, candidate_task, task_artifacts / "hardening_gate"
         )
         if not accepted:
             for relative in sources:
                 shutil.copy2(source_backup / relative, candidate_task / relative)
-        return accepted
+            return False, "promoted baseline failed the dual correctness gate"
+        return True, None
 
     def _enhance_cases(
         self,
@@ -749,52 +748,13 @@ class QualityLoop:
                 return False
         return True
 
-    def _handle_unrepairable(
-        self, task_id: str, report: dict[str, Any], task_artifacts: Path
-    ) -> None:
+    def _handle_unrepairable(self, task_id: str, report: dict[str, Any]) -> None:
         assert self.state is not None
-        fingerprint = stable_fingerprint(
-            {
-                "task": task_id,
-                "base_sha": self.state.data["base_sha"],
-                "checks": report.get("checks"),
-            }
-        )
-        body = (
-            f"`quality_loop` could not repair task `{task_id}`.\n\n"
-            f"Base commit: `{self.state.data['base_sha']}`\n\n"
-            "Validator report:\n\n```yaml\n"
-            + yaml.safe_dump(report, sort_keys=False)
-            + "```"
-        )
-        issue_url = None
-        if self.defer_github and self.config.github.publish:
-            state = "issue_pending"
-        elif self.config.github.publish:
-            issue_url = self.publisher.ensure_issue(
-                repo_slug=str(self.state.data["repo_slug"]),
-                task_id=task_id,
-                fingerprint=fingerprint,
-                title=f"[quality_loop] Invalid task: {task_id}",
-                body=body,
-                artifact_dir=task_artifacts,
-            )
-            state = "issue_filed"
-        else:
-            state = "reported_failure"
         self.state.transition(
             task_id,
-            state,
-            issue_url=issue_url,
+            "reported_failure",
+            warnings=_validation_warnings(report),
             validation_report=report,
-            issue_request={
-                "task_id": task_id,
-                "fingerprint": fingerprint,
-                "title": f"[quality_loop] Invalid task: {task_id}",
-                "body": body,
-            }
-            if state == "issue_pending"
-            else None,
         )
 
     def _make_workspace(self, task_id: str, task_dir: Path, stage_dir: Path) -> Path:
@@ -874,14 +834,17 @@ class QualityLoop:
         records = self.state.data.get("tasks", {})
         completed = [task for task, value in records.items() if value.get("state") == "completed"]
         changed = [task for task in completed if records[task].get("changes")]
-        issues = [value.get("issue_url") for value in records.values() if value.get("issue_url")]
+        unresolved = [
+            task for task, value in records.items() if value.get("state") == "reported_failure"
+        ]
         warnings = sum(len(value.get("warnings") or []) for value in records.values())
+        report_relative = report_path.relative_to(self.repo_root)
         return f"""## Summary
 
 - Audited tasks: {len(records)}
 - Accepted task changes: {len(changed)}
 - Validator warnings recorded: {warnings}
-- Unrepairable task issues: {len(issues)}
+- Unresolved validation failures: {len(unresolved)}
 - Optimizer: Codex, exactly one iteration per task
 - Easy-task threshold: reproducible {self.config.easy_speedup_threshold:.1f}x
 
@@ -889,11 +852,11 @@ class QualityLoop:
 
 {chr(10).join(f'- `{task}`' for task in changed) or '- None'}
 
-## Issues
+## Unresolved validation failures
 
-{chr(10).join(f'- {url}' for url in issues) or '- None'}
+{chr(10).join(f'- `{task}`' for task in unresolved) or '- None'}
 
 The full machine-readable report is stored in the local run artifact
-`{report_path}`. Every promoted baseline and case change passed the fail-closed
+`{report_relative}`. Every promoted baseline and case change passed the fail-closed
 dual correctness gate against the pre-audit kernel.
 """

--- a/agents/quality_loop/prompts.py
+++ b/agents/quality_loop/prompts.py
@@ -1,0 +1,82 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def repair_prompt(report: dict, task_id: str) -> str:
+    return f"""# quality_loop validation repair
+
+Task: `{task_id}`
+
+The task validator found blocking failures. Fix only the FAIL/TIMEOUT findings in
+this task workspace. Do not spend time fixing WARN-only findings. Preserve the
+task's intended computation and public contract. Run the relevant compile and
+correctness commands after editing. Do not use GitHub, git, network services, or
+edit anything outside this workspace.
+
+Validation report:
+```yaml
+{yaml.safe_dump(report, sort_keys=False)}
+```
+"""
+
+
+def optimizer_prompt(base_prompt: str, task_id: str) -> str:
+    return base_prompt.rstrip() + f"""
+
+## quality_loop single-iteration boundary
+
+This is the one and only optimization iteration for `{task_id}`. Produce at most
+one candidate implementation. Complete all analysis, implementation, compile,
+correctness, and performance checks needed for that candidate in this single
+iteration. You may edit only declared kernel/source files. Do not edit config,
+tests, scripts, performance helpers, or any other harness file. Do not use git or
+GitHub. Preserve the exact computation, outputs, dtypes, shapes, aliasing, and
+side effects of the original task.
+"""
+
+
+def reviewer_prompt(task_id: str, result_file: Path, output_name: str) -> str:
+    return f"""# quality_loop independent evaluation review
+
+Review task `{task_id}` independently. You are a read-only evaluator, not the
+optimizer. Compare the candidate's declared source paths with their pre-optimizer
+copies under `.quality_loop_original_sources/`. Inspect the config, test harness,
+and centralized evaluator evidence in `{result_file.name}`. Decide whether the
+candidate preserves the task's computation and whether the evidence is strong
+enough to accept it. Also decide whether task cases have material coverage gaps.
+
+Do not edit any existing file. Write exactly one new YAML file `{output_name}`:
+
+```yaml
+accepted: true                    # boolean
+logic_equivalent: true            # boolean
+evidence_sufficient: true         # boolean
+case_enhancement_needed: false    # boolean
+case_rationale: "..."
+summary: "..."
+```
+
+Fail closed: set accepted false when behavior is ambiguous, evidence is missing,
+the harness changed, performance methods differ, valid case counts shrink, or
+the candidate depends on untested assumptions. Do not use git, GitHub, or network
+services.
+"""
+
+
+def case_enhancement_prompt(task_id: str, rationale: str) -> str:
+    return f"""# quality_loop task-case hardening
+
+Task: `{task_id}`
+Reviewer rationale: {rationale}
+
+Strengthen correctness coverage only where the rationale identifies a real gap.
+Add a small, targeted set of valid boundary/shape/dtype cases. Do not modify the
+kernel/source implementation, computation contract, tolerances merely to accept
+wrong answers, benchmark timing helpers, or performance methodology. Every new
+case must be valid for and pass the original pre-audit kernel. Run the appropriate
+correctness command. Do not use git, GitHub, or network services.
+"""

--- a/agents/quality_loop/state.py
+++ b/agents/quality_loop/state.py
@@ -1,0 +1,134 @@
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved.
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+TERMINAL_TASK_STATES = {
+    "completed",
+    "issue_filed",
+    "issue_pending",
+    "reported_failure",
+    "platform_deferred",
+}
+
+RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def validate_run_id(run_id: str) -> str:
+    if not RUN_ID_PATTERN.fullmatch(run_id) or run_id in {".", ".."}:
+        raise ValueError(
+            "quality_loop run ID must contain only letters, digits, '.', '_', or '-'"
+        )
+    return run_id
+
+
+def resolve_worktree(repo_root: Path, stored_path: str | Path) -> Path:
+    path = Path(stored_path)
+    return path.resolve() if path.is_absolute() else (repo_root / path).resolve()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def stable_fingerprint(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class AuditState:
+    """Crash-safe YAML manifest used for resume and publication summaries."""
+
+    def __init__(self, path: Path, data: dict[str, Any]):
+        self.path = path
+        self.data = data
+
+    @classmethod
+    def create(
+        cls,
+        path: Path,
+        *,
+        run_id: str,
+        config_fingerprint: str,
+        repo_slug: str,
+        base_sha: str,
+        base_branch: str,
+        branch: str,
+        worktree: Path,
+    ) -> "AuditState":
+        validate_run_id(run_id)
+        state = cls(
+            path,
+            {
+                "schema_version": 1,
+                "run_id": run_id,
+                "created_at": utc_now(),
+                "updated_at": utc_now(),
+                "config_fingerprint": config_fingerprint,
+                "repo_slug": repo_slug,
+                "base_sha": base_sha,
+                "base_branch": base_branch,
+                "branch": branch,
+                "worktree": str(worktree),
+                "status": "running",
+                "tasks": {},
+                "pull_request_url": None,
+            },
+        )
+        state.save()
+        return state
+
+    @classmethod
+    def load(cls, path: Path) -> "AuditState":
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+            raise ValueError(f"unsupported or corrupt quality_loop state: {path}")
+        return cls(path, raw)
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.data["updated_at"] = utc_now()
+        tmp = self.path.with_name(f".{self.path.name}.{os.getpid()}.tmp")
+        tmp.write_text(
+            yaml.safe_dump(self.data, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp, self.path)
+
+    def task(self, task_id: str) -> dict[str, Any]:
+        tasks = self.data.setdefault("tasks", {})
+        return tasks.setdefault(
+            task_id,
+            {
+                "state": "pending",
+                "events": [],
+                "warnings": [],
+                "changes": [],
+                "issue_url": None,
+            },
+        )
+
+    def transition(self, task_id: str, state: str, **fields: Any) -> None:
+        record = self.task(task_id)
+        record["state"] = state
+        record.update(fields)
+        record.setdefault("events", []).append({"at": utc_now(), "state": state})
+        self.save()
+
+    def is_terminal(self, task_id: str) -> bool:
+        return self.task(task_id).get("state") in TERMINAL_TASK_STATES
+
+    def finish(self, status: str, *, pull_request_url: str | None = None) -> None:
+        self.data["status"] = status
+        if pull_request_url:
+            self.data["pull_request_url"] = pull_request_url
+        self.save()

--- a/agents/quality_loop/state.py
+++ b/agents/quality_loop/state.py
@@ -14,8 +14,6 @@ import yaml
 
 TERMINAL_TASK_STATES = {
     "completed",
-    "issue_filed",
-    "issue_pending",
     "reported_failure",
     "platform_deferred",
 }
@@ -113,7 +111,6 @@ class AuditState:
                 "events": [],
                 "warnings": [],
                 "changes": [],
-                "issue_url": None,
             },
         )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ python -m sphinx -T -b html docs docs/_build/html
 | `how-to/agents.md` | How-to | Supported agents, model providers, and A/B testing. |
 | `how-to/add-task.md` | How-to | Task directory layout, `config.yaml` fields, and task types. |
 | `how-to/task-validator.md` | How-to | The task_validator agent and its 10 checks. |
-| `how-to/quality-loop.md` | How-to | Repository-wide validation, one-pass optimization, task hardening, issue filing, and draft PR publication. |
+| `how-to/quality-loop.md` | How-to | Repository-wide validation, one-pass optimization, task hardening, and single-draft-PR publication. |
 | `how-to/held-out-evaluation.md` | How-to | Generate private shapes and evaluate completed runs for generalization. |
 | `how-to/visualization.md` | How-to | Build dashboard data and serve the comparison dashboard. |
 | `examples/examples.md` | Examples | Step-by-step walkthroughs with expected output. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ python -m sphinx -T -b html docs docs/_build/html
 | `how-to/agents.md` | How-to | Supported agents, model providers, and A/B testing. |
 | `how-to/add-task.md` | How-to | Task directory layout, `config.yaml` fields, and task types. |
 | `how-to/task-validator.md` | How-to | The task_validator agent and its 10 checks. |
+| `how-to/quality-loop.md` | How-to | Repository-wide validation, one-pass optimization, task hardening, issue filing, and draft PR publication. |
 | `how-to/held-out-evaluation.md` | How-to | Generate private shapes and evaluate completed runs for generalization. |
 | `how-to/visualization.md` | How-to | Build dashboard data and serve the comparison dashboard. |
 | `examples/examples.md` | Examples | Step-by-step walkthroughs with expected output. |

--- a/docs/how-to/agents.md
+++ b/docs/how-to/agents.md
@@ -41,8 +41,9 @@ state. Specialized integrations have additional setup and configuration under
 their respective `agents/<agent_name>/` directories.
 
 `quality_loop` is intentionally not an `agent.template`. It is a repository-level
-task maintenance workflow that invokes Codex roles across many tasks, files issues,
-and publishes one draft PR. See [Audit and harden tasks](quality-loop.md).
+task maintenance workflow that invokes Codex roles across the tasks selected by its
+run config and publishes at most one draft PR. It never creates GitHub issues. See
+[Audit and harden tasks](quality-loop.md).
 
 ## Models, providers, and agent settings
 

--- a/docs/how-to/agents.md
+++ b/docs/how-to/agents.md
@@ -40,6 +40,10 @@ The Cursor, Claude Code, and Codex integrations reuse their host CLI login
 state. Specialized integrations have additional setup and configuration under
 their respective `agents/<agent_name>/` directories.
 
+`quality_loop` is intentionally not an `agent.template`. It is a repository-level
+task maintenance workflow that invokes Codex roles across many tasks, files issues,
+and publishes one draft PR. See [Audit and harden tasks](quality-loop.md).
+
 ## Models, providers, and agent settings
 
 AgentKernelArena has no shared model/provider field in the run configuration.

--- a/docs/how-to/quality-loop.md
+++ b/docs/how-to/quality-loop.md
@@ -2,7 +2,7 @@
 myst:
     html_meta:
         "description": "Audit, repair, harden, and publish AgentKernelArena tasks with the Codex-based quality_loop workflow."
-        "keywords": "AgentKernelArena, quality_loop, task audit, Codex, GitHub issues, pull request, GPU kernel"
+        "keywords": "AgentKernelArena, quality_loop, task audit, Codex, draft pull request, GPU kernel"
 ---
 
 # Audit and harden tasks with quality_loop
@@ -15,15 +15,16 @@ For every selected, platform-compatible task it:
 
 1. Runs the existing task validator in a fresh workspace.
 2. Records WARN results without repairing them.
-3. Attempts one repair for FAIL results, revalidates from a fresh copy, and files
-   a fingerprinted GitHub issue if the task remains invalid.
+3. Attempts one repair for FAIL results, revalidates from a fresh copy, and records
+   the unresolved failure locally if the task remains invalid.
 4. Runs exactly one Codex optimization iteration and the centralized evaluator.
 5. Starts a separate, read-only Codex session to review correctness evidence and
    case coverage.
 6. Promotes a first-iteration candidate only when three measurements have median
    speedup at least 5x and all correctness/method/case-count gates pass.
 7. Adds targeted cases only when both the original kernel and candidate pass them.
-8. Commits accepted task changes to one isolated branch and creates one draft PR.
+8. Commits accepted task changes to one isolated branch and creates at most one
+   draft PR. The workflow never creates GitHub issues.
 
 ## Prerequisites
 
@@ -41,7 +42,7 @@ the host. It mounts Codex state, but never mounts GitHub credentials into the GP
 container. The main checkout is mounted read-only, while only the current run's
 artifact and isolated worktree directories are writable. After the task campaign
 exits, a host-side deterministic publisher verifies the recorded diff, commits
-accepted task changes, creates issues, pushes the branch, and opens the draft PR.
+accepted task changes, pushes the branch, and opens the draft PR.
 
 ## Inspect a campaign
 
@@ -60,7 +61,7 @@ The output lists runnable and platform-deferred tasks. A task with
 
 ```bash
 make docker-quality-loop \
-  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml
+  CONFIG=example_configs/quality_loop_mi300.yaml
 ```
 
 Select `example_configs/quality_loop_mi355x.yaml` on an MI355X host.
@@ -69,7 +70,7 @@ For a bounded smoke campaign:
 
 ```bash
 make docker-quality-loop \
-  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  CONFIG=example_configs/quality_loop_mi300.yaml \
   QUALITY_LOOP_ARGS="--tasks hip2hip/gpumode/GELU triton2triton/vllm/triton_rms_norm"
 ```
 
@@ -77,12 +78,13 @@ Resume with the run ID printed in `quality_loop_runs/`:
 
 ```bash
 make docker-quality-loop \
-  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  CONFIG=example_configs/quality_loop_mi300.yaml \
   QUALITY_LOOP_ARGS="--resume <run-id>"
 ```
 
 The crash-safe `state.yaml` skips terminal tasks. `audit_report.yaml` records every
-warning, failure, issue URL, speedup confirmation, accepted file change, and commit.
+warning, unresolved failure, speedup confirmation, accepted file change, and commit.
+If a run has no accepted changes, it does not open an empty pull request.
 
 ## Safety boundaries
 
@@ -98,8 +100,9 @@ warning, failure, issue URL, speedup confirmation, accepted file change, and com
   file invalidate the review.
 - External repository/image worktrees and generated benchmark helpers are never
   copied into a task commit.
-- Translation/authoring tasks do not promote a generated 5x solution as their new
-  baseline because that would change the task category.
+- The top-level `tasks` selectors define the complete audit scope. Baseline
+  promotion is attempted without a task-type allowlist and fails closed when the
+  selected task has no promotable committed source baseline.
 - If equivalence cannot be established against a committed original kernel, the
   baseline or case change is rejected.
 

--- a/docs/how-to/quality-loop.md
+++ b/docs/how-to/quality-loop.md
@@ -1,0 +1,107 @@
+---
+myst:
+    html_meta:
+        "description": "Audit, repair, harden, and publish AgentKernelArena tasks with the Codex-based quality_loop workflow."
+        "keywords": "AgentKernelArena, quality_loop, task audit, Codex, GitHub issues, pull request, GPU kernel"
+---
+
+# Audit and harden tasks with quality_loop
+
+`quality_loop` is a repository-level workflow for maintaining the task corpus.
+It differs from a normal `agent.template`: normal agents optimize one copied task,
+while `quality_loop` owns a complete multi-task campaign and a single Git branch.
+
+For every selected, platform-compatible task it:
+
+1. Runs the existing task validator in a fresh workspace.
+2. Records WARN results without repairing them.
+3. Attempts one repair for FAIL results, revalidates from a fresh copy, and files
+   a fingerprinted GitHub issue if the task remains invalid.
+4. Runs exactly one Codex optimization iteration and the centralized evaluator.
+5. Starts a separate, read-only Codex session to review correctness evidence and
+   case coverage.
+6. Promotes a first-iteration candidate only when three measurements have median
+   speedup at least 5x and all correctness/method/case-count gates pass.
+7. Adds targeted cases only when both the original kernel and candidate pass them.
+8. Commits accepted task changes to one isolated branch and creates one draft PR.
+
+## Prerequisites
+
+Install and authenticate Codex and GitHub CLI on the host. The GitHub identity
+must have write permission to this repository:
+
+```bash
+codex --version
+gh auth status -h github.com
+gh api repos/AMD-AGI/AgentKernelArena --jq '.permissions.push'
+```
+
+The Docker launcher performs GitHub preflight and creates the audit worktree on
+the host. It mounts Codex state, but never mounts GitHub credentials into the GPU
+container. The main checkout is mounted read-only, while only the current run's
+artifact and isolated worktree directories are writable. After the task campaign
+exits, a host-side deterministic publisher verifies the recorded diff, commits
+accepted task changes, creates issues, pushes the branch, and opens the draft PR.
+
+## Inspect a campaign
+
+Planning is offline and does not create a branch or require GPU access:
+
+```bash
+python3 -m agents.quality_loop \
+  --config example_configs/quality_loop_mi300.yaml \
+  --plan
+```
+
+The output lists runnable and platform-deferred tasks. A task with
+`platform_support.required_arch` is run only on the matching architecture.
+
+## Run and resume
+
+```bash
+make docker-quality-loop \
+  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml
+```
+
+Select `example_configs/quality_loop_mi355x.yaml` on an MI355X host.
+
+For a bounded smoke campaign:
+
+```bash
+make docker-quality-loop \
+  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  QUALITY_LOOP_ARGS="--tasks hip2hip/gpumode/GELU triton2triton/vllm/triton_rms_norm"
+```
+
+Resume with the run ID printed in `quality_loop_runs/`:
+
+```bash
+make docker-quality-loop \
+  QUALITY_LOOP_CONFIG=example_configs/quality_loop_mi300.yaml \
+  QUALITY_LOOP_ARGS="--resume <run-id>"
+```
+
+The crash-safe `state.yaml` skips terminal tasks. `audit_report.yaml` records every
+warning, failure, issue URL, speedup confirmation, accepted file change, and commit.
+
+## Safety boundaries
+
+- GitHub authentication and write permission are hard preflights. Failure happens
+  before branch creation or task mutation.
+- GitHub credentials never enter the agent container, and Codex state is copied
+  into an ephemeral writable home.
+- The host refuses to commit or publish when the worktree contains a path that is
+  not in the accepted per-task change manifest.
+- Optimizers cannot edit task harness files; the existing harness digest guard is
+  checked before evaluation.
+- Reviewer output is schema checked, and modifications beyond its one YAML result
+  file invalidate the review.
+- External repository/image worktrees and generated benchmark helpers are never
+  copied into a task commit.
+- Translation/authoring tasks do not promote a generated 5x solution as their new
+  baseline because that would change the task category.
+- If equivalence cannot be established against a committed original kernel, the
+  baseline or case change is rejected.
+
+See `agents/quality_loop/README.md` and
+`agents/quality_loop/agent_config.yaml` for the complete configuration contract.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -35,6 +35,8 @@ subtrees:
       title: Add a task
     - file: how-to/task-validator
       title: Validate tasks
+    - file: how-to/quality-loop
+      title: Audit and harden tasks
     - file: how-to/held-out-evaluation
       title: Evaluate on held-out shapes
     - file: how-to/visualization

--- a/example_configs/quality_loop_mi300.yaml
+++ b/example_configs/quality_loop_mi300.yaml
@@ -1,0 +1,28 @@
+tasks:
+  - all
+target_gpu_model: MI300
+
+quality_loop:
+  backend:
+    name: codex
+    model: null
+    effort: xhigh
+    timeout_seconds: 3600
+  reviewer:
+    name: codex
+    model: null
+    effort: xhigh
+    timeout_seconds: 1800
+  max_repair_attempts: 1
+  optimization_iterations: 1
+  easy_speedup_threshold: 5.0
+  easy_confirmation_runs: 3
+  case_enhancement: true
+  artifact_root: quality_loop_runs
+  worktree_root: .quality_loop_worktrees
+  github:
+    publish: true
+    draft_pr: true
+    branch_prefix: quality-loop
+    base_branch: null
+    issue_labels: []

--- a/example_configs/quality_loop_mi300.yaml
+++ b/example_configs/quality_loop_mi300.yaml
@@ -22,7 +22,5 @@ quality_loop:
   worktree_root: .quality_loop_worktrees
   github:
     publish: true
-    draft_pr: true
     branch_prefix: quality-loop
     base_branch: null
-    issue_labels: []

--- a/example_configs/quality_loop_mi355x.yaml
+++ b/example_configs/quality_loop_mi355x.yaml
@@ -1,0 +1,28 @@
+tasks:
+  - all
+target_gpu_model: MI355X
+
+quality_loop:
+  backend:
+    name: codex
+    model: null
+    effort: xhigh
+    timeout_seconds: 3600
+  reviewer:
+    name: codex
+    model: null
+    effort: xhigh
+    timeout_seconds: 1800
+  max_repair_attempts: 1
+  optimization_iterations: 1
+  easy_speedup_threshold: 5.0
+  easy_confirmation_runs: 3
+  case_enhancement: true
+  artifact_root: quality_loop_runs
+  worktree_root: .quality_loop_worktrees
+  github:
+    publish: true
+    draft_pr: true
+    branch_prefix: quality-loop
+    base_branch: null
+    issue_labels: []

--- a/example_configs/quality_loop_mi355x.yaml
+++ b/example_configs/quality_loop_mi355x.yaml
@@ -22,7 +22,5 @@ quality_loop:
   worktree_root: .quality_loop_worktrees
   github:
     publish: true
-    draft_pr: true
     branch_prefix: quality-loop
     base_branch: null
-    issue_labels: []

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -19,6 +19,10 @@ DEFAULT_RUN_CONFIG="example_configs/quickstart_claude_mi300.yaml"
 # separate from REQUIRED_AGENTS because geak_v4 is normalized to claude_code
 # before Docker arguments are built.
 GEAK_V4_RUNTIME=0
+# quality_loop keeps the repository checkout read-only in the agent container.
+# Only these host-validated, run-specific subdirectories are over-mounted rw.
+QUALITY_LOOP_ARTIFACT_REL=""
+QUALITY_LOOP_WORKTREE_REL=""
 EVAL_TOOL_SOCKET_CONTAINER_DIR="/run/aka-eval-tools"
 EVAL_TOOL_INPUT_CONTAINER_DIR="/input"
 EVAL_TOOL_FRAMEWORK_CONTAINER_ROOT="/opt/aka-eval-tools"
@@ -47,6 +51,7 @@ Usage:
   src/scripts/docker_benchmark.sh preflight [--config_name <run-config.yaml>]
   src/scripts/docker_benchmark.sh shell
   src/scripts/docker_benchmark.sh check-agents [--config_name <run-config.yaml>]
+  src/scripts/docker_benchmark.sh quality-loop [--config <quality-loop-config.yaml>] [quality_loop args...]
   src/scripts/docker_benchmark.sh smoke
   src/scripts/docker_benchmark.sh eval-tools-smoke
   src/scripts/docker_benchmark.sh build-eval-tool-images
@@ -1004,7 +1009,21 @@ build_docker_args() {
     add_device_if_present /dev/dri
     add_device_if_present /dev/mem
 
-    add_mount "$HOST_ROOT" "$CONTAINER_WORKDIR"
+    if [[ -n "$QUALITY_LOOP_ARTIFACT_REL" || -n "$QUALITY_LOOP_WORKTREE_REL" ]]; then
+        [[ -n "$QUALITY_LOOP_ARTIFACT_REL" && -n "$QUALITY_LOOP_WORKTREE_REL" ]] \
+            || die "quality_loop requires both artifact and worktree mount paths"
+        require_path "$HOST_ROOT/$QUALITY_LOOP_ARTIFACT_REL" "quality_loop artifact directory"
+        require_path "$HOST_ROOT/$QUALITY_LOOP_WORKTREE_REL" "quality_loop worktree"
+        add_mount "$HOST_ROOT" "$CONTAINER_WORKDIR" ro
+        add_mount \
+            "$HOST_ROOT/$QUALITY_LOOP_ARTIFACT_REL" \
+            "$CONTAINER_WORKDIR/$QUALITY_LOOP_ARTIFACT_REL"
+        add_mount \
+            "$HOST_ROOT/$QUALITY_LOOP_WORKTREE_REL" \
+            "$CONTAINER_WORKDIR/$QUALITY_LOOP_WORKTREE_REL"
+    else
+        add_mount "$HOST_ROOT" "$CONTAINER_WORKDIR"
+    fi
     # A scoring container receives the per-worker Unix-socket directory and its
     # dedicated report tree. Tool images, credentials, Docker access, and the
     # rest of the experiments/workspace tree never enter a sidecar writable.
@@ -1123,6 +1142,46 @@ extract_config_name() {
         shift || true
     done
     printf '%s\n' "$config"
+}
+
+extract_quality_loop_config() {
+    local config="agents/quality_loop/agent_config.yaml"
+    local arg
+    while [[ $# -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --config)
+                shift
+                [[ $# -gt 0 ]] || die "--config requires a value"
+                config="$1"
+                ;;
+            --config=*)
+                config="${arg#--config=}"
+                ;;
+        esac
+        shift || true
+    done
+    printf '%s\n' "$config"
+}
+
+extract_quality_loop_resume() {
+    local arg
+    while [[ $# -gt 0 ]]; do
+        arg="$1"
+        case "$arg" in
+            --resume)
+                shift
+                [[ $# -gt 0 ]] || die "--resume requires a run ID"
+                printf '%s\n' "$1"
+                return
+                ;;
+            --resume=*)
+                printf '%s\n' "${arg#--resume=}"
+                return
+                ;;
+        esac
+        shift || true
+    done
 }
 
 container_smoke() {
@@ -1562,6 +1621,42 @@ case "${1:-}" in
     parallel-run)
         shift
         run_parallel "$@"
+        ;;
+    quality-loop)
+        shift
+        quality_loop_config="$(extract_quality_loop_config "$@")"
+        [[ -f "$quality_loop_config" ]] || die "quality_loop config file not found: $quality_loop_config"
+        if has_arg --plan "$@"; then
+            python3 -m agents.quality_loop "$@"
+            exit
+        fi
+        quality_loop_resume="$(extract_quality_loop_resume "$@" || true)"
+        if [[ -n "$quality_loop_resume" ]]; then
+            quality_loop_run_id="$(python3 -m agents.quality_loop.host check "$@")"
+        else
+            quality_loop_run_id="$(python3 -m agents.quality_loop.host start "$@")"
+        fi
+        echo "quality_loop run ID: $quality_loop_run_id" >&2
+        mapfile -t quality_loop_paths < <(
+            python3 -m agents.quality_loop.host paths "$@" --run-id "$quality_loop_run_id"
+        )
+        [[ "${#quality_loop_paths[@]}" -eq 2 ]] \
+            || die "quality_loop host returned invalid runtime paths"
+        QUALITY_LOOP_ARTIFACT_REL="${quality_loop_paths[0]}"
+        QUALITY_LOOP_WORKTREE_REL="${quality_loop_paths[1]}"
+        select_runtime_for_config "$quality_loop_config"
+        REQUIRED_AGENTS="codex"
+        AGENTS_STRICT=1
+        AGENT_HOME_ISOLATION=1
+        AKA_CONTAINER_HOME="/tmp/aka-quality-loop-${quality_loop_run_id}"
+        AKA_CACHE_SUFFIX="quality-loop-${quality_loop_run_id}"
+        quality_loop_container_args=("$@")
+        if [[ -z "$quality_loop_resume" ]]; then
+            quality_loop_container_args+=(--resume "$quality_loop_run_id")
+        fi
+        quality_loop_container_args+=(--defer-github --skip-preflight)
+        docker_exec 0 python3 -m agents.quality_loop "${quality_loop_container_args[@]}"
+        python3 -m agents.quality_loop.host finalize "$@" --run-id "$quality_loop_run_id"
         ;;
     preflight)
         shift

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -1655,7 +1655,13 @@ case "${1:-}" in
             quality_loop_container_args+=(--resume "$quality_loop_run_id")
         fi
         quality_loop_container_args+=(--defer-github --skip-preflight)
+        trap stop_eval_tool_sidecars EXIT
+        start_eval_tool_sidecars \
+            "$quality_loop_config" \
+            "quality-loop-${quality_loop_run_id}"
         docker_exec 0 python3 -m agents.quality_loop "${quality_loop_container_args[@]}"
+        stop_eval_tool_sidecars
+        trap - EXIT
         python3 -m agents.quality_loop.host finalize "$@" --run-id "$quality_loop_run_id"
         ;;
     preflight)

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -97,7 +97,10 @@ assert_cache_args_absent() {
 
 TEST_HOME="$(mktemp -d)"
 PATH_TEST_PARENT="$ROOT/.eval-tool-runner-test-$$"
-trap 'rm -rf "$TEST_HOME" "$PATH_TEST_PARENT" "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"' EXIT
+QUALITY_TEST_RUN_ID="runner-test-$$-${RANDOM:-0}"
+QUALITY_ARTIFACT_REL="quality_loop_runs/$QUALITY_TEST_RUN_ID"
+QUALITY_WORKTREE_REL=".quality_loop_worktrees/$QUALITY_TEST_RUN_ID"
+trap 'rm -rf -- "$TEST_HOME" "$PATH_TEST_PARENT" "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"' EXIT
 UNRELATED_GEAK_WORKFLOW_DIR="$TEST_HOME/unrelated-geak-workflow"
 GEAK_SDK_PYTHONPATH="PYTHONPATH=/workspace/.aka-pyuserbase/geak-sdk"
 mkdir -p "$UNRELATED_GEAK_WORKFLOW_DIR"
@@ -251,10 +254,12 @@ mkdir -p "$QUALITY_HOME/.codex" "$QUALITY_HOME/.config/gh" "$QUALITY_PREFIX/bin"
 touch "$QUALITY_PREFIX/bin/node" "$QUALITY_PREFIX/bin/codex"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$QUALITY_BIN/gh"
 chmod +x "$QUALITY_BIN/gh"
-printf '#!/usr/bin/env bash\ncase "$*" in *"agents.quality_loop.host start"*) echo test-run;; *"agents.quality_loop.host paths"*) printf "quality_loop_runs/test-run\\n.quality_loop_worktrees/test-run\\n";; *"agents.quality_loop.host finalize"*) echo test-pr;; esac\n' > "$QUALITY_BIN/python3"
+printf '#!/usr/bin/env bash\ncase "$*" in *"agents.quality_loop.host start"*) echo "%s";; *"agents.quality_loop.host paths"*) printf "%%s\\n%%s\\n" "%s" "%s";; *"agents.quality_loop.host finalize"*) echo test-pr;; esac\n' \
+    "$QUALITY_TEST_RUN_ID" "$QUALITY_ARTIFACT_REL" "$QUALITY_WORKTREE_REL" \
+    > "$QUALITY_BIN/python3"
 chmod +x "$QUALITY_BIN/python3"
 printf 'tasks:\n  - hip2hip/gpumode/GELU\ntarget_gpu_model: MI300\nquality_loop: {}\n' > "$QUALITY_CONFIG"
-mkdir -p "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"
+mkdir -p "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"
 
 mapfile -t args < <(
     env \
@@ -266,17 +271,17 @@ mapfile -t args < <(
 assert_has "$QUALITY_PREFIX:/opt/node:ro" "${args[@]}"
 assert_has "$QUALITY_HOME/.codex:/opt/aka-agent-state/.codex:ro" "${args[@]}"
 assert_has "$ROOT:/workspace:ro" "${args[@]}"
-assert_has "$ROOT/quality_loop_runs/test-run:/workspace/quality_loop_runs/test-run" "${args[@]}"
-assert_has "$ROOT/.quality_loop_worktrees/test-run:/workspace/.quality_loop_worktrees/test-run" "${args[@]}"
+assert_has "$ROOT/$QUALITY_ARTIFACT_REL:/workspace/$QUALITY_ARTIFACT_REL" "${args[@]}"
+assert_has "$ROOT/$QUALITY_WORKTREE_REL:/workspace/$QUALITY_WORKTREE_REL" "${args[@]}"
 assert_not_has "$QUALITY_BIN/gh:$QUALITY_BIN/gh:ro" "${args[@]}"
 assert_not_has "$QUALITY_HOME/.config/gh:$QUALITY_HOME/.config/gh:ro" "${args[@]}"
 assert_has "python3" "${args[@]}"
 assert_has "agents.quality_loop" "${args[@]}"
 assert_has "--resume" "${args[@]}"
-assert_has "test-run" "${args[@]}"
+assert_has "$QUALITY_TEST_RUN_ID" "${args[@]}"
 assert_has "--defer-github" "${args[@]}"
 assert_has "--skip-preflight" "${args[@]}"
-rm -rf "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"
+rm -rf -- "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"
 
 # A Codex-only config likewise receives neither Claude credentials nor GEAK's
 # dependency path/mount, even when both are configured on the host.

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -97,7 +97,7 @@ assert_cache_args_absent() {
 
 TEST_HOME="$(mktemp -d)"
 PATH_TEST_PARENT="$ROOT/.eval-tool-runner-test-$$"
-trap 'rm -rf "$TEST_HOME" "$PATH_TEST_PARENT"' EXIT
+trap 'rm -rf "$TEST_HOME" "$PATH_TEST_PARENT" "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"' EXIT
 UNRELATED_GEAK_WORKFLOW_DIR="$TEST_HOME/unrelated-geak-workflow"
 GEAK_SDK_PYTHONPATH="PYTHONPATH=/workspace/.aka-pyuserbase/geak-sdk"
 mkdir -p "$UNRELATED_GEAK_WORKFLOW_DIR"
@@ -240,6 +240,43 @@ assert_not_has "ANTHROPIC_BASE_URL" "${args[@]}"
 assert_not_has "$GEAK_SDK_PYTHONPATH" "${args[@]}"
 assert_not_has "$UNRELATED_GEAK_WORKFLOW_DIR:$UNRELATED_GEAK_WORKFLOW_DIR:ro" "${args[@]}"
 assert_not_has "GEAK_V4_WORKFLOW_DIR=$UNRELATED_GEAK_WORKFLOW_DIR" "${args[@]}"
+
+# quality_loop provisions only isolated Codex state, never GitHub CLI state, and
+# mounts the main checkout read-only while over-mounting only this run's state rw.
+QUALITY_HOME="$TEST_HOME/quality-home"
+QUALITY_PREFIX="$TEST_HOME/quality-node"
+QUALITY_BIN="$TEST_HOME/quality-bin"
+QUALITY_CONFIG="$TEST_HOME/quality-loop.yaml"
+mkdir -p "$QUALITY_HOME/.codex" "$QUALITY_HOME/.config/gh" "$QUALITY_PREFIX/bin" "$QUALITY_BIN"
+touch "$QUALITY_PREFIX/bin/node" "$QUALITY_PREFIX/bin/codex"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$QUALITY_BIN/gh"
+chmod +x "$QUALITY_BIN/gh"
+printf '#!/usr/bin/env bash\ncase "$*" in *"agents.quality_loop.host start"*) echo test-run;; *"agents.quality_loop.host paths"*) printf "quality_loop_runs/test-run\\n.quality_loop_worktrees/test-run\\n";; *"agents.quality_loop.host finalize"*) echo test-pr;; esac\n' > "$QUALITY_BIN/python3"
+chmod +x "$QUALITY_BIN/python3"
+printf 'tasks:\n  - hip2hip/gpumode/GELU\ntarget_gpu_model: MI300\nquality_loop: {}\n' > "$QUALITY_CONFIG"
+mkdir -p "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"
+
+mapfile -t args < <(
+    env \
+        HOME="$QUALITY_HOME" \
+        PATH="$QUALITY_BIN:$PATH" \
+        AKA_NODE_PREFIX="$QUALITY_PREFIX" \
+        bash "$RUNNER" quality-loop --config "$QUALITY_CONFIG" 2>/dev/null
+)
+assert_has "$QUALITY_PREFIX:/opt/node:ro" "${args[@]}"
+assert_has "$QUALITY_HOME/.codex:/opt/aka-agent-state/.codex:ro" "${args[@]}"
+assert_has "$ROOT:/workspace:ro" "${args[@]}"
+assert_has "$ROOT/quality_loop_runs/test-run:/workspace/quality_loop_runs/test-run" "${args[@]}"
+assert_has "$ROOT/.quality_loop_worktrees/test-run:/workspace/.quality_loop_worktrees/test-run" "${args[@]}"
+assert_not_has "$QUALITY_BIN/gh:$QUALITY_BIN/gh:ro" "${args[@]}"
+assert_not_has "$QUALITY_HOME/.config/gh:$QUALITY_HOME/.config/gh:ro" "${args[@]}"
+assert_has "python3" "${args[@]}"
+assert_has "agents.quality_loop" "${args[@]}"
+assert_has "--resume" "${args[@]}"
+assert_has "test-run" "${args[@]}"
+assert_has "--defer-github" "${args[@]}"
+assert_has "--skip-preflight" "${args[@]}"
+rm -rf "$ROOT/quality_loop_runs/test-run" "$ROOT/.quality_loop_worktrees/test-run"
 
 # A Codex-only config likewise receives neither Claude credentials nor GEAK's
 # dependency path/mount, even when both are configured on the host.

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -8,6 +8,8 @@ PINNED_GFX950_IMAGE="lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705"
 PINNED_GFX950_IMMUTABLE_IMAGE="lmsysorg/sglang-rocm@sha256:b435b508b5aa696abb25c909341ce73e41574c4271cf716bed72418dcea86b78"
 export PINNED_GFX950_IMMUTABLE_IMAGE
 OLD_GFX950_IMAGE="lmsysorg/sglang:v0.5.12-rocm720-mi35x"
+REAL_PYTHON3="$(command -v python3)"
+export REAL_PYTHON3
 
 fail() {
     echo "FAIL: $*" >&2
@@ -58,6 +60,45 @@ docker() {
         fi
         return 0
     fi
+    if [[ "${1:-}" == "run" && "${2:-}" == "-d" ]]; then
+        local index mount="" name="" socket_path=""
+        local -a docker_argv=("$@")
+        for ((index = 0; index < ${#docker_argv[@]}; index++)); do
+            case "${docker_argv[$index]}" in
+                --name) name="${docker_argv[$((index + 1))]}" ;;
+                -v)
+                    if [[ "${docker_argv[$((index + 1))]}" == *":/run/aka-eval-tools:rw" ]]; then
+                        mount="${docker_argv[$((index + 1))]}"
+                    fi
+                    ;;
+                --socket) socket_path="${docker_argv[$((index + 1))]}" ;;
+            esac
+        done
+        [[ -n "$mount" && -n "$socket_path" ]] \
+            || fail "fake sidecar launch did not receive a socket mount/path"
+        local socket_host_dir="${mount%:/run/aka-eval-tools:rw}"
+        "$REAL_PYTHON3" -c \
+            'import socket, sys; sock = socket.socket(socket.AF_UNIX); sock.bind(sys.argv[1]); sock.close()' \
+            "$socket_host_dir/${socket_path##*/}"
+        [[ -z "${FAKE_DOCKER_EVENTS:-}" ]] \
+            || printf 'sidecar-start:%s\n' "$name" >> "$FAKE_DOCKER_EVENTS"
+        printf 'fake-sidecar-id\n'
+        return 0
+    fi
+    if [[ "${1:-}" == "stop" ]]; then
+        [[ -z "${FAKE_DOCKER_EVENTS:-}" ]] \
+            || printf 'sidecar-stop:%s\n' "${!#}" >> "$FAKE_DOCKER_EVENTS"
+        return 0
+    fi
+    local value
+    for value in "$@"; do
+        if [[ "$value" == "agents.quality_loop" ]]; then
+            [[ -z "${FAKE_DOCKER_EVENTS:-}" ]] \
+                || printf 'quality-loop-container\n' >> "$FAKE_DOCKER_EVENTS"
+            [[ "${FAKE_SCORING_DOCKER_FAILURE:-0}" == "0" ]] || return 42
+            break
+        fi
+    done
     printf '%s\n' "$@"
 }
 export -f docker
@@ -100,7 +141,8 @@ PATH_TEST_PARENT="$ROOT/.eval-tool-runner-test-$$"
 QUALITY_TEST_RUN_ID="runner-test-$$-${RANDOM:-0}"
 QUALITY_ARTIFACT_REL="quality_loop_runs/$QUALITY_TEST_RUN_ID"
 QUALITY_WORKTREE_REL=".quality_loop_worktrees/$QUALITY_TEST_RUN_ID"
-trap 'rm -rf -- "$TEST_HOME" "$PATH_TEST_PARENT" "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"' EXIT
+QUALITY_EVAL_ARTIFACT_DIR="$ROOT/.eval-tool-artifacts/quality-loop-$QUALITY_TEST_RUN_ID"
+trap 'rm -rf -- "$TEST_HOME" "$PATH_TEST_PARENT" "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL" "$QUALITY_EVAL_ARTIFACT_DIR"' EXIT
 UNRELATED_GEAK_WORKFLOW_DIR="$TEST_HOME/unrelated-geak-workflow"
 GEAK_SDK_PYTHONPATH="PYTHONPATH=/workspace/.aka-pyuserbase/geak-sdk"
 mkdir -p "$UNRELATED_GEAK_WORKFLOW_DIR"
@@ -250,15 +292,16 @@ QUALITY_HOME="$TEST_HOME/quality-home"
 QUALITY_PREFIX="$TEST_HOME/quality-node"
 QUALITY_BIN="$TEST_HOME/quality-bin"
 QUALITY_CONFIG="$TEST_HOME/quality-loop.yaml"
+QUALITY_DOCKER_EVENTS="$TEST_HOME/quality-docker-events"
 mkdir -p "$QUALITY_HOME/.codex" "$QUALITY_HOME/.config/gh" "$QUALITY_PREFIX/bin" "$QUALITY_BIN"
 touch "$QUALITY_PREFIX/bin/node" "$QUALITY_PREFIX/bin/codex"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$QUALITY_BIN/gh"
 chmod +x "$QUALITY_BIN/gh"
-printf '#!/usr/bin/env bash\ncase "$*" in *"agents.quality_loop.host start"*) echo "%s";; *"agents.quality_loop.host paths"*) printf "%%s\\n%%s\\n" "%s" "%s";; *"agents.quality_loop.host finalize"*) echo test-pr;; esac\n' \
+printf '#!/usr/bin/env bash\ncase "$*" in *"agents.quality_loop.host start"*) echo "%s";; *"agents.quality_loop.host paths"*) printf "%%s\\n%%s\\n" "%s" "%s";; *"agents.quality_loop.host finalize"*) [[ -z "${FAKE_DOCKER_EVENTS:-}" ]] || printf "host-finalize\\n" >> "$FAKE_DOCKER_EVENTS"; echo test-pr;; *) exec "$REAL_PYTHON3" "$@";; esac\n' \
     "$QUALITY_TEST_RUN_ID" "$QUALITY_ARTIFACT_REL" "$QUALITY_WORKTREE_REL" \
     > "$QUALITY_BIN/python3"
 chmod +x "$QUALITY_BIN/python3"
-printf 'tasks:\n  - hip2hip/gpumode/GELU\ntarget_gpu_model: MI300\nquality_loop: {}\n' > "$QUALITY_CONFIG"
+printf 'tasks:\n  - hip2hip/gpumode/GELU\ntarget_gpu_model: MI355X\nquality_loop: {}\nevaluation_tools:\n  enabled:\n    - gpu_asan\n  policy: advisory\n' > "$QUALITY_CONFIG"
 mkdir -p "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"
 
 mapfile -t args < <(
@@ -266,6 +309,7 @@ mapfile -t args < <(
         HOME="$QUALITY_HOME" \
         PATH="$QUALITY_BIN:$PATH" \
         AKA_NODE_PREFIX="$QUALITY_PREFIX" \
+        FAKE_DOCKER_EVENTS="$QUALITY_DOCKER_EVENTS" \
         bash "$RUNNER" quality-loop --config "$QUALITY_CONFIG" 2>/dev/null
 )
 assert_has "$QUALITY_PREFIX:/opt/node:ro" "${args[@]}"
@@ -281,7 +325,54 @@ assert_has "--resume" "${args[@]}"
 assert_has "$QUALITY_TEST_RUN_ID" "${args[@]}"
 assert_has "--defer-github" "${args[@]}"
 assert_has "--skip-preflight" "${args[@]}"
-rm -rf -- "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"
+assert_has "$ROOT/.eval-tool-artifacts:/workspace/.eval-tool-artifacts:ro" "${args[@]}"
+assert_has "$QUALITY_EVAL_ARTIFACT_DIR:/workspace/.eval-tool-artifacts/quality-loop-$QUALITY_TEST_RUN_ID" "${args[@]}"
+assert_has "AKA_EVAL_TOOL_SOCKET_DIR=/run/aka-eval-tools" "${args[@]}"
+assert_has "AKA_EVAL_TOOLS_SELECTED=gpu_asan" "${args[@]}"
+assert_has "AKA_EVAL_TOOL_RUNTIME_REF_GPU_ASAN=sha256:pinned-image-id" "${args[@]}"
+quality_socket_mount=""
+for value in "${args[@]}"; do
+    if [[ "$value" == *":/run/aka-eval-tools:ro" ]]; then
+        quality_socket_mount="$value"
+        break
+    fi
+done
+[[ -n "$quality_socket_mount" ]] \
+    || fail "quality_loop container did not receive the read-only evaluation-tool socket mount"
+mapfile -t quality_events < "$QUALITY_DOCKER_EVENTS"
+[[ "${quality_events[0]}" == sidecar-start:*gpu-asan* ]] \
+    || fail "quality_loop did not start its configured evaluation-tool sidecar"
+[[ "${quality_events[1]}" == "quality-loop-container" ]] \
+    || fail "quality_loop container ran before its evaluation-tool sidecar"
+[[ "${quality_events[2]}" == sidecar-stop:*gpu-asan* ]] \
+    || fail "quality_loop did not stop its evaluation-tool sidecar"
+[[ "${quality_events[3]}" == "host-finalize" ]] \
+    || fail "quality_loop finalized before stopping its evaluation-tool sidecar"
+
+# A failed quality-loop container still triggers sidecar cleanup and does not
+# finalize/publish the incomplete run.
+rm -f -- "$QUALITY_DOCKER_EVENTS"
+rm -rf -- "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL" "$QUALITY_EVAL_ARTIFACT_DIR"
+mkdir -p "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL"
+if env \
+    HOME="$QUALITY_HOME" \
+    PATH="$QUALITY_BIN:$PATH" \
+    AKA_NODE_PREFIX="$QUALITY_PREFIX" \
+    FAKE_DOCKER_EVENTS="$QUALITY_DOCKER_EVENTS" \
+    FAKE_SCORING_DOCKER_FAILURE=1 \
+    bash "$RUNNER" quality-loop --config "$QUALITY_CONFIG" >/dev/null 2>&1; then
+    fail "quality_loop unexpectedly succeeded after its container failed"
+fi
+mapfile -t quality_failure_events < "$QUALITY_DOCKER_EVENTS"
+[[ "${quality_failure_events[0]}" == sidecar-start:*gpu-asan* ]] \
+    || fail "failed quality_loop did not start its configured evaluation-tool sidecar"
+[[ "${quality_failure_events[1]}" == "quality-loop-container" ]] \
+    || fail "failed quality_loop did not enter its scoring container"
+[[ "${quality_failure_events[2]}" == sidecar-stop:*gpu-asan* ]] \
+    || fail "failed quality_loop leaked its evaluation-tool sidecar"
+[[ "${#quality_failure_events[@]}" -eq 3 ]] \
+    || fail "failed quality_loop unexpectedly finalized/published its run"
+rm -rf -- "$ROOT/$QUALITY_ARTIFACT_REL" "$ROOT/$QUALITY_WORKTREE_REL" "$QUALITY_EVAL_ARTIFACT_DIR"
 
 # A Codex-only config likewise receives neither Claude credentials nor GEAK's
 # dependency path/mount, even when both are configured on the host.

--- a/tests/test_quality_loop.py
+++ b/tests/test_quality_loop.py
@@ -1,0 +1,630 @@
+import json
+import logging
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+from agents.quality_loop.config import QualityLoopConfig
+from agents.quality_loop.filesystem import (
+    apply_changes,
+    diff_trees,
+    is_case_path,
+    snapshot_tree,
+)
+from agents.quality_loop.github import CommandError, GitHubPublisher, parse_github_slug
+from agents.quality_loop.orchestrator import QualityLoop, difficulty_is_easy
+from agents.quality_loop.state import AuditState, resolve_worktree, validate_run_id
+
+
+LOGGER = logging.getLogger("quality-loop-test")
+
+
+class FakePublisher:
+    def __init__(self):
+        self.issues = []
+        self.commits = []
+
+    def commit_task(self, worktree, task_id):
+        self.commits.append(task_id)
+        return "abc123"
+
+    def ensure_issue(self, **kwargs):
+        self.issues.append(kwargs)
+        return "https://github.com/AMD-AGI/AgentKernelArena/issues/999"
+
+
+class RepairBackend:
+    def __init__(self, change_on_repair=True):
+        self.roles = []
+        self.change_on_repair = change_on_repair
+
+    def run(self, prompt, workspace, *, role):
+        self.roles.append(role)
+        if role == "repair" and self.change_on_repair:
+            (workspace / "kernel.py").write_text("def kernel():\n    return 1\n")
+        return "ok"
+
+
+class TamperingReviewerBackend:
+    def run(self, prompt, workspace, *, role):
+        (workspace / "task_result.yaml").write_text("pass_correctness: false\n")
+        (workspace / "quality_loop_review.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "accepted": True,
+                    "logic_equivalent": True,
+                    "evidence_sufficient": True,
+                    "case_enhancement_needed": False,
+                    "case_rationale": "none",
+                    "summary": "accepted",
+                }
+            )
+        )
+        return "tampered"
+
+
+class StubQualityLoop(QualityLoop):
+    def __init__(self, *args, reports, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reports = list(reports)
+
+    def _validate(self, task_id, task_dir, stage_dir):
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        workspace = stage_dir / "workspace"
+        if workspace.exists():
+            self._reset_path(workspace)
+        workspace.mkdir()
+        for path in task_dir.iterdir():
+            if path.is_file():
+                (workspace / path.name).write_bytes(path.read_bytes())
+        report = self.reports.pop(0)
+        (workspace / "validation_report.yaml").write_text(yaml.safe_dump(report))
+        return workspace, report
+
+    def _optimize_once(self, task_id, task_dir, stage_dir):
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        workspace = stage_dir / "workspace"
+        workspace.mkdir()
+        for path in task_dir.iterdir():
+            if path.is_file():
+                (workspace / path.name).write_bytes(path.read_bytes())
+        result = {
+            "task_name": task_id,
+            "pass_compilation": True,
+            "pass_correctness": True,
+            "speedup_ratio": 2.0,
+            "benchmark_method_consistent": True,
+            "valid_baseline_cases": 1,
+            "valid_optimized_cases": 1,
+        }
+        (workspace / "task_result.yaml").write_text(yaml.safe_dump(result))
+        return workspace, [], result
+
+    def _review(self, task_id, workspace, result):
+        return {
+            "accepted": True,
+            "logic_equivalent": True,
+            "evidence_sufficient": True,
+            "case_enhancement_needed": False,
+            "case_rationale": "coverage is sufficient",
+            "summary": "accepted",
+        }
+
+
+def make_task(root: Path) -> Path:
+    task = root / "tasks" / "hip2hip" / "sample"
+    task.mkdir(parents=True)
+    (task / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "task_type": "hip2hip",
+                "source_file_path": ["kernel.py"],
+                "target_kernel_functions": ["kernel"],
+                "compile_command": ["true"],
+                "correctness_command": ["true"],
+                "performance_command": ["true"],
+            }
+        )
+    )
+    (task / "kernel.py").write_text("def kernel():\n    raise RuntimeError('broken')\n")
+    return task
+
+
+def attach_state(workflow: QualityLoop, root: Path, worktree: Path) -> None:
+    workflow.artifact_dir = root / "artifacts" / "run"
+    workflow.worktree = worktree
+    workflow.state = AuditState.create(
+        workflow.artifact_dir / "state.yaml",
+        run_id="run",
+        config_fingerprint="fingerprint",
+        repo_slug="AMD-AGI/AgentKernelArena",
+        base_sha="base",
+        base_branch="main",
+        branch="quality-loop/run",
+        worktree=worktree,
+    )
+
+
+class QualityLoopTests(unittest.TestCase):
+    def test_config_defaults_to_codex_and_exactly_one_iteration(self):
+        config = QualityLoopConfig.from_dict(
+            {"tasks": ["all"], "target_gpu_model": "MI300", "quality_loop": {}}
+        )
+        self.assertEqual(config.backend.name, "codex")
+        self.assertEqual(config.reviewer.name, "codex")
+        self.assertEqual(config.optimization_iterations, 1)
+        self.assertTrue(config.github.draft_pr)
+
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["all"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"optimization_iterations": 2},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "repository-relative"):
+            QualityLoopConfig.from_dict(
+                {
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"artifact_root": "../outside"},
+                }
+            )
+
+    def test_run_ids_and_relative_worktree_paths_are_container_portable(self):
+        with self.assertRaisesRegex(ValueError, "run ID"):
+            validate_run_id("../../escape")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expected = root / ".quality_loop_worktrees" / "run"
+            self.assertEqual(
+                resolve_worktree(root, ".quality_loop_worktrees/run"),
+                expected.resolve(),
+            )
+
+    def test_parse_github_slug(self):
+        for remote in (
+            "git@github.com:AMD-AGI/AgentKernelArena.git",
+            "https://github.com/AMD-AGI/AgentKernelArena.git",
+            "ssh://git@github.com/AMD-AGI/AgentKernelArena.git",
+        ):
+            with self.subTest(remote=remote):
+                self.assertEqual(parse_github_slug(remote), "AMD-AGI/AgentKernelArena")
+
+    def test_preflight_rejects_missing_write_permission(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+
+            def fake_run(args, **kwargs):
+                if args[:3] == ["git", "status", "--porcelain"]:
+                    stdout = ""
+                elif args[:3] == ["git", "remote", "get-url"]:
+                    stdout = "git@github.com:AMD-AGI/AgentKernelArena.git\n"
+                elif args[:2] == ["gh", "api"]:
+                    stdout = json.dumps(
+                        {
+                            "permissions": {"push": False},
+                            "viewer_permission": "READ",
+                            "has_issues": True,
+                            "default_branch": "main",
+                        }
+                    )
+                else:
+                    stdout = ""
+                return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+            with mock.patch(
+                "agents.quality_loop.github.shutil.which", return_value="/bin/tool"
+            ), mock.patch(
+                "agents.quality_loop.github.run_command", side_effect=fake_run
+            ):
+                with self.assertRaisesRegex(RuntimeError, "lacks write permission"):
+                    publisher.preflight()
+
+    def test_preflight_stops_on_gh_auth_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+
+            def fake_run(args, **kwargs):
+                if args[:3] == ["git", "status", "--porcelain"]:
+                    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+                if args[:3] == ["git", "var", "GIT_AUTHOR_IDENT"]:
+                    return subprocess.CompletedProcess(
+                        args, 0, stdout="Quality Loop <test@example.invalid>\n", stderr=""
+                    )
+                if args[:3] == ["gh", "auth", "status"]:
+                    raise CommandError("not logged in")
+                raise AssertionError(f"preflight continued after auth failure: {args}")
+
+            with mock.patch(
+                "agents.quality_loop.github.shutil.which", return_value="/bin/tool"
+            ), mock.patch(
+                "agents.quality_loop.github.run_command", side_effect=fake_run
+            ):
+                with self.assertRaisesRegex(CommandError, "not logged in"):
+                    publisher.preflight()
+
+    def test_isolated_worktree_can_live_under_ignored_runtime_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            remote = parent / "remote.git"
+            subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+            root = parent / "repo"
+            subprocess.run(["git", "clone", str(remote), str(root)], check=True, capture_output=True)
+            subprocess.run(["git", "switch", "-c", "main"], cwd=root, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "config", "user.email", "quality-loop@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "quality_loop test"], cwd=root, check=True
+            )
+            (root / ".gitignore").write_text(".quality_loop_worktrees/\n")
+            (root / "README.md").write_text("test\n")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-m", "base"], cwd=root, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "push", "--set-upstream", "origin", "main"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+            worktree = root / ".quality_loop_worktrees" / "run"
+            publisher.create_worktree(path=worktree, branch="quality-loop/run", base_branch="main")
+            self.assertTrue((worktree / "README.md").is_file())
+            self.assertEqual(
+                subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    cwd=root,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout,
+                "",
+            )
+
+    def test_tree_diff_and_apply_are_task_local(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "kernel.py").write_text("old\n")
+            (destination / "kernel.py").write_text("old\n")
+            before = snapshot_tree(source)
+            (source / "kernel.py").write_text("new\n")
+            (source / "test_kernel.py").write_text("case\n")
+            changes = diff_trees(before, snapshot_tree(source))
+            apply_changes(source, destination, changes)
+            self.assertEqual((destination / "kernel.py").read_text(), "new\n")
+            self.assertEqual((destination / "test_kernel.py").read_text(), "case\n")
+            self.assertTrue(is_case_path("test_kernel.py"))
+            self.assertFalse(is_case_path("kernel.py"))
+
+    def test_pending_diff_verification_rejects_unrecorded_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "config", "user.email", "quality-loop@example.invalid"],
+                cwd=root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "quality_loop test"],
+                cwd=root,
+                check=True,
+            )
+            (root / "README.md").write_text("base\n")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "base"], cwd=root, check=True, capture_output=True
+            )
+            branch = subprocess.run(
+                ["git", "branch", "--show-current"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            (root / "README.md").write_text("unexpected\n")
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+            with self.assertRaisesRegex(RuntimeError, "does not match"):
+                publisher.verify_pending_changes(
+                    worktree=root,
+                    branch=branch,
+                    base_sha=base_sha,
+                    expected_paths=set(),
+                )
+
+    def test_reviewer_cannot_modify_evaluation_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / "task_result.yaml").write_text(
+                yaml.safe_dump(
+                    {
+                        "pass_compilation": True,
+                        "pass_correctness": True,
+                        "benchmark_method_consistent": True,
+                    }
+                )
+            )
+            original = workspace / ".quality_loop_original_sources"
+            original.mkdir()
+            (original / "kernel.py").write_text("def kernel():\n    return 1\n")
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            workflow = QualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                reviewer_backend=TamperingReviewerBackend(),
+            )
+            with self.assertRaisesRegex(RuntimeError, "protected evaluation evidence"):
+                workflow._review(
+                    "hip2hip/sample",
+                    workspace,
+                    {
+                        "pass_compilation": True,
+                        "pass_correctness": True,
+                        "benchmark_method_consistent": True,
+                    },
+                )
+
+    def test_repair_then_revalidate_commits_only_successful_task_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktree = root / "worktree"
+            task = make_task(worktree)
+            backend = RepairBackend(change_on_repair=True)
+            publisher = FakePublisher()
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["hip2hip/sample"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = StubQualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                backend=backend,
+                reviewer_backend=backend,
+                publisher=publisher,
+                reports=[
+                    {"overall_status": "FAIL", "checks": {}, "summary": "broken"},
+                    {"overall_status": "PASS", "checks": {}, "summary": "fixed"},
+                ],
+            )
+            attach_state(workflow, root, worktree)
+            workflow._process_task("hip2hip/sample", task)
+
+            self.assertIn("return 1", (task / "kernel.py").read_text())
+            self.assertEqual(workflow.state.task("hip2hip/sample")["state"], "completed")
+            self.assertEqual(backend.roles, ["repair"])
+            self.assertEqual(publisher.commits, ["hip2hip/sample"])
+            self.assertEqual(publisher.issues, [])
+
+    def test_unrepairable_failure_files_issue_without_touching_task(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktree = root / "worktree"
+            task = make_task(worktree)
+            original = (task / "kernel.py").read_text()
+            backend = RepairBackend(change_on_repair=False)
+            publisher = FakePublisher()
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["hip2hip/sample"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = StubQualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                backend=backend,
+                reviewer_backend=backend,
+                publisher=publisher,
+                reports=[{"overall_status": "FAIL", "checks": {}, "summary": "broken"}],
+            )
+            attach_state(workflow, root, worktree)
+            workflow._process_task("hip2hip/sample", task)
+
+            record = workflow.state.task("hip2hip/sample")
+            self.assertEqual(record["state"], "issue_filed")
+            self.assertTrue(record["issue_url"].endswith("/999"))
+            self.assertEqual((task / "kernel.py").read_text(), original)
+            self.assertEqual(len(publisher.issues), 1)
+            self.assertEqual(publisher.commits, [])
+
+    def test_container_defers_issue_request_without_github_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktree = root / "worktree"
+            task = make_task(worktree)
+            backend = RepairBackend(change_on_repair=False)
+            publisher = FakePublisher()
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["hip2hip/sample"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = StubQualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                backend=backend,
+                reviewer_backend=backend,
+                publisher=publisher,
+                defer_github=True,
+                reports=[{"overall_status": "FAIL", "checks": {}, "summary": "broken"}],
+            )
+            attach_state(workflow, root, worktree)
+            workflow._process_task("hip2hip/sample", task)
+
+            record = workflow.state.task("hip2hip/sample")
+            self.assertEqual(record["state"], "issue_pending")
+            self.assertEqual(record["issue_url"], None)
+            self.assertEqual(record["issue_request"]["task_id"], "hip2hip/sample")
+            self.assertEqual(publisher.issues, [])
+
+    def test_container_defers_task_commit_to_host_finalizer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktree = root / "worktree"
+            task = make_task(worktree)
+            backend = RepairBackend(change_on_repair=True)
+            publisher = FakePublisher()
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["hip2hip/sample"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = StubQualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                backend=backend,
+                reviewer_backend=backend,
+                publisher=publisher,
+                defer_github=True,
+                reports=[
+                    {"overall_status": "FAIL", "checks": {}, "summary": "broken"},
+                    {"overall_status": "PASS", "checks": {}, "summary": "fixed"},
+                ],
+            )
+            attach_state(workflow, root, worktree)
+            workflow._process_task("hip2hip/sample", task)
+
+            record = workflow.state.task("hip2hip/sample")
+            self.assertTrue(record["commit_pending"])
+            self.assertIsNone(record["commit"])
+            self.assertEqual(publisher.commits, [])
+
+    def test_warn_is_reported_without_repair(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            worktree = root / "worktree"
+            task = make_task(worktree)
+            backend = RepairBackend()
+            publisher = FakePublisher()
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["hip2hip/sample"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = StubQualityLoop(
+                root,
+                config,
+                logger=LOGGER,
+                backend=backend,
+                reviewer_backend=backend,
+                publisher=publisher,
+                reports=[
+                    {
+                        "overall_status": "WARN",
+                        "checks": {
+                            "performance": {"status": "WARN", "details": "too few repeats"}
+                        },
+                        "summary": "warning",
+                    }
+                ],
+            )
+            attach_state(workflow, root, worktree)
+            workflow._process_task("hip2hip/sample", task)
+
+            record = workflow.state.task("hip2hip/sample")
+            self.assertEqual(record["state"], "completed")
+            self.assertEqual(record["warnings"], ["performance: too few repeats"])
+            self.assertNotIn("repair", backend.roles)
+            self.assertEqual(publisher.issues, [])
+
+    def test_easy_gate_is_fail_closed_and_not_used_for_authoring_tasks(self):
+        config = QualityLoopConfig.from_dict(
+            {"target_gpu_model": "MI300", "quality_loop": {}}
+        )
+        result = {
+            "pass_compilation": True,
+            "pass_correctness": True,
+            "benchmark_method_consistent": True,
+            "valid_baseline_cases": 3,
+            "valid_optimized_cases": 3,
+        }
+        review = {
+            "accepted": True,
+            "logic_equivalent": True,
+            "evidence_sufficient": True,
+        }
+        self.assertTrue(
+            difficulty_is_easy(
+                task_type="hip2hip",
+                speedups=[5.1, 5.0, 6.0],
+                result=result,
+                review=review,
+                config=config,
+            )
+        )
+        self.assertFalse(
+            difficulty_is_easy(
+                task_type="torch2hip",
+                speedups=[10.0, 10.0, 10.0],
+                result=result,
+                review=review,
+                config=config,
+            )
+        )
+        result["benchmark_method_consistent"] = False
+        self.assertFalse(
+            difficulty_is_easy(
+                task_type="hip2hip",
+                speedups=[6.0, 6.0, 6.0],
+                result=result,
+                review=review,
+                config=config,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_loop.py
+++ b/tests/test_quality_loop.py
@@ -25,17 +25,11 @@ LOGGER = logging.getLogger("quality-loop-test")
 
 class FakePublisher:
     def __init__(self):
-        self.issues = []
         self.commits = []
 
     def commit_task(self, worktree, task_id):
         self.commits.append(task_id)
         return "abc123"
-
-    def ensure_issue(self, **kwargs):
-        self.issues.append(kwargs)
-        return "https://github.com/AMD-AGI/AgentKernelArena/issues/999"
-
 
 class RepairBackend:
     def __init__(self, change_on_repair=True):
@@ -157,7 +151,6 @@ class QualityLoopTests(unittest.TestCase):
         self.assertEqual(config.backend.name, "codex")
         self.assertEqual(config.reviewer.name, "codex")
         self.assertEqual(config.optimization_iterations, 1)
-        self.assertTrue(config.github.draft_pr)
 
         with self.assertRaisesRegex(ValueError, "exactly one"):
             QualityLoopConfig.from_dict(
@@ -165,6 +158,38 @@ class QualityLoopTests(unittest.TestCase):
                     "tasks": ["all"],
                     "target_gpu_model": "MI300",
                     "quality_loop": {"optimization_iterations": 2},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "always drafts"):
+            QualityLoopConfig.from_dict(
+                {
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"github": {"draft_pr": False}},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "never creates GitHub issues"):
+            QualityLoopConfig.from_dict(
+                {
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"github": {"issue_labels": ["task-bug"]}},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "exactly one repair"):
+            QualityLoopConfig.from_dict(
+                {
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"max_repair_attempts": 0},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "top-level tasks field"):
+            QualityLoopConfig.from_dict(
+                {
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {"promotion_task_types": ["hip2hip"]},
                 }
             )
 
@@ -195,6 +220,23 @@ class QualityLoopTests(unittest.TestCase):
         ):
             with self.subTest(remote=remote):
                 self.assertEqual(parse_github_slug(remote), "AMD-AGI/AgentKernelArena")
+
+    def test_yaml_task_selectors_define_the_complete_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for task_id in ("custom/selected", "hip2hip/not-selected"):
+                task = root / "tasks" / task_id
+                task.mkdir(parents=True)
+                (task / "config.yaml").write_text("task_type: custom\n")
+            config = QualityLoopConfig.from_dict(
+                {
+                    "tasks": ["custom/selected"],
+                    "target_gpu_model": "MI300",
+                    "quality_loop": {},
+                }
+            )
+            workflow = QualityLoop(root, config, logger=LOGGER)
+            self.assertEqual(list(workflow.discover_tasks(root)), ["custom/selected"])
 
     def test_preflight_rejects_missing_write_permission(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -366,6 +408,99 @@ class QualityLoopTests(unittest.TestCase):
                     expected_paths=set(),
                 )
 
+    def test_publisher_always_creates_at_most_one_draft_pr(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "artifacts"
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+            calls = []
+            existing = False
+
+            def fake_run(args, **kwargs):
+                nonlocal existing
+                calls.append(list(args))
+                if args[:2] == ["git", "rev-list"]:
+                    stdout = "1\n"
+                elif args[:3] == ["gh", "pr", "list"]:
+                    stdout = (
+                        json.dumps([{"url": "https://example.invalid/pr/1"}])
+                        if existing
+                        else "[]"
+                    )
+                elif args[:3] == ["gh", "pr", "create"]:
+                    existing = True
+                    stdout = "https://example.invalid/pr/1\n"
+                else:
+                    stdout = ""
+                return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+            with mock.patch(
+                "agents.quality_loop.github.run_command", side_effect=fake_run
+            ):
+                first = publisher.publish_draft_pr(
+                    worktree=root,
+                    repo_slug="AMD-AGI/AgentKernelArena",
+                    branch="quality-loop/run",
+                    base_branch="main",
+                    title="quality audit",
+                    body="summary",
+                    artifact_dir=artifact,
+                )
+                second = publisher.publish_draft_pr(
+                    worktree=root,
+                    repo_slug="AMD-AGI/AgentKernelArena",
+                    branch="quality-loop/run",
+                    base_branch="main",
+                    title="quality audit",
+                    body="summary",
+                    artifact_dir=artifact,
+                )
+
+            create_calls = [args for args in calls if args[:3] == ["gh", "pr", "create"]]
+            self.assertEqual(first, "https://example.invalid/pr/1")
+            self.assertEqual(second, first)
+            self.assertEqual(len(create_calls), 1)
+            self.assertIn("--draft", create_calls[0])
+            self.assertFalse(any(args[:2] == ["gh", "issue"] for args in calls))
+
+    def test_publisher_skips_pr_when_run_has_no_commits(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "artifacts"
+            config = QualityLoopConfig.from_dict(
+                {"target_gpu_model": "MI300", "quality_loop": {}}
+            )
+            publisher = GitHubPublisher(root, config.github, LOGGER)
+            calls = []
+
+            def fake_run(args, **kwargs):
+                calls.append(list(args))
+                if args[:2] == ["git", "rev-list"]:
+                    return subprocess.CompletedProcess(
+                        args, 0, stdout="0\n", stderr=""
+                    )
+                raise AssertionError(f"unexpected command after empty run: {args}")
+
+            with mock.patch(
+                "agents.quality_loop.github.run_command", side_effect=fake_run
+            ):
+                result = publisher.publish_draft_pr(
+                    worktree=root,
+                    repo_slug="AMD-AGI/AgentKernelArena",
+                    branch="quality-loop/run",
+                    base_branch="main",
+                    title="quality audit",
+                    body="summary",
+                    artifact_dir=artifact,
+                )
+
+            self.assertIsNone(result)
+            self.assertEqual(calls, [["git", "rev-list", "--count", "origin/main..HEAD"]])
+            self.assertFalse(artifact.exists())
+
     def test_reviewer_cannot_modify_evaluation_evidence(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -436,9 +571,8 @@ class QualityLoopTests(unittest.TestCase):
             self.assertEqual(workflow.state.task("hip2hip/sample")["state"], "completed")
             self.assertEqual(backend.roles, ["repair"])
             self.assertEqual(publisher.commits, ["hip2hip/sample"])
-            self.assertEqual(publisher.issues, [])
 
-    def test_unrepairable_failure_files_issue_without_touching_task(self):
+    def test_unrepairable_failure_is_reported_without_external_action(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             worktree = root / "worktree"
@@ -466,13 +600,12 @@ class QualityLoopTests(unittest.TestCase):
             workflow._process_task("hip2hip/sample", task)
 
             record = workflow.state.task("hip2hip/sample")
-            self.assertEqual(record["state"], "issue_filed")
-            self.assertTrue(record["issue_url"].endswith("/999"))
+            self.assertEqual(record["state"], "reported_failure")
+            self.assertEqual(record["validation_report"]["overall_status"], "FAIL")
             self.assertEqual((task / "kernel.py").read_text(), original)
-            self.assertEqual(len(publisher.issues), 1)
             self.assertEqual(publisher.commits, [])
 
-    def test_container_defers_issue_request_without_github_credentials(self):
+    def test_container_reports_unrepairable_failure_without_publication_request(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             worktree = root / "worktree"
@@ -500,10 +633,9 @@ class QualityLoopTests(unittest.TestCase):
             workflow._process_task("hip2hip/sample", task)
 
             record = workflow.state.task("hip2hip/sample")
-            self.assertEqual(record["state"], "issue_pending")
-            self.assertEqual(record["issue_url"], None)
-            self.assertEqual(record["issue_request"]["task_id"], "hip2hip/sample")
-            self.assertEqual(publisher.issues, [])
+            self.assertEqual(record["state"], "reported_failure")
+            self.assertNotIn("issue_request", record)
+            self.assertNotIn("issue_url", record)
 
     def test_container_defers_task_commit_to_host_finalizer(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -578,9 +710,8 @@ class QualityLoopTests(unittest.TestCase):
             self.assertEqual(record["state"], "completed")
             self.assertEqual(record["warnings"], ["performance: too few repeats"])
             self.assertNotIn("repair", backend.roles)
-            self.assertEqual(publisher.issues, [])
 
-    def test_easy_gate_is_fail_closed_and_not_used_for_authoring_tasks(self):
+    def test_easy_gate_is_fail_closed_and_task_type_agnostic(self):
         config = QualityLoopConfig.from_dict(
             {"target_gpu_model": "MI300", "quality_loop": {}}
         )
@@ -598,17 +729,7 @@ class QualityLoopTests(unittest.TestCase):
         }
         self.assertTrue(
             difficulty_is_easy(
-                task_type="hip2hip",
                 speedups=[5.1, 5.0, 6.0],
-                result=result,
-                review=review,
-                config=config,
-            )
-        )
-        self.assertFalse(
-            difficulty_is_easy(
-                task_type="torch2hip",
-                speedups=[10.0, 10.0, 10.0],
                 result=result,
                 review=review,
                 config=config,
@@ -617,7 +738,6 @@ class QualityLoopTests(unittest.TestCase):
         result["benchmark_method_consistent"] = False
         self.assertFalse(
             difficulty_is_easy(
-                task_type="hip2hip",
                 speedups=[6.0, 6.0, 6.0],
                 result=result,
                 review=review,


### PR DESCRIPTION
## Summary

- add the repository-level `quality_loop` workflow, defaulting to Codex
- use the top-level YAML `tasks` selectors as the complete task scope, without a task-type allowlist
- run validator -> one repair attempt for blocking failures -> exactly one optimization iteration -> centralized evaluation -> independent Codex review
- record WARN and unresolved FAIL results locally; the workflow never creates GitHub issues
- when a task is valid, detect reproducibly easy tasks and promote a better baseline only after fresh validation and dual original/candidate correctness gates
- preserve the trusted evaluation-tools control-plane integration without carrying its already-merged implementation history in this PR
- keep GitHub credentials outside the GPU container and verify accepted task-local changes on the host
- publish at most one pull request per run, always created as a draft; skip PR creation when a run has no accepted changes
- keep the dedicated `make docker-quality-loop CONFIG=...` entry point because this is a repository-level, multi-task workflow rather than a normal per-task `agent.template`
- add a root `CLAUDE.md` that imports `AGENTS.md`, so Claude Code follows the repository-wide agent instructions without duplicating them

## Branch cleanup

This PR is now based directly on the latest `main`. It no longer depends on #75 and does not contain the already-merged evaluation-tools or Campaign 20 task history.

## Validation

- `python3 -m unittest discover -s tests -p 'test_quality_loop.py' -v` — 18 passed
- `make check-docker-runner` — passed
- `make check-evaluator` — 9 passed
- pinned MI35X ROCm Docker image: `python3 -m pytest -q -p no:cacheprovider tests` — 482 passed, 4 skipped, 3 subtests passed
- `make docker-smoke` — passed on AMD Instinct MI355X / `gfx950`
- offline `--plan` checks passed for the MI300 and MI355X example configs
- `CLAUDE.md` uses Claude Code's documented `@AGENTS.md` import syntax

A real quality-loop campaign was not rerun for this history-only rebase because it invokes external agents and can publish a separate remote PR. The workflow and GPU runtime paths are covered by the focused tests, full Docker suite, and MI355X smoke above.
