### PR TITLE
Make image-kernel correctness check what performance actually scores, and add three tasks

### DIFF
--- a/src/jit_rebuild.py
+++ b/src/jit_rebuild.py
@@ -125,9 +125,60 @@ def apply_jit_rebuild(
 
     if workspace is not None and task_config is not None:
         _clear_stale_aiter_op_so(Path(workspace), task_config, lg)
+        if _sources_match_image(Path(workspace), task_config, lg):
+            # Nothing has been edited yet, so the prebuilt in-tree .so IS the
+            # current source and forcing a rebuild only burns compile time. This
+            # matters most under the profiler, which re-spawns the driver once
+            # per counter pass and would otherwise re-enter the rebuild path
+            # every time.
+            return {}
     # Explicit "1" (not setdefault): an inherited AITER_REBUILD=0 must still be
     # overridden when a rebuild is required. Scoped to the caller's subprocess.
     return {"AITER_REBUILD": "1"}
+
+
+def _sources_match_image(
+    workspace: Path, task_config: dict[str, Any], logger: logging.Logger
+) -> bool:
+    """True only when every editable source is byte-identical to the in-image copy.
+
+    Deliberately fails safe. Serving a prebuilt ``.so`` for an edited kernel is
+    the exact failure this module exists to prevent — the benchmark would measure
+    the ORIGINAL kernel — so anything we cannot positively verify (missing image
+    path, unreadable file, source we cannot locate) counts as edited.
+    """
+    image_root = task_config.get("image_repo_path")
+    if not image_root:
+        return False
+    image_root = Path(str(image_root))
+    if not image_root.is_dir():
+        return False
+
+    sfp = task_config.get("source_file_path") or []
+    if isinstance(sfp, str):
+        sfp = [sfp]
+    rels = [str(s) for s in sfp if str(s).lower().endswith(_CPP_EXTS)]
+    if not rels:
+        return False
+
+    resolved = _resolve_source_files(workspace, task_config)
+    if len(resolved) != len(rels):
+        return False
+
+    for rel, ours in zip(rels, resolved):
+        theirs = image_root / rel
+        try:
+            if ours.read_bytes() != theirs.read_bytes():
+                return False
+        except OSError:
+            return False
+
+    logger.info(
+        "force_jit_rebuild: %d editable source(s) still match the in-image copy; "
+        "keeping the prebuilt .so instead of forcing a rebuild",
+        len(rels),
+    )
+    return True
 
 
 def _op_name_keys(task_config: dict[str, Any]) -> set[str]:

--- a/src/tools/perf/vllm_cuda_graph_block.py
+++ b/src/tools/perf/vllm_cuda_graph_block.py
@@ -42,8 +42,9 @@ class _TimedRun:
 
     Under CUDA-graph timing the buffers are captured once and every replay
     writes to those same addresses, so ``outputs`` keeps tracking replays. Under
-    event-timing fallback each call allocates fresh buffers, so ``outputs`` is
-    only populated once ``rerun`` has run.
+    event-timing fallback the measured outputs cannot be observed reliably, so a
+    benchmark that requests this collector fails closed instead of validating a
+    separate post-timing invocation.
     """
 
     def __init__(self):
@@ -82,19 +83,12 @@ def _benchmark_cuda_graph_or_events(
 ):
     import torch
 
-    def _bind_direct_call():
-        # Fallback paths allocate fresh outputs per call, so there is nothing to
-        # alias; the caller gets them by re-running the same unit once.
-        if timed_run is None:
-            return
-
-        def _call_once():
-            out = fn()
-            if torch.cuda.is_available():
-                torch.cuda.synchronize()
-            return out
-
-        timed_run._bind(_call_once)
+    def _reject_unobservable_fallback(reason):
+        if timed_run is not None:
+            raise RuntimeError(
+                f"{reason}; timed_run requires an observable CUDA-graph replay "
+                "and cannot validate a separate post-timing invocation"
+            )
 
     # A captured graph whose measured per-iteration time falls below this floor is
     # treated as empty (it recorded no device work) and rejected in favour of
@@ -116,23 +110,23 @@ def _benchmark_cuda_graph_or_events(
     }
 
     if not torch.cuda.is_available():
+        _reject_unobservable_fallback("CUDA is unavailable")
         times = _measure_cuda_event_fallback(fn, repetition)
         metadata.update({
             "benchmark_method": "cpu_timer_fallback",
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": fallback_reason or "cuda_unavailable",
         })
-        _bind_direct_call()
         return sum(times) / len(times), metadata
 
     if not use_cuda_graph:
+        _reject_unobservable_fallback("CUDA-graph timing is disabled")
         times = _measure_cuda_event_fallback(fn, repetition)
         metadata.update({
             "benchmark_method": "cuda_event_fallback",
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": fallback_reason or "cuda_graph_disabled",
         })
-        _bind_direct_call()
         return sum(times) / len(times), metadata
 
     try:
@@ -178,13 +172,13 @@ def _benchmark_cuda_graph_or_events(
 
         graph_mean = sum(retry_times) / len(retry_times)
         if graph_mean < empty_graph_floor_ms:
+            _reject_unobservable_fallback("CUDA graph captured no device work")
             times = _measure_cuda_event_fallback(fn, repetition)
             metadata.update({
                 "benchmark_method": "cuda_event_fallback",
                 "benchmark_effective_repeats": int(repetition),
                 "benchmark_fallback_reason": fallback_reason or "empty_cuda_graph_capture",
             })
-            _bind_direct_call()
             return sum(times) / len(times), metadata
 
         metadata.update({
@@ -214,6 +208,11 @@ def _benchmark_cuda_graph_or_events(
             torch.cuda.synchronize()
         except Exception:
             pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed_run cannot validate the "
+                "separate CUDA-event fallback invocation"
+            ) from exc
         for _ in range(min(3, max(1, int(warmup)))):
             fn()
         torch.cuda.synchronize()
@@ -223,5 +222,4 @@ def _benchmark_cuda_graph_or_events(
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": f"cuda_graph_failed: {type(exc).__name__}: {str(exc)[:160]}",
         })
-        _bind_direct_call()
         return sum(times) / len(times), metadata

--- a/src/tools/perf/vllm_cuda_graph_block.py
+++ b/src/tools/perf/vllm_cuda_graph_block.py
@@ -31,6 +31,43 @@ def _measure_cuda_event_fallback(fn, repetition):
     return times_ms
 
 
+class _TimedRun:
+    """Handle on the exact invocation a benchmark measured.
+
+    Timing and correctness are otherwise separate invocations, so a kernel can
+    tell them apart and do less work in the one that is scored. Passing this
+    collector to the benchmark makes the scored invocation itself observable:
+    ``outputs`` aliases the buffers the timed unit last wrote, and ``rerun``
+    executes that same unit again.
+
+    Under CUDA-graph timing the buffers are captured once and every replay
+    writes to those same addresses, so ``outputs`` keeps tracking replays. Under
+    event-timing fallback each call allocates fresh buffers, so ``outputs`` is
+    only populated once ``rerun`` has run.
+    """
+
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError(
+                "timed run was never bound; the benchmark did not reach a "
+                "measurement path"
+            )
+        self.outputs = self._rerun()
+        return self.outputs
+
+
 def _benchmark_cuda_graph_or_events(
     fn,
     warmup=10,
@@ -41,8 +78,23 @@ def _benchmark_cuda_graph_or_events(
     max_graph_repeats=1000,
     use_cuda_graph=True,
     fallback_reason=None,
+    timed_run=None,
 ):
     import torch
+
+    def _bind_direct_call():
+        # Fallback paths allocate fresh outputs per call, so there is nothing to
+        # alias; the caller gets them by re-running the same unit once.
+        if timed_run is None:
+            return
+
+        def _call_once():
+            out = fn()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            return out
+
+        timed_run._bind(_call_once)
 
     # A captured graph whose measured per-iteration time falls below this floor is
     # treated as empty (it recorded no device work) and rejected in favour of
@@ -70,6 +122,7 @@ def _benchmark_cuda_graph_or_events(
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": fallback_reason or "cuda_unavailable",
         })
+        _bind_direct_call()
         return sum(times) / len(times), metadata
 
     if not use_cuda_graph:
@@ -79,6 +132,7 @@ def _benchmark_cuda_graph_or_events(
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": fallback_reason or "cuda_graph_disabled",
         })
+        _bind_direct_call()
         return sum(times) / len(times), metadata
 
     try:
@@ -107,8 +161,9 @@ def _benchmark_cuda_graph_or_events(
 
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
+                captured_outputs = None
                 for _ in range(n_repeat):
-                    fn()
+                    captured_outputs = fn()
             torch.cuda.synchronize()
 
             retry_times = []
@@ -129,12 +184,27 @@ def _benchmark_cuda_graph_or_events(
                 "benchmark_effective_repeats": int(repetition),
                 "benchmark_fallback_reason": fallback_reason or "empty_cuda_graph_capture",
             })
+            _bind_direct_call()
             return sum(times) / len(times), metadata
 
         metadata.update({
             "benchmark_method": "cuda_graph",
             "benchmark_effective_repeats": int(n_repeat),
         })
+        if timed_run is not None:
+
+            def _replay_once():
+                # Callers stage work on their own stream before re-running (they
+                # perturb inputs and poison outputs). The capture stream must be
+                # ordered after that, or the replay races the staged writes and
+                # they land on top of the kernel's results.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
         return graph_mean, metadata
     except Exception as exc:
         # Isolate the aborted capture before re-measuring so the fallback timing is
@@ -153,4 +223,5 @@ def _benchmark_cuda_graph_or_events(
             "benchmark_effective_repeats": int(repetition),
             "benchmark_fallback_reason": f"cuda_graph_failed: {type(exc).__name__}: {str(exc)[:160]}",
         })
+        _bind_direct_call()
         return sum(times) / len(times), metadata

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/forge_driver.py
@@ -85,7 +85,7 @@ def _run_correctness(tr) -> int:
     torch = tr._torch()
     all_ok = True
     for case in tr.CASES:
-        inputs = tr._make(case, correctness=True)
+        inputs = tr._make(case)
         got = tr._fused_output(inputs)
         torch.cuda.synchronize()
         err = tr._relerr(got, tr._reference(inputs))
@@ -103,7 +103,7 @@ def _run_bench(tr, warmup: int, iters: int) -> int:
     torch = tr._torch()
     results = []
     for case in tr.CASES:
-        inputs = tr._make(case, correctness=False)
+        inputs = tr._make(case)
         tr._run_gemms(inputs)  # warm/JIT settle before capture
         torch.cuda.synchronize()
         ms, meta = tr._benchmark_cuda_graph(
@@ -132,7 +132,7 @@ def _run_profile(tr) -> int:
     """Kernel-only profiling for one case: warm, a few launches, sync, exit 0."""
     torch = tr._torch()
     case = max(tr.CASES, key=lambda c: int(c["params"]["tokens"]))
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run_gemms(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/forge_driver.py
@@ -106,11 +106,14 @@ def _run_bench(tr, warmup: int, iters: int) -> int:
         inputs = tr._make(case)
         tr._run_gemms(inputs)  # warm/JIT settle before capture
         torch.cuda.synchronize()
+        timed = tr._TimedRun()
         ms, meta = tr._benchmark_cuda_graph(
             lambda i=inputs: tr._run_gemms(i),
             warmup=max(1, warmup),
             repetition=max(1, iters),
+            timed_run=timed,
         )
+        tr._assert_timed_outputs(inputs, timed)
         if not math.isfinite(ms) or ms <= 0:
             print(f"error: invalid timing for case {case['id']!r}: {ms!r}", file=sys.stderr)
             return 1

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/standalone_driver.py
@@ -112,7 +112,10 @@ WORKSPACE = _resolve_workspace()
 SPEC = json.loads(_SESSION_CASES_JSON)
 CASES = SPEC["cases"]
 BLOCK_M = 64
-CORRECTNESS_MAX_TOKENS = 64  # cap T so the O(T*top_k) python reference stays cheap
+# Token count for the compile smoke test only. Correctness and performance both
+# run at the scored token count; the reference is batched per expert, so a full
+# shape stays affordable.
+COMPILE_SMOKE_MAX_TOKENS = 64
 
 
 def _configure() -> None:
@@ -220,7 +223,13 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
 # --------------------------------------------------------------------------- #
 # Build the two grouped-GEMM invocations of one MoE forward (untimed setup).
 # --------------------------------------------------------------------------- #
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+    """
     torch = _torch()
     from sglang.kernels.ops.moe.minimax_m3_swiglu import swiglu_oai_split
     from sglang.kernels.ops.moe.mxfp8_moe_amd_gfx95 import _grouped_gemm_mxfp8
@@ -233,7 +242,7 @@ def _make(case: dict, correctness: bool = False) -> dict:
     )
 
     p = case["params"]
-    T = min(p["tokens"], CORRECTNESS_MAX_TOKENS) if correctness else p["tokens"]
+    T = p["tokens"]
     H, I, E, top_k = p["hidden"], p["inter"], p["experts"], p["top_k"]
     alpha, beta, limit = p["alpha"], p["beta"], p["limit"]
     torch.manual_seed(case.get("seed", 0))
@@ -311,36 +320,77 @@ def _fused_output(inputs: dict):
 
 
 def _reference(inputs: dict):
+    """Dequantized torch reference for one MoE forward.
+
+    Iterates experts rather than (token, slot) pairs: every token routed to an
+    expert is one batched matmul instead of a Python step. The loop this replaces
+    ran T*top_k times and synchronised on ``topk_ids`` each step, which is what
+    made a full-shape correctness run impractical.
+
+    The dequantized weights stay bf16 and are cast per expert, so the reference
+    never materialises an fp32 copy of the whole expert bank.
+    """
     torch = _torch()
     from sglang.kernels.ops.quantization.mxfp8_amd_gfx95 import dequant_mxfp8_to_bf16
 
     x = dequant_mxfp8_to_bf16(inputs["a_q"], inputs["a_s"]).float()
-    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"]).float()
-    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"]).float()
+    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"])
+    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"])
     T, I, top_k = inputs["T"], inputs["I"], inputs["top_k"]
     alpha, beta, limit = inputs["alpha"], inputs["beta"], inputs["limit"]
     topk_weights, topk_ids = inputs["topk_weights"], inputs["topk_ids"]
     H = inputs["H"]
+    num_experts = w13.shape[0]
+
     out = torch.zeros(T, H, device=x.device, dtype=torch.float32)
-    for t in range(T):
-        for j in range(top_k):
-            e = int(topk_ids[t, j].item())
-            if e < 0 or e >= w13.shape[0]:
-                continue
-            g1 = x[t] @ w13[e].T
-            gate, up = g1[:I], g1[I:]
-            gate = gate.clamp(max=limit)
-            up = up.clamp(min=-limit, max=limit)
-            act = gate * torch.sigmoid(alpha * gate) * (up + beta)
-            out[t] += topk_weights[t, j].float() * (act @ w2[e].T)
+    flat_expert = topk_ids.long().reshape(-1)
+    flat_token = torch.arange(
+        T, device=x.device
+    ).unsqueeze(1).expand(T, top_k).reshape(-1)
+    flat_weight = topk_weights.float().reshape(-1)
+
+    # moe_align_block_size can emit padding slots outside the expert range.
+    keep = (flat_expert >= 0) & (flat_expert < num_experts)
+    flat_expert = flat_expert[keep]
+    flat_token = flat_token[keep]
+    flat_weight = flat_weight[keep]
+
+    order = torch.argsort(flat_expert)
+    counts = torch.bincount(flat_expert[order], minlength=num_experts)
+    offsets = torch.cumsum(counts, dim=0).tolist()
+    start = 0
+    for expert, stop in enumerate(offsets):
+        if stop == start:
+            continue
+        rows = flat_token[order[start:stop]]
+        g1 = x[rows] @ w13[expert].float().T  # [n, 2*I]
+        gate = g1[:, :I].clamp(max=limit)
+        up = g1[:, I:].clamp(min=-limit, max=limit)
+        act = gate * torch.sigmoid(alpha * gate) * (up + beta)
+        contrib = (act @ w2[expert].float().T) * flat_weight[
+            order[start:stop]
+        ].unsqueeze(-1)
+        out.index_add_(0, rows, contrib)
+        start = stop
     return out.to(torch.bfloat16)
 
 
 # --------------------------------------------------------------------------- #
 # Modes
 # --------------------------------------------------------------------------- #
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    params["tokens"] = min(params["tokens"], COMPILE_SMOKE_MAX_TOKENS)
+    return {**case, "params": params}
+
+
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(_compile_smoke_case(CASES[0]))
     _run_gemms(inputs)
     _torch().cuda.synchronize()
     print("mxfp8_grouped_gemm compile smoke: PASS")
@@ -349,7 +399,7 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _fused_output(inputs)
         torch.cuda.synchronize()
         err = _relerr(got, _reference(inputs))
@@ -362,7 +412,7 @@ def run_performance() -> None:
     torch = _torch()
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run_gemms(inputs)
         torch.cuda.synchronize()
         ms, bmeta = _benchmark_cuda_graph(lambda: _run_gemms(inputs))
@@ -410,7 +460,7 @@ def _run_correctness(tr, mode: str) -> int:
     torch = tr._torch()
     all_ok = True
     for case in tr.CASES:
-        inputs = tr._make(case, correctness=True)
+        inputs = tr._make(case)
         got = tr._fused_output(inputs)
         torch.cuda.synchronize()
         err = tr._relerr(got, tr._reference(inputs))
@@ -428,7 +478,7 @@ def _run_bench(tr, warmup: int, iters: int) -> int:
     torch = tr._torch()
     means = []
     for case in tr.CASES:
-        inputs = tr._make(case, correctness=False)
+        inputs = tr._make(case)
         tr._run_gemms(inputs)  # warm/JIT settle before capture
         torch.cuda.synchronize()
         ms, meta = tr._benchmark_cuda_graph(
@@ -457,7 +507,7 @@ def _run_profile(tr, case_id: str) -> int:
     else:
         # Default: the largest / dominant case (most tokens) when unspecified.
         case = max(tr.CASES, key=lambda c: int(c["params"]["tokens"]))
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run_gemms(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/standalone_driver.py
@@ -162,7 +162,34 @@ def _measure_cuda_event(fn, repetition):
     return times_ms
 
 
-def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_graph_repeats=200):
+class _TimedRun:
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError("timed run was never bound")
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph(
+    fn,
+    warmup=10,
+    repetition=100,
+    target_ms=1.0,
+    max_graph_repeats=200,
+    timed_run=None,
+):
     import torch
 
     for _ in range(max(0, int(warmup))):
@@ -189,8 +216,9 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
 
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
+                captured_outputs = None
                 for _ in range(repeats):
-                    fn()
+                    captured_outputs = fn()
             torch.cuda.synchronize()
 
             times = []
@@ -205,12 +233,26 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
         if mean_ms < 1e-5:
             raise RuntimeError("empty_cuda_graph_capture")
         meta.update(benchmark_method="cuda_graph", benchmark_effective_repeats=int(repeats))
+        if timed_run is not None:
+            def _replay_once():
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
         return mean_ms, meta
     except Exception as exc:
         try:
             torch.cuda.synchronize()
         except Exception:
             pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed outputs cannot be validated "
+                "through a separate event-timed invocation"
+            ) from exc
         times = _measure_cuda_event(fn, repetition)
         meta.update(
             benchmark_method="cuda_event_fallback",
@@ -295,8 +337,9 @@ def _run_gemms(inputs: dict):
     """The timed region: the two grouped-GEMM launches of one MoE forward."""
     from sglang.kernels.ops.moe.mxfp8_moe_amd_gfx95 import _grouped_gemm_mxfp8
 
-    _grouped_gemm_mxfp8(**inputs["gemm1_args"])
-    return _grouped_gemm_mxfp8(**inputs["gemm2_args"])
+    gemm1 = _grouped_gemm_mxfp8(**inputs["gemm1_args"])
+    gemm2 = _grouped_gemm_mxfp8(**inputs["gemm2_args"])
+    return gemm1, gemm2
 
 
 def _fused_output(inputs: dict):
@@ -317,6 +360,65 @@ def _fused_output(inputs: dict):
     g2 = _grouped_gemm_mxfp8(**args)  # [M, H] fp32, top-k weighted
     T, top_k, H = inputs["T"], inputs["top_k"], inputs["H"]
     return g2.view(T, top_k, H).sum(dim=1).to(torch.bfloat16)
+
+
+def _timed_references(inputs: dict):
+    """Independent references for the two outputs produced inside the timed region."""
+    torch = _torch()
+    from sglang.kernels.ops.quantization.mxfp8_amd_gfx95 import dequant_mxfp8_to_bf16
+
+    x = dequant_mxfp8_to_bf16(inputs["a_q"], inputs["a_s"]).float()
+    act = dequant_mxfp8_to_bf16(
+        inputs["gemm2_args"]["a_q"],
+        inputs["gemm2_args"]["a_scale"],
+    ).float()
+    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"])
+    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"])
+
+    topk_ids = inputs["topk_ids"].long().reshape(-1)
+    topk_weights = inputs["topk_weights"].float().reshape(-1)
+    top_k = inputs["top_k"]
+    flat_token = torch.arange(
+        inputs["T"], device=x.device
+    ).unsqueeze(1).expand(inputs["T"], top_k).reshape(-1)
+
+    gemm1 = torch.empty(
+        topk_ids.numel(),
+        2 * inputs["I"],
+        device=x.device,
+        dtype=torch.bfloat16,
+    )
+    gemm2 = torch.empty(
+        topk_ids.numel(),
+        inputs["H"],
+        device=x.device,
+        dtype=torch.float32,
+    )
+    for expert in range(w13.shape[0]):
+        slots = torch.where(topk_ids == expert)[0]
+        if slots.numel() == 0:
+            continue
+        rows = flat_token[slots]
+        gemm1[slots] = (x[rows] @ w13[expert].float().T).to(torch.bfloat16)
+        gemm2[slots] = (
+            act[slots] @ w2[expert].float().T
+        ) * topk_weights[slots].unsqueeze(-1)
+    return gemm1, gemm2
+
+
+def _assert_timed_outputs(inputs: dict, timed: _TimedRun) -> None:
+    if not timed.bound or not isinstance(timed.outputs, tuple) or len(timed.outputs) != 2:
+        raise RuntimeError("benchmark did not expose both timed GEMM outputs")
+
+    for output in timed.outputs:
+        output.fill_(float("nan"))
+    got1, got2 = timed.rerun()
+    ref1, ref2 = _timed_references(inputs)
+    tol = inputs["cfg"]["params"].get("max_relerr", 0.08)
+    err1 = _relerr(got1, ref1)
+    err2 = _relerr(got2, ref2)
+    assert err1 < tol, (inputs["cfg"]["id"], "timed_gemm1", err1, tol)
+    assert err2 < tol, (inputs["cfg"]["id"], "timed_gemm2", err2, tol)
 
 
 def _reference(inputs: dict):
@@ -415,7 +517,12 @@ def run_performance() -> None:
         inputs = _make(case)
         _run_gemms(inputs)
         torch.cuda.synchronize()
-        ms, bmeta = _benchmark_cuda_graph(lambda: _run_gemms(inputs))
+        timed = _TimedRun()
+        ms, bmeta = _benchmark_cuda_graph(
+            lambda: _run_gemms(inputs),
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
         row = {
             "test_case_id": case["id"],
             "execution_time_ms": ms,
@@ -481,11 +588,14 @@ def _run_bench(tr, warmup: int, iters: int) -> int:
         inputs = tr._make(case)
         tr._run_gemms(inputs)  # warm/JIT settle before capture
         torch.cuda.synchronize()
+        timed = tr._TimedRun()
         ms, meta = tr._benchmark_cuda_graph(
             lambda i=inputs: tr._run_gemms(i),
             warmup=max(1, warmup),
             repetition=max(1, iters),
+            timed_run=timed,
         )
+        tr._assert_timed_outputs(inputs, timed)
         means.append(ms)
         # Per-case time (forge can round-trip the case_id to --profile-case).
         print(f"case_ms: {case['id']} {ms:.6f}")

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/task_runner.py
@@ -28,7 +28,10 @@ SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
 OPERATOR = SPEC["operator"]
 CASES = SPEC["cases"]
 BLOCK_M = 64
-CORRECTNESS_MAX_TOKENS = 64  # cap T so the O(T*top_k) python reference stays cheap
+# Token count for the compile smoke test only. Correctness and performance both
+# run at the scored token count; the reference is batched per expert, so a full
+# shape stays affordable.
+COMPILE_SMOKE_MAX_TOKENS = 64
 
 
 def _configure() -> None:
@@ -136,7 +139,13 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
 # --------------------------------------------------------------------------- #
 # Build the two grouped-GEMM invocations of one MoE forward (untimed setup).
 # --------------------------------------------------------------------------- #
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+    """
     torch = _torch()
     from sglang.kernels.ops.moe.minimax_m3_swiglu import swiglu_oai_split
     from sglang.kernels.ops.moe.mxfp8_moe_amd_gfx95 import _grouped_gemm_mxfp8
@@ -149,7 +158,7 @@ def _make(case: dict, correctness: bool = False) -> dict:
     )
 
     p = case["params"]
-    T = min(p["tokens"], CORRECTNESS_MAX_TOKENS) if correctness else p["tokens"]
+    T = p["tokens"]
     H, I, E, top_k = p["hidden"], p["inter"], p["experts"], p["top_k"]
     alpha, beta, limit = p["alpha"], p["beta"], p["limit"]
     torch.manual_seed(case.get("seed", 0))
@@ -227,36 +236,77 @@ def _fused_output(inputs: dict):
 
 
 def _reference(inputs: dict):
+    """Dequantized torch reference for one MoE forward.
+
+    Iterates experts rather than (token, slot) pairs: every token routed to an
+    expert is one batched matmul instead of a Python step. The loop this replaces
+    ran T*top_k times and synchronised on ``topk_ids`` each step, which is what
+    made a full-shape correctness run impractical.
+
+    The dequantized weights stay bf16 and are cast per expert, so the reference
+    never materialises an fp32 copy of the whole expert bank.
+    """
     torch = _torch()
     from sglang.kernels.ops.quantization.mxfp8_amd_gfx95 import dequant_mxfp8_to_bf16
 
     x = dequant_mxfp8_to_bf16(inputs["a_q"], inputs["a_s"]).float()
-    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"]).float()
-    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"]).float()
+    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"])
+    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"])
     T, I, top_k = inputs["T"], inputs["I"], inputs["top_k"]
     alpha, beta, limit = inputs["alpha"], inputs["beta"], inputs["limit"]
     topk_weights, topk_ids = inputs["topk_weights"], inputs["topk_ids"]
     H = inputs["H"]
+    num_experts = w13.shape[0]
+
     out = torch.zeros(T, H, device=x.device, dtype=torch.float32)
-    for t in range(T):
-        for j in range(top_k):
-            e = int(topk_ids[t, j].item())
-            if e < 0 or e >= w13.shape[0]:
-                continue
-            g1 = x[t] @ w13[e].T
-            gate, up = g1[:I], g1[I:]
-            gate = gate.clamp(max=limit)
-            up = up.clamp(min=-limit, max=limit)
-            act = gate * torch.sigmoid(alpha * gate) * (up + beta)
-            out[t] += topk_weights[t, j].float() * (act @ w2[e].T)
+    flat_expert = topk_ids.long().reshape(-1)
+    flat_token = torch.arange(
+        T, device=x.device
+    ).unsqueeze(1).expand(T, top_k).reshape(-1)
+    flat_weight = topk_weights.float().reshape(-1)
+
+    # moe_align_block_size can emit padding slots outside the expert range.
+    keep = (flat_expert >= 0) & (flat_expert < num_experts)
+    flat_expert = flat_expert[keep]
+    flat_token = flat_token[keep]
+    flat_weight = flat_weight[keep]
+
+    order = torch.argsort(flat_expert)
+    counts = torch.bincount(flat_expert[order], minlength=num_experts)
+    offsets = torch.cumsum(counts, dim=0).tolist()
+    start = 0
+    for expert, stop in enumerate(offsets):
+        if stop == start:
+            continue
+        rows = flat_token[order[start:stop]]
+        g1 = x[rows] @ w13[expert].float().T  # [n, 2*I]
+        gate = g1[:, :I].clamp(max=limit)
+        up = g1[:, I:].clamp(min=-limit, max=limit)
+        act = gate * torch.sigmoid(alpha * gate) * (up + beta)
+        contrib = (act @ w2[expert].float().T) * flat_weight[
+            order[start:stop]
+        ].unsqueeze(-1)
+        out.index_add_(0, rows, contrib)
+        start = stop
     return out.to(torch.bfloat16)
 
 
 # --------------------------------------------------------------------------- #
 # Modes
 # --------------------------------------------------------------------------- #
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    params["tokens"] = min(params["tokens"], COMPILE_SMOKE_MAX_TOKENS)
+    return {**case, "params": params}
+
+
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(_compile_smoke_case(CASES[0]))
     _run_gemms(inputs)
     _torch().cuda.synchronize()
     print("mxfp8_grouped_gemm compile smoke: PASS")
@@ -265,7 +315,7 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _fused_output(inputs)
         torch.cuda.synchronize()
         err = _relerr(got, _reference(inputs))
@@ -275,10 +325,16 @@ def run_correctness() -> None:
 
 
 def run_performance() -> None:
+    # Sibling tasks additionally validate the timed invocation itself. That is
+    # not done here yet: `_make` freezes GEMM2's activation from a setup-time
+    # GEMM1, so inside the timed `_run_gemms` the GEMM2 result does not depend on
+    # GEMM1 at all, and the returned value cannot witness whether GEMM1 ran.
+    # Closing this needs `_run_gemms` to surface both results, which should land
+    # with a run on an sglang build that can execute the operator.
     torch = _torch()
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run_gemms(inputs)
         torch.cuda.synchronize()
         ms, bmeta = _benchmark_cuda_graph(lambda: _run_gemms(inputs))

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm/scripts/task_runner.py
@@ -78,7 +78,34 @@ def _measure_cuda_event(fn, repetition):
     return times_ms
 
 
-def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_graph_repeats=200):
+class _TimedRun:
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError("timed run was never bound")
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph(
+    fn,
+    warmup=10,
+    repetition=100,
+    target_ms=1.0,
+    max_graph_repeats=200,
+    timed_run=None,
+):
     import torch
 
     for _ in range(max(0, int(warmup))):
@@ -105,8 +132,9 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
 
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
+                captured_outputs = None
                 for _ in range(repeats):
-                    fn()
+                    captured_outputs = fn()
             torch.cuda.synchronize()
 
             times = []
@@ -121,12 +149,26 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
         if mean_ms < 1e-5:
             raise RuntimeError("empty_cuda_graph_capture")
         meta.update(benchmark_method="cuda_graph", benchmark_effective_repeats=int(repeats))
+        if timed_run is not None:
+            def _replay_once():
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
         return mean_ms, meta
     except Exception as exc:
         try:
             torch.cuda.synchronize()
         except Exception:
             pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed outputs cannot be validated "
+                "through a separate event-timed invocation"
+            ) from exc
         times = _measure_cuda_event(fn, repetition)
         meta.update(
             benchmark_method="cuda_event_fallback",
@@ -211,8 +253,9 @@ def _run_gemms(inputs: dict):
     """The timed region: the two grouped-GEMM launches of one MoE forward."""
     from sglang.kernels.ops.moe.mxfp8_moe_amd_gfx95 import _grouped_gemm_mxfp8
 
-    _grouped_gemm_mxfp8(**inputs["gemm1_args"])
-    return _grouped_gemm_mxfp8(**inputs["gemm2_args"])
+    gemm1 = _grouped_gemm_mxfp8(**inputs["gemm1_args"])
+    gemm2 = _grouped_gemm_mxfp8(**inputs["gemm2_args"])
+    return gemm1, gemm2
 
 
 def _fused_output(inputs: dict):
@@ -233,6 +276,65 @@ def _fused_output(inputs: dict):
     g2 = _grouped_gemm_mxfp8(**args)  # [M, H] fp32, top-k weighted
     T, top_k, H = inputs["T"], inputs["top_k"], inputs["H"]
     return g2.view(T, top_k, H).sum(dim=1).to(torch.bfloat16)
+
+
+def _timed_references(inputs: dict):
+    """Independent references for the two outputs produced inside the timed region."""
+    torch = _torch()
+    from sglang.kernels.ops.quantization.mxfp8_amd_gfx95 import dequant_mxfp8_to_bf16
+
+    x = dequant_mxfp8_to_bf16(inputs["a_q"], inputs["a_s"]).float()
+    act = dequant_mxfp8_to_bf16(
+        inputs["gemm2_args"]["a_q"],
+        inputs["gemm2_args"]["a_scale"],
+    ).float()
+    w13 = dequant_mxfp8_to_bf16(inputs["w13_fp8"], inputs["w13_scale"])
+    w2 = dequant_mxfp8_to_bf16(inputs["w2_fp8"], inputs["w2_scale"])
+
+    topk_ids = inputs["topk_ids"].long().reshape(-1)
+    topk_weights = inputs["topk_weights"].float().reshape(-1)
+    top_k = inputs["top_k"]
+    flat_token = torch.arange(
+        inputs["T"], device=x.device
+    ).unsqueeze(1).expand(inputs["T"], top_k).reshape(-1)
+
+    gemm1 = torch.empty(
+        topk_ids.numel(),
+        2 * inputs["I"],
+        device=x.device,
+        dtype=torch.bfloat16,
+    )
+    gemm2 = torch.empty(
+        topk_ids.numel(),
+        inputs["H"],
+        device=x.device,
+        dtype=torch.float32,
+    )
+    for expert in range(w13.shape[0]):
+        slots = torch.where(topk_ids == expert)[0]
+        if slots.numel() == 0:
+            continue
+        rows = flat_token[slots]
+        gemm1[slots] = (x[rows] @ w13[expert].float().T).to(torch.bfloat16)
+        gemm2[slots] = (
+            act[slots] @ w2[expert].float().T
+        ) * topk_weights[slots].unsqueeze(-1)
+    return gemm1, gemm2
+
+
+def _assert_timed_outputs(inputs: dict, timed: _TimedRun) -> None:
+    if not timed.bound or not isinstance(timed.outputs, tuple) or len(timed.outputs) != 2:
+        raise RuntimeError("benchmark did not expose both timed GEMM outputs")
+
+    for output in timed.outputs:
+        output.fill_(float("nan"))
+    got1, got2 = timed.rerun()
+    ref1, ref2 = _timed_references(inputs)
+    tol = inputs["cfg"]["params"].get("max_relerr", 0.08)
+    err1 = _relerr(got1, ref1)
+    err2 = _relerr(got2, ref2)
+    assert err1 < tol, (inputs["cfg"]["id"], "timed_gemm1", err1, tol)
+    assert err2 < tol, (inputs["cfg"]["id"], "timed_gemm2", err2, tol)
 
 
 def _reference(inputs: dict):
@@ -325,19 +427,18 @@ def run_correctness() -> None:
 
 
 def run_performance() -> None:
-    # Sibling tasks additionally validate the timed invocation itself. That is
-    # not done here yet: `_make` freezes GEMM2's activation from a setup-time
-    # GEMM1, so inside the timed `_run_gemms` the GEMM2 result does not depend on
-    # GEMM1 at all, and the returned value cannot witness whether GEMM1 ran.
-    # Closing this needs `_run_gemms` to surface both results, which should land
-    # with a run on an sglang build that can execute the operator.
     torch = _torch()
     rows = []
     for case in CASES:
         inputs = _make(case)
         _run_gemms(inputs)
         torch.cuda.synchronize()
-        ms, bmeta = _benchmark_cuda_graph(lambda: _run_gemms(inputs))
+        timed = _TimedRun()
+        ms, bmeta = _benchmark_cuda_graph(
+            lambda: _run_gemms(inputs),
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
         row = {
             "test_case_id": case["id"],
             "execution_time_ms": ms,

--- a/tasks/image_kernel/mi355x_sglang_triton_mxfp8_linear/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_sglang_triton_mxfp8_linear/scripts/task_runner.py
@@ -72,8 +72,55 @@ def _measure_cuda_event(fn, repetition):
     return times_ms
 
 
-def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_graph_repeats=200):
+class _TimedRun:
+    """Handle on the exact invocation the benchmark measured.
+
+    Timing and correctness are otherwise separate invocations, so a kernel can
+    tell them apart and do less work in the one that is scored. ``outputs``
+    aliases the buffers the timed unit last wrote, and ``rerun`` executes that
+    same unit again. Mirrors the shared helper in
+    src/tools/perf/vllm_cuda_graph_block.py; this task ships its own timer.
+    """
+
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError(
+                "timed run was never bound; the benchmark did not reach a "
+                "measurement path"
+            )
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph(
+    fn, warmup=10, repetition=100, target_ms=1.0, max_graph_repeats=200, timed_run=None
+):
     import torch
+
+    def _bind_direct_call():
+        # The fallback path allocates fresh outputs per call, so there is nothing
+        # to alias; the caller gets them by re-running the same unit once.
+        if timed_run is None:
+            return
+
+        def _call_once():
+            out = fn()
+            torch.cuda.synchronize()
+            return out
+
+        timed_run._bind(_call_once)
 
     for _ in range(max(0, int(warmup))):
         fn()
@@ -99,8 +146,9 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
 
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
+                captured_outputs = None
                 for _ in range(repeats):
-                    fn()
+                    captured_outputs = fn()
             torch.cuda.synchronize()
 
             times = []
@@ -115,6 +163,20 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
         if mean_ms < 1e-5:
             raise RuntimeError("empty_cuda_graph_capture")
         meta.update(benchmark_method="cuda_graph", benchmark_effective_repeats=int(repeats))
+        if timed_run is not None:
+
+            def _replay_once():
+                # Callers stage work on their own stream before re-running (they
+                # perturb inputs and poison outputs). The capture stream must be
+                # ordered after that, or the replay races the staged writes and
+                # they land on top of the kernel's results.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
         return mean_ms, meta
     except Exception as exc:
         try:
@@ -127,6 +189,7 @@ def _benchmark_cuda_graph(fn, warmup=10, repetition=100, target_ms=1.0, max_grap
             benchmark_effective_repeats=int(repetition),
             benchmark_fallback_reason=f"{type(exc).__name__}: {str(exc)[:160]}",
         )
+        _bind_direct_call()
         return sum(times) / len(times), meta
 
 
@@ -184,6 +247,48 @@ def _reference(inputs: dict):
 # --------------------------------------------------------------------------- #
 # Modes
 # --------------------------------------------------------------------------- #
+def _assert_close(case: dict, inputs: dict, got, label: str = "") -> float:
+    err = _relerr(got, _reference(inputs))
+    tol = case["params"].get("max_relerr", 0.06)
+    assert err < tol, (case["id"], label, err, tol)
+    return err
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the activation in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. The activation is re-quantized
+    the same way ``_make`` built it, so the quantized tensor and its scale stay
+    consistent; the weight stays fixed.
+    """
+    torch = _torch()
+    from sglang.kernels.ops.quantization.mxfp8_amd_gfx95 import mxfp8_e4m3_quantize
+
+    p = inputs["cfg"]["params"]
+    torch.manual_seed(59)
+    x_bf16 = torch.randn(p["m"], p["k"], device="cuda", dtype=torch.bfloat16) * 0.5
+    x_fp8, x_scale = mxfp8_e4m3_quantize(x_bf16)
+    inputs["x_fp8"].copy_(x_fp8)
+    inputs["x_scale"].copy_(x_scale)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against a freshly perturbed
+    activation and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(case, inputs, timed.rerun(), label="timed run")
+
+
 def run_compile() -> None:
     inputs = _make(CASES[0])
     _run(inputs)
@@ -197,9 +302,7 @@ def run_correctness() -> None:
         inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
-        err = _relerr(got, _reference(inputs))
-        tol = case["params"].get("max_relerr", 0.06)
-        assert err < tol, (case["id"], err, tol)
+        err = _assert_close(case, inputs, got)
         print("correctness PASS", case["id"], f"relerr={err:.4f}")
 
 
@@ -210,7 +313,9 @@ def run_performance() -> None:
         inputs = _make(case)
         _run(inputs)
         torch.cuda.synchronize()
-        ms, bmeta = _benchmark_cuda_graph(lambda: _run(inputs))
+        timed = _TimedRun()
+        ms, bmeta = _benchmark_cuda_graph(lambda: _run(inputs), timed_run=timed)
+        _assert_timed_outputs(case, inputs, timed)
         row = {
             "test_case_id": case["id"],
             "execution_time_ms": ms,

--- a/tasks/image_kernel/mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3/scripts/task_runner.py
@@ -453,24 +453,72 @@ def run_correctness() -> None:
             assert tuple(got.shape) == tuple(expected.shape), (
                 case["id"], tuple(got.shape), tuple(expected.shape)
             )
-            g, e = got.float().flatten(), expected.float().flatten()
-            worst_cos = min(
-                worst_cos, torch.nn.functional.cosine_similarity(g, e, dim=0).item()
-            )
-            worst_err = max(worst_err, ((g - e).norm() / e.norm().clamp_min(1e-8)).item())
+            cos, err = _moe_deviation(got, expected)
+            worst_cos = min(worst_cos, cos)
+            worst_err = max(worst_err, err)
 
-        assert worst_cos > tol.get("min_cosine", 0.97), (
-            case["id"], f"worst-of-{_CORRECTNESS_REPEATS} cosine {worst_cos:.6f} "
-            f"vs torch reference too low"
-        )
-        assert worst_err < tol.get("max_rel_norm_err", 0.25), (
-            case["id"], f"worst-of-{_CORRECTNESS_REPEATS} relative norm error "
-            f"{worst_err:.4f} too high"
+        _assert_moe_within_tolerance(
+            case, worst_cos, worst_err, f"worst-of-{_CORRECTNESS_REPEATS}"
         )
         print(f"correctness PASS {case['id']:34s} token={token_used:<6d} "
               f"cos={worst_cos:.6f} rel_err={worst_err:.4f}")
-        del inputs, expected, got, g, e
+        del inputs, expected, got
         _free()
+
+
+def _moe_deviation(got, expected):
+    torch = _torch()
+    g, e = got.float().flatten(), expected.float().flatten()
+    cos = torch.nn.functional.cosine_similarity(g, e, dim=0).item()
+    err = ((g - e).norm() / e.norm().clamp_min(1e-8)).item()
+    return cos, err
+
+
+def _assert_moe_within_tolerance(case: dict, cos: float, err: float, label: str) -> None:
+    tol = case["params"]
+    assert cos > tol.get("min_cosine", 0.97), (
+        case["id"], f"{label} cosine {cos:.6f} vs torch reference too low"
+    )
+    assert err < tol.get("max_rel_norm_err", 0.25), (
+        case["id"], f"{label} relative norm error {err:.4f} too high"
+    )
+
+
+def _perturb_moe_inputs(inputs: dict) -> None:
+    """Refresh the activation in place with values no earlier launch has seen.
+
+    Only ``hidden`` is redrawn. The routing tensors are kernel inputs rather than
+    something the kernel derives, so leaving them fixed keeps the kernel and the
+    reference describing the same workload; the quantized weights have shuffled
+    runtime copies that would have to be rebuilt in lockstep, which buys nothing
+    here.
+    """
+    torch = _torch()
+    torch.manual_seed(43)
+    inputs["hidden"].normal_(0.0, 0.1)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against a freshly perturbed
+    activation and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    torch = _torch()
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+
+    _perturb_moe_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    got = timed.rerun()
+    expected = _reference(inputs)
+    assert torch.isfinite(got).all(), (case["id"], "timed run produced non-finite output")
+    cos, err = _moe_deviation(got, expected)
+    _assert_moe_within_tolerance(case, cos, err, "timed run")
+    del expected
 
 
 def run_performance() -> None:
@@ -486,13 +534,16 @@ def run_performance() -> None:
         kn1, kn2, blob = _dispatch_names(inputs)
         _assert_tuned_dispatch(case["id"], kn1, kn2, blob)
         bench = case.get("benchmark", {})
+        timed = _TimedRun()
         exec_ms, meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=bench.get("warmup", 3),
             repetition=bench.get("repetition", 20),
             target_ms=bench.get("target_ms", 1.0),
             max_graph_repeats=bench.get("max_graph_repeats", 100),
+            timed_run=timed,
         )
+        _assert_timed_outputs(case, inputs, timed)
         metadata = {
             **case["params"],
             "model": case.get("model"),

--- a/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/forge_driver.py
@@ -17,7 +17,7 @@ entirely and no per-run driver authoring can fail.
 How it satisfies the contract without per-kernel reimplementation
 -----------------------------------------------------------------
 Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
-canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
 / ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
 writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
 ``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
@@ -45,7 +45,7 @@ kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
         real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
 
   * Profiling    ``--profile-run``
-        builds ONE case's inputs (``_make(case, correctness=False)``) and launches
+        builds ONE case's inputs (``_make(case)``) and launches
         ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
         couple of profiled launches, one synchronize, exit 0. No timing printed.
 
@@ -150,7 +150,7 @@ def _pick_profile_case(tr) -> dict:
 def _run_profile(tr) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/standalone_driver.py
@@ -387,7 +387,7 @@ def _run_quant_correctness(inputs: dict) -> None:
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -396,7 +396,7 @@ def run_compile() -> None:
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
@@ -437,7 +437,7 @@ def run_performance() -> None:
     _write_report(rows)
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
     return _make_quant(case)
 
 
@@ -447,7 +447,7 @@ def _run(inputs: dict):
 
 def run_correctness() -> None:
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         _run_quant_correctness(inputs)
         print("correctness PASS", case["id"])
 
@@ -521,7 +521,7 @@ def _pick_profile_case(tr, case_id: str) -> dict:
 def _run_profile(tr, case_id: str) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr, case_id)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/task_runner.py
@@ -13,10 +13,44 @@ OPERATOR = SPEC["operator"]
 CASES = SPEC["cases"]
 
 
+def _sources_edited() -> bool:
+    """True unless every editable source still matches its in-image original.
+
+    Fails safe: anything we cannot positively verify counts as edited. Serving a
+    prebuilt .so for an edited kernel would silently benchmark the ORIGINAL, so
+    a false "unedited" is far worse than a redundant rebuild.
+    """
+    try:
+        import yaml
+
+        cfg = yaml.safe_load((WORKSPACE / "config.yaml").read_text()) or {}
+        image_root = Path(str(cfg["image_repo_path"]))
+        repo_subdir = str(cfg.get("repo_subdir") or "")
+        sources = cfg["source_file_path"] or []
+        if isinstance(sources, str):
+            sources = [sources]
+        if not sources or not image_root.is_dir():
+            return True
+        for rel in sources:
+            ours = WORKSPACE / repo_subdir / str(rel)
+            if ours.read_bytes() != (image_root / str(rel)).read_bytes():
+                return True
+        return False
+    except Exception:  # noqa: BLE001 - unverifiable means "assume edited"
+        return True
+
+
 def _configure() -> None:
     for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
         os.environ.setdefault(key, "gfx950")
-    os.environ.setdefault("AITER_REBUILD", "2")  # incremental ninja rebuild: keep object cache, recompile only edited sources (avoids full CK re-compile on every agent edit)
+    # Incremental ninja rebuild: keep the object cache, recompile only edited
+    # sources. Only force it once something has actually been edited -- aiter
+    # treats any non-zero AITER_REBUILD as "rebuild this module on first use"
+    # without checking the source, and the profiler re-spawns this driver once
+    # per counter pass, so an unedited baseline would re-enter the rebuild path
+    # hundreds of times for a kernel that never changed.
+    if _sources_edited():
+        os.environ.setdefault("AITER_REBUILD", "2")
     os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "jit"))
     if (WORKSPACE / "aiter_meta").is_dir():
         os.environ["AITER_META_DIR"] = str(WORKSPACE / "aiter_meta")

--- a/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant/scripts/task_runner.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
-import math
 import os
 import sys
 from pathlib import Path
@@ -101,170 +99,6 @@ def _import_aiter():
     return aiter
 
 
-def _make_attention(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
-    num_seqs = params["q_tokens"]
-    num_q_heads = params["num_q_heads"]
-    num_kv_heads = params["num_kv_heads"]
-    head_size = params["head_size"]
-    block_size = params["block_size"]
-    pages_per_seq = (ctx_len + block_size - 1) // block_size
-    num_blocks = num_seqs * pages_per_seq
-
-    torch.manual_seed(7)
-    query = torch.randn(
-        (num_seqs, num_q_heads, head_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    kv = torch.randn(
-        (num_blocks, block_size, num_kv_heads, head_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    if params["kv_dtype"] == "fp8":
-        key = kv.to(torch.float8_e4m3fn)
-        value = (kv * 0.7).to(torch.float8_e4m3fn)
-    else:
-        key = kv
-        value = kv * 0.7
-
-    output = torch.empty_like(query)
-    cu_seqlens_q = torch.arange(num_seqs + 1, device="cuda", dtype=torch.int32)
-    seqused_k = torch.full(
-        (num_seqs,), ctx_len, device="cuda", dtype=torch.int32
-    )
-    block_table = torch.arange(
-        num_blocks, device="cuda", dtype=torch.int32
-    ).view(num_seqs, pages_per_seq)
-    one = torch.ones(1, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "query": query,
-        "key": key,
-        "value": value,
-        "output": output,
-        "cu_seqlens_q": cu_seqlens_q,
-        "seqused_k": seqused_k,
-        "block_table": block_table,
-        "ctx_len": ctx_len,
-        "scale": head_size**-0.5,
-        "one": one,
-    }
-
-
-def _run_attention(inputs: dict):
-    from aiter.ops.triton.attention.unified_attention import unified_attention
-
-    unified_attention(
-        inputs["query"],
-        inputs["key"],
-        inputs["value"],
-        inputs["output"],
-        inputs["cu_seqlens_q"],
-        1,
-        inputs["seqused_k"],
-        inputs["ctx_len"],
-        inputs["scale"],
-        True,
-        (-1, -1),
-        inputs["block_table"],
-        0.0,
-        inputs["one"],
-        inputs["one"],
-        inputs["one"],
-    )
-    return inputs["output"]
-
-
-def _attention_reference(inputs: dict):
-    torch = _torch()
-    query = inputs["query"].float()
-    key = inputs["key"].float()
-    value = inputs["value"].float()
-    outputs = []
-    for seq_idx in range(query.shape[0]):
-        block_ids = inputs["block_table"][seq_idx]
-        key_seq = key[block_ids].reshape(-1, key.shape[2], key.shape[3])
-        value_seq = value[block_ids].reshape(-1, value.shape[2], value.shape[3])
-        key_seq = key_seq[: inputs["ctx_len"]]
-        value_seq = value_seq[: inputs["ctx_len"]]
-        ratio = query.shape[1] // key_seq.shape[1]
-        key_seq = key_seq.repeat_interleave(ratio, dim=1)
-        value_seq = value_seq.repeat_interleave(ratio, dim=1)
-        scores = (
-            torch.einsum("hd,khd->hk", query[seq_idx], key_seq)
-            * inputs["scale"]
-        )
-        probs = torch.softmax(scores, dim=-1)
-        outputs.append(torch.einsum("hk,khd->hd", probs, value_seq))
-    return torch.stack(outputs).to(inputs["output"].dtype)
-
-
-def _make_gemm(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    m = min(params["m"], 64) if correctness else params["m"]
-    n = params["n"]
-    k = params["k"]
-    torch.manual_seed(9)
-    x = (torch.rand((m, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    weight = (torch.rand((n, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    x_scale = (
-        torch.rand((m, k // 128), device="cuda", dtype=torch.float32) * 0.1
-        + 0.01
-    )
-    w_scale = (
-        torch.rand(
-            (math.ceil(n / 128), k // 128),
-            device="cuda",
-            dtype=torch.float32,
-        )
-        * 0.1
-        + 0.01
-    )
-    return {
-        "cfg": case,
-        "x": x,
-        "weight": weight,
-        "x_scale": x_scale,
-        "w_scale": w_scale,
-        "shape": [m, n, k],
-    }
-
-
-def _run_gemm(inputs: dict):
-    return _import_aiter().gemm_a8w8_blockscale(
-        inputs["x"],
-        inputs["weight"],
-        inputs["x_scale"],
-        inputs["w_scale"],
-        _torch().bfloat16,
-    )
-
-
-def _gemm_reference(inputs: dict):
-    torch = _torch()
-    m, n, k = inputs["shape"]
-    x = (
-        inputs["x"].float()
-        * inputs["x_scale"].repeat_interleave(128, dim=1)[:, :k]
-    )
-    weight = (
-        inputs["weight"].float()
-        * inputs["w_scale"]
-        .repeat_interleave(128, dim=0)
-        .repeat_interleave(128, dim=1)[:n, :k]
-    )
-    return (x @ weight.t()).to(torch.bfloat16)
-
-
 def _make_quant(case: dict) -> dict:
     torch = _torch()
     torch.manual_seed(11)
@@ -324,534 +158,95 @@ def _run_quant_correctness(inputs: dict) -> None:
     _assert_quant_correct(inputs, got)
 
 
-def _load_mhc_module():
-    # Import the installed package first so its custom ops are registered once.
-    # Then suppress registration while loading the editable workspace copy;
-    # otherwise both copies call direct_register_custom_op with the same names.
-    import vllm.model_executor.kernels.mhc.tilelang_kernels  # noqa: F401
-    import vllm.utils.torch_utils as torch_utils
+def _perturb_quant_inputs(inputs: dict) -> None:
+    """Refresh the input in place with values no earlier launch has seen.
 
-    path = WORKSPACE / "mhc" / "tilelang.py"
-    spec = importlib.util.spec_from_file_location("ka_mhc_tilelang", path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    original_register = torch_utils.direct_register_custom_op
-    torch_utils.direct_register_custom_op = lambda *args, **kwargs: None
-    try:
-        spec.loader.exec_module(module)
-    finally:
-        torch_utils.direct_register_custom_op = original_register
-    return module
-
-
-def _make_mhc(case: dict, correctness: bool = False) -> dict:
+    A replayed CUDA graph reads the captured input address, so writing through it
+    changes what the scored kernel consumes. ``_run_quant_correctness`` leaves the
+    input scaled down by eps, so this also restores a normal magnitude.
+    """
     torch = _torch()
-    params = dict(case["params"])
-    tokens = min(params["tokens"], 64) if correctness else params["tokens"]
-    hidden_size = params["hidden_size"]
-    hc_mult = params["hc_mult"]
-    torch.manual_seed(13)
-    x = torch.randn(
-        (tokens, hidden_size), device="cuda", dtype=torch.bfloat16
-    )
-    residual = torch.randn(
-        (tokens, hc_mult, hidden_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    post_mix = torch.randn(
-        (tokens, hc_mult, 1), device="cuda", dtype=torch.float32
-    )
-    comb_mix = torch.softmax(
-        torch.randn(
-            (tokens, hc_mult, hc_mult),
-            device="cuda",
-            dtype=torch.float32,
-        ),
-        dim=-1,
-    )
-    hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
-    fn = (
-        torch.randn(
-            (hc_mult3, hc_mult * hidden_size),
-            device="cuda",
-            dtype=torch.float32,
-        )
-        * 0.001
-    )
-    hc_scale = torch.ones(3, device="cuda", dtype=torch.float32)
-    hc_base = torch.zeros(hc_mult3, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "params": params,
-        "x": x,
-        "residual": residual,
-        "post_mix": post_mix,
-        "comb_mix": comb_mix,
-        "fn": fn,
-        "hc_scale": hc_scale,
-        "hc_base": hc_base,
-        "module": _load_mhc_module(),
-    }
+    torch.manual_seed(31)
+    inputs["input"].normal_()
 
 
-def _run_mhc(inputs: dict):
-    params = inputs["params"]
-    return inputs["module"].mhc_fused_post_pre_tilelang(
-        inputs["x"],
-        inputs["residual"],
-        inputs["post_mix"],
-        inputs["comb_mix"],
-        inputs["fn"],
-        inputs["hc_scale"],
-        inputs["hc_base"],
-        params["rms_eps"],
-        params["hc_pre_eps"],
-        params["hc_sinkhorn_eps"],
-        params["hc_post_mult"],
-        params["sinkhorn_repeat"],
-        1,
-        1,
-        None,
-        0.0,
-    )
+def _assert_operator() -> None:
+    """Guard against this runner being pointed at a different operator.
+
+    The file was specialized to ``dynamic_per_tensor_quant``; the other builders, callers and
+    references from the shared template are gone. Failing loudly beats silently
+    running the wrong workload.
+    """
+    if OPERATOR != "dynamic_per_tensor_quant":
+        raise KeyError(f"{OPERATOR}: this runner only implements dynamic_per_tensor_quant")
 
 
-def _mhc_reference(inputs: dict):
-    from vllm.model_executor.kernels.mhc.torch import mhc_post_torch, mhc_pre_torch
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
 
-    params = inputs["params"]
-    residual = mhc_post_torch(
-        inputs["x"],
-        inputs["residual"],
-        inputs["post_mix"],
-        inputs["comb_mix"],
-    )
-    post_mix, comb_mix, layer_input = mhc_pre_torch(
-        residual,
-        inputs["fn"],
-        inputs["hc_scale"],
-        inputs["hc_base"],
-        params["rms_eps"],
-        params["hc_pre_eps"],
-        params["hc_sinkhorn_eps"],
-        params["hc_post_mult"],
-        params["sinkhorn_repeat"],
-    )
-    return residual, post_mix, comb_mix, layer_input
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+
+    Kept as the entry point the task drivers call, alongside :func:`_run`.
+    """
+    _assert_operator()
+    return _make_quant(case)
 
 
-def _make_mla(case: dict, correctness: bool = False) -> dict:
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against a freshly perturbed
+    input and checks the buffers it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
     torch = _torch()
-    params = dict(case["params"])
-    batch = min(params["batch"], 64) if correctness else params["batch"]
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
-    capacity = (
-        min(params["kv_capacity"], batch * ctx_len + 1024)
-        if correctness
-        else params["kv_capacity"]
-    )
-    torch.manual_seed(17)
-    query = torch.randn(
-        (batch, params["num_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    kv = torch.randn(
-        (capacity, params["page_size"], params["kv_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    output = torch.empty(
-        (batch, params["num_heads"], params["v_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    qo_indptr = torch.arange(batch + 1, device="cuda", dtype=torch.int32)
-    kv_indptr = torch.arange(
-        0, (batch + 1) * ctx_len, ctx_len, device="cuda", dtype=torch.int32
-    )
-    kv_indices = (
-        torch.arange(batch * ctx_len, device="cuda", dtype=torch.int32)
-        % capacity
-    )
-    last_page_lens = torch.ones(batch, device="cuda", dtype=torch.int32)
-    return {
-        "cfg": case,
-        "params": params,
-        "query": query,
-        "kv": kv,
-        "output": output,
-        "qo_indptr": qo_indptr,
-        "kv_indptr": kv_indptr,
-        "kv_indices": kv_indices,
-        "last_page_lens": last_page_lens,
-        "ctx_len": ctx_len,
-    }
-
-
-def _run_mla(inputs: dict):
-    params = inputs["params"]
-    return _import_aiter().mla.mla_decode_fwd(
-        inputs["query"],
-        inputs["kv"],
-        inputs["output"],
-        inputs["qo_indptr"],
-        inputs["kv_indptr"],
-        inputs["kv_indices"],
-        inputs["last_page_lens"],
-        1,
-        params["page_size"],
-        params["kv_heads"],
-        params["qk_dim"] ** -0.5,
-        num_kv_splits=None,
-        return_lse=False,
-    )
-
-
-def _mla_reference(inputs: dict):
-    torch = _torch()
-    query = inputs["query"].float()
-    outputs = []
-    for seq_idx in range(query.shape[0]):
-        start = seq_idx * inputs["ctx_len"]
-        end = (seq_idx + 1) * inputs["ctx_len"]
-        indices = inputs["kv_indices"][start:end]
-        kv = inputs["kv"][indices].reshape(
-            -1,
-            inputs["params"]["kv_heads"],
-            inputs["params"]["qk_dim"],
-        )
-        key = kv
-        value = kv[..., : inputs["params"]["v_dim"]]
-        ratio = query.shape[1] // key.shape[1]
-        key = key.repeat_interleave(ratio, dim=1)
-        value = value.repeat_interleave(ratio, dim=1)
-        scores = (
-            torch.einsum("hd,khd->hk", query[seq_idx], key.float())
-            * (inputs["params"]["qk_dim"] ** -0.5)
-        )
-        probs = torch.softmax(scores, dim=-1)
-        outputs.append(torch.einsum("hk,khd->hd", probs, value.float()))
-    return torch.stack(outputs).to(inputs["output"].dtype)
-
-
-def _moe_enums(params: dict, aiter):
-    quant_type = {
-        "per_Tensor": aiter.QuantType.per_Tensor,
-        "per_1x128": aiter.QuantType.per_1x128,
-        "per_1x32": aiter.QuantType.per_1x32,
-    }[params["quant_type"]]
-    activation = {
-        "silu": aiter.ActivationType.Silu,
-        "swiglu": aiter.ActivationType.Swiglu,
-    }[params["activation"]]
-    return quant_type, activation
-
-
-def _prepare_moe(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import fused_topk
-    from aiter.ops.shuffle import (
-        shuffle_scale_a16w4,
-        shuffle_weight,
-        shuffle_weight_a16w4,
-    )
-    from aiter.utility import fp4_utils
-
-    params = dict(case["params"])
-    token = min(params["token"], 64) if correctness else params["token"]
-    experts = params["experts"]
-    model_dim = params["model_dim"]
-    inter_dim = params["inter_dim"]
-    topk = params["topk"]
-    quant_type, activation = _moe_enums(params, aiter)
-    activation_dtype = {
-        "fp8": dtypes.fp8,
-        "fp4": dtypes.fp4x2,
-        "bf16": dtypes.bf16,
-    }[params["a_dtype"]]
-    weight_dtype = {"fp8": dtypes.fp8, "fp4": dtypes.fp4x2}[
-        params["w_dtype"]
-    ]
-
-    torch.manual_seed(19)
-    hidden = (
-        torch.randn(
-            (token, model_dim), device="cuda", dtype=dtypes.bf16
-        )
-        * 0.1
-    )
-    w1 = (
-        torch.randn(
-            (experts, inter_dim * 2, model_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    w2 = (
-        torch.randn(
-            (experts, model_dim, inter_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    score = torch.randn((token, experts), device="cuda", dtype=dtypes.bf16)
-    topk_weights, topk_ids = fused_topk(hidden, score, topk, True)
-    torch_quant = aiter.get_torch_quant(quant_type)
-
-    if quant_type == aiter.QuantType.per_Tensor:
-        w1_quant, w1_scale = aiter.pertoken_quant(
-            w1.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w2_quant, w2_scale = aiter.pertoken_quant(
-            w2.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w1_quant = w1_quant.view(w1.shape)
-        w2_quant = w2_quant.view(w2.shape)
-    else:
-        w1_quant, w1_scale = torch_quant(w1, quant_dtype=weight_dtype)
-        w2_quant, w2_scale = torch_quant(w2, quant_dtype=weight_dtype)
-
-    if quant_type == aiter.QuantType.per_1x32:
-        w1_quant = w1_quant.view(
-            experts, w1.shape[1], w1.shape[2] // 2
-        )
-        w2_quant = w2_quant.view(
-            experts, w2.shape[1], w2.shape[2] // 2
-        )
-
-    w1_reference = w1_quant
-    w2_reference = w2_quant
-    if (
-        quant_type == aiter.QuantType.per_1x32
-        and activation_dtype in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and weight_dtype == dtypes.fp4x2
-    ):
-        w1_runtime = shuffle_weight_a16w4(w1_quant, 16, True)
-        w1_scale_runtime = shuffle_scale_a16w4(
-            w1_scale, experts, True
-        )
-        w2_runtime = shuffle_weight_a16w4(w2_quant, 16, False)
-        w2_scale_runtime = shuffle_scale_a16w4(
-            w2_scale, experts, False
-        )
-    else:
-        w1_runtime = shuffle_weight(w1_quant, layout=(16, 16))
-        w2_runtime = shuffle_weight(w2_quant, layout=(16, 16))
-        w1_scale_runtime = fp4_utils.e8m0_shuffle(w1_scale)
-        w2_scale_runtime = fp4_utils.e8m0_shuffle(w2_scale)
-
-    return {
-        "cfg": case,
-        "params": params,
-        "hidden": hidden,
-        "w1": w1_runtime,
-        "w2": w2_runtime,
-        "w1_reference": w1_reference,
-        "w2_reference": w2_reference,
-        "w1_scale": w1_scale,
-        "w2_scale": w2_scale,
-        "w1_scale_runtime": w1_scale_runtime,
-        "w2_scale_runtime": w2_scale_runtime,
-        "topk_weights": topk_weights,
-        "topk_ids": topk_ids,
-        "quant_type": quant_type,
-        "activation": activation,
-        "activation_dtype": activation_dtype,
-        "weight_dtype": weight_dtype,
-    }
-
-
-def _run_moe(inputs: dict):
-    from aiter.fused_moe import fused_moe
-
-    return fused_moe(
-        inputs["hidden"],
-        inputs["w1"],
-        inputs["w2"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        w1_scale=inputs["w1_scale_runtime"],
-        w2_scale=inputs["w2_scale_runtime"],
-        quant_type=inputs["quant_type"],
-        activation=inputs["activation"],
-        dtype=_torch().bfloat16,
-    )
-
-
-def _moe_reference(inputs: dict):
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import torch_moe_stage1, torch_moe_stage2
-
-    torch_quant = aiter.get_torch_quant(inputs["quant_type"])
-    params = inputs["params"]
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"].view(inputs["hidden"].shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a1_quant = a1_quant.view(inputs["hidden"].shape)
-        a1_scale = a1_scale.squeeze(-1)
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a1_quant = inputs["hidden"].to(inputs["activation_dtype"])
-        a1_scale = None
-    else:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"], quant_dtype=inputs["activation_dtype"]
-        )
-
-    stage1 = torch_moe_stage1(
-        a1_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        activation=inputs["activation"],
-        quant_type=inputs["quant_type"],
-        a1_scale=a1_scale,
-        w1_scale=inputs["w1_scale"],
-    )
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a2_quant, a2_scale = torch_quant(
-            stage1.view(stage1.shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a2_scale = a2_scale.view(
-            stage1.shape[0], params["topk"], -1
-        )
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a2_quant = stage1
-        a2_scale = None
-    else:
-        a2_quant, a2_scale = torch_quant(
-            stage1, quant_dtype=inputs["activation_dtype"]
-        )
-    a2_quant = a2_quant.view(stage1.shape[0], params["topk"], -1)
-    return torch_moe_stage2(
-        a2_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        quant_type=inputs["quant_type"],
-        w2_scale=inputs["w2_scale"],
-        a2_scale=a2_scale,
-    )
-
-
-def _make(case: dict, correctness: bool = False) -> dict:
-    if OPERATOR == "unified_attention":
-        return _make_attention(case, correctness)
-    if OPERATOR == "a8w8_blockscale_gemm":
-        return _make_gemm(case, correctness)
-    if OPERATOR == "dynamic_per_tensor_quant":
-        return _make_quant(case)
-    if OPERATOR == "mhc_fused_post_pre":
-        return _make_mhc(case, correctness)
-    if OPERATOR == "mla_decode":
-        return _make_mla(case, correctness)
-    if OPERATOR in ("ck_moe_2stage", "cktile_moe_2stage"):
-        return _prepare_moe(case, correctness)
-    raise KeyError(OPERATOR)
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_quant_inputs(inputs)
+    # Both outputs are harness-owned, so poison them directly rather than going
+    # through the timed handle. A kernel that skips either one keeps the poison.
+    inputs["scale"].fill_(torch.finfo(inputs["scale"].dtype).max)
+    inputs["output"].fill_(torch.finfo(torch.float8_e4m3fn).max)
+    _assert_quant_correct(inputs, timed.rerun())
 
 
 def _run(inputs: dict):
-    return {
-        "unified_attention": _run_attention,
-        "a8w8_blockscale_gemm": _run_gemm,
-        "dynamic_per_tensor_quant": _run_quant,
-        "mhc_fused_post_pre": _run_mhc,
-        "mla_decode": _run_mla,
-        "ck_moe_2stage": _run_moe,
-        "cktile_moe_2stage": _run_moe,
-    }[OPERATOR](inputs)
+    _assert_operator()
+    return _run_quant(inputs)
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
 
 
 def run_correctness() -> None:
-    torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
-        if OPERATOR == "dynamic_per_tensor_quant":
-            _run_quant_correctness(inputs)
-            print("correctness PASS", case["id"])
-            continue
-
-        got = _run(inputs)
-        torch.cuda.synchronize()
-        if OPERATOR == "unified_attention":
-            torch.testing.assert_close(
-                got, _attention_reference(inputs), atol=0.08, rtol=0.08
-            )
-        elif OPERATOR == "a8w8_blockscale_gemm":
-            torch.testing.assert_close(
-                got, _gemm_reference(inputs), atol=0.15, rtol=0.12
-            )
-        elif OPERATOR == "mhc_fused_post_pre":
-            for actual, expected in zip(got, _mhc_reference(inputs)):
-                torch.testing.assert_close(
-                    actual, expected, atol=0.08, rtol=0.08
-                )
-        elif OPERATOR == "mla_decode":
-            torch.testing.assert_close(
-                inputs["output"],
-                _mla_reference(inputs),
-                atol=0.08,
-                rtol=0.08,
-            )
-        else:
-            expected = _moe_reference(inputs)
-            cosine_error = 1 - torch.nn.functional.cosine_similarity(
-                got.float().flatten(),
-                expected.float().flatten(),
-                dim=0,
-            )
-            assert torch.isfinite(got).all()
-            assert float(cosine_error) < 0.03, (
-                case["id"],
-                float(cosine_error),
-            )
+        _run_quant_correctness(_make(case))
         print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=3,
             repetition=20,
             target_ms=1.0,
             max_graph_repeats=100,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case["model"],

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/README.md
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/README.md
@@ -1,0 +1,115 @@
+# mi355x-rocm-paged-attention-decode-20260801
+
+Image_kernel harness for the ROCm custom paged-attention decode pair
+`paged_attention_ll4mi_QKV_mfma16_kernel` (per-partition attention) and
+`paged_attention_ll4mi_reduce_kernel` (cross-partition softmax reduction), reached
+through `aiter.paged_attention_rocm`.
+
+This operator is the largest decode leaf in four MI355X Hyperloom 2026-08-01
+sessions:
+
+| Model | GQA | Q/KV heads | Session GPU share | Session MFMA variant |
+| --- | --- | --- | --- | --- |
+| Llama-3.1-8B-Instruct | 4:1 | 32 / 8 | 26.85% | MFMA4 |
+| Qwen3-8B | 4:1 | 32 / 8 | 25.041% | MFMA4 |
+| Qwen3-0.6B | 2:1 | 16 / 8 | 35.778% | MFMA4 |
+| Qwen3-14B-FP8 | 5:1 | 40 / 8 | 10.544% | MFMA16 |
+
+## Workload
+
+All four sessions ran the same harness — TP=1, EP=1, concurrency 64, ISL=1024,
+OSL=1024, `max_model_len=6144` — so the only thing that varies across models is
+the head geometry. Every session reported `kv_cache_dtype=auto`, i.e. BF16
+Q / KV cache / output, cross-checked against each kernel's own
+`(vllm::Fp8KVCacheDataType)0 = kAuto` template argument. Qwen3-14B-FP8 quantizes
+weights, not the KV cache. Head counts were read from each model's `config.json`
+and cross-checked against the `GQA_RATIO` template argument in each trace.
+
+Seven cases cover the three distinct geometries at `head_size=128`,
+`block_size=16`, 64 decode sequences and 1024–2048 tokens of KV context. The
+primary model is sampled at three context lengths to expose the memory-bound
+scaling; the coverage models are sampled at the two endpoints of their decode
+regime. `num_seqs` and `ctx_len` are reconstructed from that decode regime: the
+graph-captured decode launches carry no recorded tensor shapes in the trace.
+
+Qwen3-8B gets no dedicated cases: its geometry, dtypes and workload are identical
+to Llama-3.1-8B-Instruct, so the `llama3_1-8b-*` cases already cover it exactly
+and duplicate ids would only double suite runtime.
+
+Correctness and performance sweep all seven cases. Profiling is a single-shape
+probe pinned to `llama3_1-8b-decode-m64-ctx1024` via `profile_case` in
+`session_cases.json` (surfaced as `PROFILE_CASE_ID` / `profile_case()` in the task
+runner) — GQA 4:1 at `head_size=128` is the most common decode geometry here, and
+pinning keeps the profiled kernel from drifting with measurement noise.
+
+## Which kernel this measures
+
+Three of the four sessions ran **vLLM's** MFMA4 variant from
+`csrc/rocm/attention.cu`, selected because `gqa_ratio <= 4`. This task measures
+**AITER's** MFMA16 implementation of the same logical operator at each session's
+exact shapes and dtypes. Only the Qwen3-14B-FP8 cases (GQA 5:1) match the
+session's MFMA variant as well.
+
+The reason is that the runtime image ships no vLLM C++ source: vLLM is a
+wheel-only install and `/app/vllm` contains only `benchmarks/`, `docker/` and
+`examples/`, so there is nothing to seed and edit. AITER ships the same
+`paged_attention_ll4mi` family with full source, but dispatches MFMA16 for every
+GQA ratio — the MFMA4 launches are commented out in both
+`csrc/kernels/attention.cu` and `csrc/cpp_itfs/pa/pa.cpp.jinja`. Confirmed by
+symbol inspection: `mfma4` exists only in `vllm/_rocm_C.abi3.so`, while
+`aiter/jit/module_pa*.so` carry `mfma16` only.
+
+Treat wins here as transferable to the same operator, not as a direct measurement
+of the MFMA4 leaf kernel three of these sessions executed.
+
+## Editable surface and JIT
+
+`aiter.paged_attention_rocm` goes through `csrc/cpp_itfs/pa/pa.py`, which renders
+`pa.cpp.jinja` and compiles it per specialization via `compile_template_op`. The
+four files listed in `config.yaml` (`pa_kernels.cuh`, `pa.cuh`, `pa_common.cuh`,
+`pa.cpp.jinja`) are the editable device-code surface.
+
+`compile_template_op` caches purely by template arguments, so an edited kernel
+would otherwise keep serving a stale `lib.so`. Two things prevent that:
+
+- `AITER_REBUILD=1` clears the template-op build cache at import.
+  AgentKernelArena injects it per build subprocess (`src/jit_rebuild.py`); the
+  task runner also sets it by default so standalone runs stay honest.
+- `AITER_META_DIR` points the importable `csrc` package — and therefore
+  `AITER_CORE_DIR`, the jinja template and every include — at the workspace copy.
+  `_import_aiter()` asserts this resolved to the seeded tree and fails loudly
+  rather than silently measuring the in-image source.
+
+The cache key includes `gqa_ratio`, so the suite builds three specializations
+(GQA 2 / 4 / 5) at roughly 15 s each. All cases give
+`npar_loops = ceil(ceil(ctx_len/256) / 64) = 1`, matching the sessions'
+`paged_attention_ll4mi_reduce_kernel<..., 128, 128, 256, 1>`. Profiling builds
+only the one pinned specialization.
+
+## Verified locally
+
+Workspace materialized through `src.preprocessing.setup_workspace` on
+MI355X/gfx950:
+
+```text
+compile      paged_attention_rocm compile smoke: PASS
+correctness  PASS x7
+performance  llama3_1-8b   ctx1024/1536/2048  0.055 / 0.076 / 0.128 ms
+             qwen3-0_6b    ctx1024/2048       0.055 / 0.125 ms
+             qwen3-14b-fp8 ctx1024/2048       0.057 / 0.130 ms
+             benchmark_method=cuda_graph on every case
+forge_driver --bench-mode  7x case_ms + mean_ms: 0.089140
+forge_driver --profile-run exit 0, single specialization built
+```
+
+Edit propagation was checked end to end by scaling the reduce kernel's output by
+2 in `pa_kernels.cuh`: correctness flipped to `allclose: False` and back to
+`allclose: True` after restoring the file. The profile pin was checked against a
+performance report whose slowest case was `qwen3-14b-fp8-decode-m64-ctx2048`; the
+driver still selected the pinned Llama case.
+
+Expected runtime image:
+
+```text
+harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0
+```

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/config.yaml
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/config.yaml
@@ -1,0 +1,46 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/aiter_meta
+repo_subdir: aiter_meta
+repository_language: hip
+source_file_path:
+- csrc/cpp_itfs/pa/pa_kernels.cuh
+- csrc/cpp_itfs/pa/pa.cuh
+- csrc/cpp_itfs/pa/pa_common.cuh
+- csrc/cpp_itfs/pa/pa.cpp.jinja
+target_kernel_functions:
+- paged_attention_ll4mi_QKV_mfma16_kernel
+- paged_attention_ll4mi_reduce_kernel
+kernel_identity:
+  logical_operator: paged_attention_rocm
+  kernel_kind: hip
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: llama3_1-8b-decode-m64-ctx1024
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: 'Optimize the ROCm custom paged-attention decode kernels on MI355X/gfx950.
+    The device kernels are paged_attention_ll4mi_QKV_mfma16_kernel (partial attention
+    per KV partition) and paged_attention_ll4mi_reduce_kernel (cross-partition
+    softmax reduction), reached through aiter.paged_attention_rocm. Both are JIT
+    specialized per (gqa_ratio, head_size, npar_loops, dtype, block_size, ...) from
+    csrc/cpp_itfs/pa/pa.cpp.jinja, whose device code lives in pa.cuh / pa_kernels.cuh
+    / pa_common.cuh - all four files are editable and every edit is recompiled before
+    each scoring step. The workload is BF16 decode with 64 sequences, head_size 128,
+    block_size 16 and 1024-2048 tokens of KV context, across the three head
+    geometries these models produce: GQA 2:1 (16 q / 8 kv), 4:1 (32 q / 8 kv) and
+    5:1 (40 q / 8 kv). That is three JIT specializations for the seven cases, so a
+    rebuild costs three compiles. Do not tune one gqa_ratio at the expense of
+    another. Cases come from four MI355X Hyperloom 2026-08-01 sessions
+    (Llama-3.1-8B-Instruct, Qwen3-8B, Qwen3-0.6B, Qwen3-14B-FP8) and are stored in
+    session_cases.json. Preserve all correctness cases and improve CUDA-graph
+    measured performance. Do not change the signature of aiter.paged_attention_rocm
+    or the launch contract in pa.cpp.jinja.'
+  cheatsheet: null

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/forge_driver.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Profiling is a single-shape probe. When the task pins one representative
+    # case, honour it so the profiled kernel does not drift with timing noise.
+    pinned = getattr(tr, "profile_case", None)
+    if callable(pinned):
+        return pinned()
+    # Otherwise prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/task_runner.py
@@ -32,6 +32,32 @@ PARTITION_SIZE = 256
 PROFILE_CASE_ID = SPEC.get("profile_case") or CASES[0]["id"]
 
 
+def _sources_edited() -> bool:
+    """True unless every editable source still matches its in-image original.
+
+    Fails safe: anything we cannot positively verify counts as edited. Serving a
+    prebuilt .so for an edited kernel would silently benchmark the ORIGINAL, so
+    a false "unedited" is far worse than a redundant rebuild.
+    """
+    try:
+        import yaml
+
+        cfg = yaml.safe_load((WORKSPACE / "config.yaml").read_text()) or {}
+        image_root = Path(str(cfg["image_repo_path"]))
+        sources = cfg["source_file_path"] or []
+        if isinstance(sources, str):
+            sources = [sources]
+        if not sources or not image_root.is_dir():
+            return True
+        for rel in sources:
+            ours = WORKSPACE / REPO_SUBDIR / str(rel)
+            if ours.read_bytes() != (image_root / str(rel)).read_bytes():
+                return True
+        return False
+    except Exception:  # noqa: BLE001 - unverifiable means "assume edited"
+        return True
+
+
 def _configure() -> None:
     for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
         os.environ.setdefault(key, "gfx950")
@@ -41,7 +67,14 @@ def _configure() -> None:
     # the cache is what makes a source edit take effect. AgentKernelArena also
     # injects AITER_REBUILD=1 per build subprocess (src/jit_rebuild.py); the
     # default here keeps standalone runs honest.
-    os.environ.setdefault("AITER_REBUILD", "1")
+    #
+    # Only force it once something has actually been edited. aiter treats any
+    # non-zero AITER_REBUILD as "rebuild this module on first use", without
+    # checking the source, and the profiler re-spawns this driver once per
+    # counter pass, so an unedited baseline would re-enter the rebuild path
+    # over and over for a kernel that never changed.
+    if _sources_edited():
+        os.environ.setdefault("AITER_REBUILD", "1")
     # Keep the template-op build cache inside the workspace instead of the
     # shared ~/.aiter, so parallel runs cannot serve each other's kernels.
     os.environ.setdefault("AITER_ROOT_DIR", str(WORKSPACE / "build" / "aiter_root"))

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/scripts/task_runner.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Harness for the ROCm custom paged-attention decode kernels
+``paged_attention_ll4mi_QKV_mfma16_kernel`` + ``paged_attention_ll4mi_reduce_kernel``
+(AITER ``csrc/cpp_itfs/pa``), reached through ``aiter.paged_attention_rocm``.
+
+The kernels are JIT specialized from the editable workspace copy of the in-image
+AITER source tree: ``AITER_META_DIR`` points the importable ``csrc`` package and
+``AITER_CORE_DIR`` at ``<workspace>/aiter_meta``, and ``AITER_REBUILD`` clears the
+template-op build cache so an agent's edit to ``pa_kernels.cuh`` / ``pa.cuh`` /
+``pa_common.cuh`` / ``pa.cpp.jinja`` is recompiled before it is measured.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+
+REPO_SUBDIR = "aiter_meta"
+PARTITION_SIZE = 256
+
+# Profiling is a single-shape probe, pinned rather than derived from timings so
+# the profiled kernel never drifts between runs. GQA 4:1 at head_size 128 /
+# block_size 16 is the most common decode geometry in this suite (shared by
+# Llama-3.1-8B-Instruct and Qwen3-8B). Correctness and performance still sweep
+# every case in CASES.
+PROFILE_CASE_ID = SPEC.get("profile_case") or CASES[0]["id"]
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+
+    # compile_template_op caches purely by template arguments, so an edited
+    # kernel would otherwise keep serving the previously built lib.so. Clearing
+    # the cache is what makes a source edit take effect. AgentKernelArena also
+    # injects AITER_REBUILD=1 per build subprocess (src/jit_rebuild.py); the
+    # default here keeps standalone runs honest.
+    os.environ.setdefault("AITER_REBUILD", "1")
+    # Keep the template-op build cache inside the workspace instead of the
+    # shared ~/.aiter, so parallel runs cannot serve each other's kernels.
+    os.environ.setdefault("AITER_ROOT_DIR", str(WORKSPACE / "build" / "aiter_root"))
+
+    repo = WORKSPACE / REPO_SUBDIR
+    if repo.is_dir():
+        # aiter/jit/core.py puts this on sys.path, which is what makes
+        # `import csrc.cpp_itfs.pa.pa` resolve to the workspace copy; pa.py then
+        # derives AITER_CORE_DIR from its own location, so the jinja template and
+        # every include come from the same editable tree.
+        os.environ["AITER_META_DIR"] = str(repo)
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _import_aiter():
+    import aiter
+
+    seeded = os.environ.get("AITER_META_DIR")
+    if seeded:
+        import csrc.cpp_itfs.utils as cpp_itfs_utils
+
+        core = Path(cpp_itfs_utils.AITER_CORE_DIR).resolve()
+        if core != Path(seeded).resolve():
+            raise RuntimeError(
+                "AITER template ops resolved to "
+                f"{core}, not the editable workspace tree {seeded}; "
+                "kernel edits would be silently ignored."
+            )
+    return aiter
+
+
+def profile_case() -> dict:
+    """The single case profiling runs against (see PROFILE_CASE_ID)."""
+    for case in CASES:
+        if case["id"] == PROFILE_CASE_ID:
+            return case
+    raise KeyError(
+        f"profile_case {PROFILE_CASE_ID!r} is not present in session_cases.json"
+    )
+
+
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one. ``ctx_len`` also sets the split-K partition
+    count, so a shortened context changes which reduction path the kernel takes.
+    """
+    torch = _torch()
+    aiter = _import_aiter()
+    params = dict(case["params"])
+    num_seqs = params["num_seqs"]
+    ctx_len = params["ctx_len"]
+    num_query_heads = params["num_query_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    head_size = params["head_size"]
+    block_size = params["block_size"]
+    dtype = torch.bfloat16
+    scale = head_size**-0.5
+
+    torch.manual_seed(29)
+
+    # Decode: one query token per sequence.
+    query = torch.randn(
+        (num_seqs, num_query_heads, head_size), device="cuda", dtype=dtype
+    )
+    output = torch.empty_like(query)
+
+    # Contiguous per-sequence context KV, used both to fill the paged cache and
+    # to compute the reference.
+    key = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+    value = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+
+    pages_per_seq = (ctx_len + block_size - 1) // block_size
+    num_blocks = num_seqs * pages_per_seq + 1
+
+    # Paged KV cache in the vLLM ROCm layout: (2, num_blocks, block_size,
+    # num_kv_heads, head_size), split into the 5D key / 4D value views that
+    # paged_attention_rocm expects.
+    kv_cache = torch.zeros(
+        (2, num_blocks, block_size, num_kv_heads, head_size),
+        device="cuda",
+        dtype=dtype,
+    )
+    from vllm.v1.attention.ops.paged_attn import PagedAttention
+
+    key_cache, value_cache = PagedAttention.split_kv_cache(
+        kv_cache, num_kv_heads, head_size
+    )
+
+    block_table = torch.arange(
+        num_seqs * pages_per_seq, device="cuda", dtype=torch.int32
+    ).view(num_seqs, pages_per_seq)
+
+    # slot = physical_block * block_size + offset, in (seq, pos) row-major order.
+    seq_idx = torch.arange(num_seqs, device="cuda").view(-1, 1).expand(-1, ctx_len)
+    pos = torch.arange(ctx_len, device="cuda").view(1, -1).expand(num_seqs, -1)
+    phys_block = block_table[seq_idx, pos // block_size].long()
+    slot_mapping = (phys_block * block_size + (pos % block_size)).reshape(-1)
+
+    one = torch.ones(1, device="cuda", dtype=torch.float32)
+
+    # Split-K scratch, sized exactly as vLLM sizes it in
+    # chunked_prefill_paged_decode.py before calling paged_attention_rocm.
+    max_num_partitions = (ctx_len + PARTITION_SIZE - 1) // PARTITION_SIZE
+    tmp_output = torch.empty(
+        (num_seqs, num_query_heads, max_num_partitions, head_size),
+        device="cuda",
+        dtype=dtype,
+    )
+    exp_sums = torch.empty(
+        (num_seqs, num_query_heads, max_num_partitions),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    max_logits = torch.empty_like(exp_sums)
+
+    inputs = {
+        "cfg": case,
+        "aiter": aiter,
+        "query": query,
+        "output": output,
+        "key": key,
+        "value": value,
+        "key_cache": key_cache,
+        "value_cache": value_cache,
+        "block_table": block_table,
+        "seq_lens": torch.full(
+            (num_seqs,), ctx_len, device="cuda", dtype=torch.int32
+        ),
+        "exp_sums": exp_sums,
+        "max_logits": max_logits,
+        "tmp_output": tmp_output,
+        "num_kv_heads": num_kv_heads,
+        "head_size": head_size,
+        "block_size": block_size,
+        "max_seq_len": ctx_len,
+        "scale": scale,
+        "one": one,
+        "slot_mapping": slot_mapping,
+    }
+    _fill_kv_cache(inputs)
+    return inputs
+
+
+def _fill_kv_cache(inputs: dict) -> None:
+    """Page the contiguous key/value into the cache the kernel reads.
+
+    The reference reads ``key``/``value`` while the kernel reads the paged cache,
+    so the two have to be refreshed together or they stop describing the same
+    workload.
+    """
+    import vllm._custom_ops as ops
+
+    num_kv_heads = inputs["num_kv_heads"]
+    head_size = inputs["head_size"]
+    ops.reshape_and_cache(
+        inputs["key"].reshape(-1, num_kv_heads, head_size),
+        inputs["value"].reshape(-1, num_kv_heads, head_size),
+        inputs["key_cache"],
+        inputs["value_cache"],
+        inputs["slot_mapping"],
+        "auto",
+        inputs["one"],
+        inputs["one"],
+    )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. Fresh values stop an output
+    buffer that the kernel never wrote from matching the reference by accident.
+    """
+    torch = _torch()
+    torch.manual_seed(71)
+    inputs["query"].normal_()
+    inputs["key"].normal_()
+    inputs["value"].normal_()
+    _fill_kv_cache(inputs)
+
+
+def _run(inputs: dict):
+    inputs["aiter"].paged_attention_rocm(
+        inputs["output"],
+        inputs["exp_sums"],
+        inputs["max_logits"],
+        inputs["tmp_output"],
+        inputs["query"],
+        inputs["key_cache"],
+        inputs["value_cache"],
+        inputs["num_kv_heads"],
+        inputs["scale"],
+        inputs["block_table"],
+        inputs["seq_lens"],
+        inputs["block_size"],
+        inputs["max_seq_len"],
+        None,
+        "auto",
+        inputs["one"],
+        inputs["one"],
+    )
+    return inputs["output"]
+
+
+def _reference(inputs: dict):
+    torch = _torch()
+    query = inputs["query"].float()  # (S, num_query_heads, head_size)
+    key = inputs["key"].float()  # (S, ctx, num_kv_heads, head_size)
+    value = inputs["value"].float()
+    scale = inputs["scale"]
+    ratio = query.shape[1] // key.shape[2]
+    outputs = []
+    for s in range(query.shape[0]):
+        k = key[s].repeat_interleave(ratio, dim=1)  # (ctx, num_query_heads, hs)
+        v = value[s].repeat_interleave(ratio, dim=1)
+        scores = torch.einsum("hd,khd->hk", query[s], k) * scale
+        probs = torch.softmax(scores, dim=-1)
+        outputs.append(torch.einsum("hk,khd->hd", probs, v))
+    return torch.stack(outputs).to(inputs["output"].dtype)
+
+
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.02, rtol=0.02)
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    params["num_seqs"] = min(params["num_seqs"], 8)
+    params["ctx_len"] = min(params["ctx_len"], 256)
+    return {**case, "params": params}
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote, so work the scored path skips cannot
+    hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    inputs["output"].fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        # The output buffer is written, never accumulated: poison it so an
+        # implementation that leaves elements untouched cannot pass by reusing
+        # whatever the allocator handed back.
+        inputs["output"].fill_(float("nan"))
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "session_id": case.get("session_id"),
+            "kernel_ids": case.get("kernel_ids"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/session_cases.json
+++ b/tasks/image_kernel/mi355x_vllm_hip_paged_attention_decode/session_cases.json
@@ -1,0 +1,211 @@
+{
+  "source_day": "2026-08-01",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.24.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0",
+  "selection": "ROCm custom paged-attention decode, the largest decode leaf in four MI355X Hyperloom sessions. Cases cover the three distinct head geometries those models produce (GQA 2:1 / 4:1 / 5:1) at head_size=128, block_size=16, BF16 Q/KV/O.",
+  "task_name": "mi355x-rocm-paged-attention-decode-20260801",
+  "operator": "paged_attention_rocm",
+  "profile_case": "llama3_1-8b-decode-m64-ctx1024",
+  "provenance": {
+    "entry": "aiter.paged_attention_rocm -> csrc/cpp_itfs/pa/pa.py -> compile_template_op(csrc/cpp_itfs/pa/pa.cpp.jinja)",
+    "call_chain_in_session": "vllm::unified_attention_with_output -> v1/attention/backends/rocm_attn.py:360 -> v1/attention/ops/chunked_prefill_paged_decode.py:392 -> vllm/_custom_ops.py:208 paged_attention_rocm -> torch.ops._rocm_C.paged_attention",
+    "shared_workload": "All four sessions ran the same harness: TP=1, EP=1, concurrency=64, ISL=1024, OSL=1024, max_model_len=6144, NUM_PROMPTS=776. Decode batch is therefore 64 sequences and per-sequence KV context grows across 1024..2048 tokens. num_seqs and ctx_len are reconstructed from that regime: the graph-captured decode launches carry no recorded tensor shapes in the trace.",
+    "shared_dtypes": "Every session reported kv_cache_dtype=auto, i.e. BF16 Q / KV cache / output, cross-checked against the kernels' own (vllm::Fp8KVCacheDataType)0 = kAuto template argument. Qwen3-14B-FP8 quantizes weights, not the KV cache.",
+    "head_geometry_source": "Head counts read from each model's config.json under /shared_nfs/hyperloom/models and cross-checked against the GQA_RATIO template argument recorded in each trace.",
+    "models": [
+      {
+        "model": "Llama-3.1-8B-Instruct",
+        "session_id": "Llama-3.1-8B-Instruct_20260801T062921Z_b5aa24f5",
+        "session_dir": "/shared_nfs/hyperloom-claw/Llama-3.1-8B-Instruct/20260801T062920Z",
+        "trace": "runs/roofline/0d44af26d4a748adbb023cb713ee1aea/benchmark_vllm_20260801_070113/torch_trace",
+        "geometry": "32 q heads / 8 kv heads / head_dim 128, 32 layers -> gqa_ratio 4",
+        "device_kernel_in_session": "paged_attention_ll4mi_QKV_mfma4_kernel<__hip_bfloat16, __hip_bfloat16, (vllm::Fp8KVCacheDataType)0, __hip_bfloat16, 16, 128, 256, false, 4>",
+        "gpu_pct": 26.85,
+        "vllm_source": "csrc/rocm/attention.cu:2874"
+      },
+      {
+        "model": "Qwen3-8B",
+        "session_id": "Qwen3-8B_20260801T032923Z_54d41b49",
+        "session_dir": "/shared_nfs/hyperloom-claw/Qwen3-8B/20260801T032923Z",
+        "geometry": "32 q heads / 8 kv heads / head_dim 128, 36 layers -> gqa_ratio 4",
+        "device_kernel_in_session": "paged_attention_ll4mi_QKV_mfma4_kernel<__hip_bfloat16, __hip_bfloat16, (vllm::Fp8KVCacheDataType)0, __hip_bfloat16, 16, 128, 256, false, 4>",
+        "gpu_pct": 25.041,
+        "vllm_source": "csrc/rocm/attention.cu",
+        "no_dedicated_cases": "Geometry, dtypes and workload are identical to Llama-3.1-8B-Instruct (32/8/128, block_size 16, BF16, concurrency 64, ISL/OSL 1024), so the llama3_1-8b-* cases cover this model exactly. Adding duplicate case ids would only double suite runtime."
+      },
+      {
+        "model": "Qwen3-0.6B",
+        "session_id": "Qwen3-0.6B_20260801T185902Z_a2ce5c46",
+        "session_dir": "/shared_nfs/hyperloom-k8s/safe-opt-claw-top-models-forge-qwen-qwen-da0e48bb-a1/da0e48bb-9d3c-4365-9cbc-52f8f1a15709/Qwen3-0.6B/20260801T185902Z",
+        "geometry": "16 q heads / 8 kv heads / head_dim 128, 28 layers -> gqa_ratio 2",
+        "device_kernel_in_session": "paged_attention_ll4mi_QKV_mfma4_kernel<bf16, bf16, kAuto, bf16, 16, 128, 256, false, 2>",
+        "gpu_pct": 35.778,
+        "vllm_source": "csrc/rocm/attention.cu:922"
+      },
+      {
+        "model": "Qwen3-14B-FP8",
+        "session_id": "Qwen3-14B-FP8_20260801T155323Z_537c1f91",
+        "session_dir": "/shared_nfs/hyperloom-k8s/safe-opt-claw-top-models-forge-qwen-qwen-b700704f-a1/b700704f-a714-46f4-b309-7ce4f9622a5d/Qwen3-14B-FP8/20260801T155323Z",
+        "geometry": "40 q heads / 8 kv heads / head_dim 128, 40 layers -> gqa_ratio 5",
+        "device_kernel_in_session": "paged_attention_ll4mi_QKV_mfma16_kernel<bf16, bf16, kAuto, bf16, 16, 128, 256, false, 5, MFMAType=0>",
+        "gpu_pct": 10.544,
+        "vllm_source": "csrc/rocm/attention.cu:321",
+        "note": "The only one of the four whose session already ran the MFMA16 variant (gqa_ratio 5 > 4), so it is the closest match to what this task actually measures."
+      }
+    ],
+    "mfma_variant_caveat": "Three of the four sessions (Llama-3.1-8B, Qwen3-8B, Qwen3-0.6B) ran vLLM's MFMA4 variant, selected because gqa_ratio <= 4 (see the 'mfma4 kernel is faster than mfma16 for gqa_ratio <= 4' switch in csrc/rocm/attention.cu). vLLM ships no csrc in the runtime image (wheel-only install; /app/vllm holds only benchmarks/docker/examples), so there is no in-image vLLM source to seed and edit. AITER ships the same paged_attention_ll4mi family with full source, but dispatches MFMA16 for every gqa_ratio - the MFMA4 launches are commented out in both csrc/kernels/attention.cu and csrc/cpp_itfs/pa/pa.cpp.jinja. This task therefore measures AITER's MFMA16 implementation of the same logical operator at each session's exact shapes and dtypes. Only the Qwen3-14B-FP8 cases match the session's MFMA variant as well. Verified: mfma4 symbols exist only in vllm/_rocm_C.abi3.so; aiter/jit/module_pa*.so carry mfma16 only.",
+    "specializations": "compile_template_op keys on (gqa_ratio, head_size, npar_loops, dtype, kv_dtype, out_dtype, block_size, alibi, mtp, quant_method, v_shuffle). All cases give max_num_partitions = ceil(ctx_len/256) <= 8 with warpSize 64, hence npar_loops=1 - matching the sessions' paged_attention_ll4mi_reduce_kernel<..., 128, 128, 256, 1>. The suite therefore builds exactly three specializations, one per gqa_ratio (2, 4, 5).",
+    "case_density": "The primary model (Llama-3.1-8B-Instruct, the largest single hot kernel across these sessions) is sampled at three context lengths to expose the memory-bound scaling; the coverage models are sampled at the two endpoints of their decode regime."
+  },
+  "cases": [
+    {
+      "id": "llama3_1-8b-decode-m64-ctx1024",
+      "model": "Llama-3.1-8B-Instruct",
+      "session_id": "Llama-3.1-8B-Instruct_20260801T062921Z_b5aa24f5",
+      "kernel_ids": ["k001"],
+      "gpu_pct": 26.85,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 32,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 1024,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,32,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "llama3_1-8b-decode-m64-ctx1536",
+      "model": "Llama-3.1-8B-Instruct",
+      "session_id": "Llama-3.1-8B-Instruct_20260801T062921Z_b5aa24f5",
+      "kernel_ids": ["k001"],
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 32,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 1536,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,32,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "llama3_1-8b-decode-m64-ctx2048",
+      "model": "Llama-3.1-8B-Instruct",
+      "session_id": "Llama-3.1-8B-Instruct_20260801T062921Z_b5aa24f5",
+      "kernel_ids": ["k001"],
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 32,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 2048,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,32,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "qwen3-0_6b-decode-m64-ctx1024",
+      "model": "Qwen3-0.6B",
+      "session_id": "Qwen3-0.6B_20260801T185902Z_a2ce5c46",
+      "kernel_ids": ["k001"],
+      "gpu_pct": 35.778,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 16,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 1024,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,16,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "qwen3-0_6b-decode-m64-ctx2048",
+      "model": "Qwen3-0.6B",
+      "session_id": "Qwen3-0.6B_20260801T185902Z_a2ce5c46",
+      "kernel_ids": ["k001"],
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 16,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 2048,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,16,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "qwen3-14b-fp8-decode-m64-ctx1024",
+      "model": "Qwen3-14B-FP8",
+      "session_id": "Qwen3-14B-FP8_20260801T155323Z_537c1f91",
+      "kernel_ids": [],
+      "gpu_pct": 10.544,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 40,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 1024,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,40,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    },
+    {
+      "id": "qwen3-14b-fp8-decode-m64-ctx2048",
+      "model": "Qwen3-14B-FP8",
+      "session_id": "Qwen3-14B-FP8_20260801T155323Z_537c1f91",
+      "kernel_ids": [],
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_query_heads": 40,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "block_size": 16,
+        "ctx_len": 2048,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,40,128) bf16",
+        "K/V cache pages (num_blocks,8,128) bf16, block_size=16"
+      ]
+    }
+  ]
+}

--- a/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/forge_driver.py
@@ -17,7 +17,7 @@ entirely and no per-run driver authoring can fail.
 How it satisfies the contract without per-kernel reimplementation
 -----------------------------------------------------------------
 Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
-canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
 / ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
 writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
 ``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
@@ -45,7 +45,7 @@ kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
         real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
 
   * Profiling    ``--profile-run``
-        builds ONE case's inputs (``_make(case, correctness=False)``) and launches
+        builds ONE case's inputs (``_make(case)``) and launches
         ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
         couple of profiled launches, one synchronize, exit 0. No timing printed.
 
@@ -150,7 +150,7 @@ def _pick_profile_case(tr) -> dict:
 def _run_profile(tr) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/standalone_driver.py
@@ -375,10 +375,10 @@ def _load_mhc_module():
     return module
 
 
-def _make_mhc(case: dict, correctness: bool = False) -> dict:
+def _make_mhc(case: dict) -> dict:
     torch = _torch()
     params = dict(case["params"])
-    tokens = min(params["tokens"], 64) if correctness else params["tokens"]
+    tokens = params["tokens"]
     hidden_size = params["hidden_size"]
     hc_mult = params["hc_mult"]
     torch.manual_seed(13)
@@ -473,7 +473,7 @@ def _mhc_reference(inputs: dict):
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -482,7 +482,7 @@ def run_compile() -> None:
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
@@ -523,8 +523,8 @@ def run_performance() -> None:
     _write_report(rows)
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
-    return _make_mhc(case, correctness)
+def _make(case: dict) -> dict:
+    return _make_mhc(case)
 
 
 def _run(inputs: dict):
@@ -534,7 +534,7 @@ def _run(inputs: dict):
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
         for actual, expected in zip(got, _mhc_reference(inputs)):
@@ -611,7 +611,7 @@ def _pick_profile_case(tr, case_id: str) -> dict:
 def _run_profile(tr, case_id: str) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr, case_id)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre/scripts/task_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import math
 import os
 import sys
 from pathlib import Path
@@ -95,196 +94,17 @@ def _torch():
     return torch
 
 
-def _import_aiter():
-    import aiter
+def _assert_operator() -> None:
+    """Guard against this runner being pointed at a different operator.
 
-    return aiter
-
-
-def _make_attention(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
-    num_seqs = params["q_tokens"]
-    num_q_heads = params["num_q_heads"]
-    num_kv_heads = params["num_kv_heads"]
-    head_size = params["head_size"]
-    block_size = params["block_size"]
-    pages_per_seq = (ctx_len + block_size - 1) // block_size
-    num_blocks = num_seqs * pages_per_seq
-
-    torch.manual_seed(7)
-    query = torch.randn(
-        (num_seqs, num_q_heads, head_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    kv = torch.randn(
-        (num_blocks, block_size, num_kv_heads, head_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    if params["kv_dtype"] == "fp8":
-        key = kv.to(torch.float8_e4m3fn)
-        value = (kv * 0.7).to(torch.float8_e4m3fn)
-    else:
-        key = kv
-        value = kv * 0.7
-
-    output = torch.empty_like(query)
-    cu_seqlens_q = torch.arange(num_seqs + 1, device="cuda", dtype=torch.int32)
-    seqused_k = torch.full(
-        (num_seqs,), ctx_len, device="cuda", dtype=torch.int32
-    )
-    block_table = torch.arange(
-        num_blocks, device="cuda", dtype=torch.int32
-    ).view(num_seqs, pages_per_seq)
-    one = torch.ones(1, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "query": query,
-        "key": key,
-        "value": value,
-        "output": output,
-        "cu_seqlens_q": cu_seqlens_q,
-        "seqused_k": seqused_k,
-        "block_table": block_table,
-        "ctx_len": ctx_len,
-        "scale": head_size**-0.5,
-        "one": one,
-    }
-
-
-def _run_attention(inputs: dict):
-    from aiter.ops.triton.attention.unified_attention import unified_attention
-
-    unified_attention(
-        inputs["query"],
-        inputs["key"],
-        inputs["value"],
-        inputs["output"],
-        inputs["cu_seqlens_q"],
-        1,
-        inputs["seqused_k"],
-        inputs["ctx_len"],
-        inputs["scale"],
-        True,
-        (-1, -1),
-        inputs["block_table"],
-        0.0,
-        inputs["one"],
-        inputs["one"],
-        inputs["one"],
-    )
-    return inputs["output"]
-
-
-def _attention_reference(inputs: dict):
-    torch = _torch()
-    query = inputs["query"].float()
-    key = inputs["key"].float()
-    value = inputs["value"].float()
-    outputs = []
-    for seq_idx in range(query.shape[0]):
-        block_ids = inputs["block_table"][seq_idx]
-        key_seq = key[block_ids].reshape(-1, key.shape[2], key.shape[3])
-        value_seq = value[block_ids].reshape(-1, value.shape[2], value.shape[3])
-        key_seq = key_seq[: inputs["ctx_len"]]
-        value_seq = value_seq[: inputs["ctx_len"]]
-        ratio = query.shape[1] // key_seq.shape[1]
-        key_seq = key_seq.repeat_interleave(ratio, dim=1)
-        value_seq = value_seq.repeat_interleave(ratio, dim=1)
-        scores = (
-            torch.einsum("hd,khd->hk", query[seq_idx], key_seq)
-            * inputs["scale"]
+    The file was specialized to ``mhc_fused_post_pre``; the other builders,
+    callers and references from the shared template are gone. Failing loudly
+    beats silently running the wrong workload.
+    """
+    if OPERATOR != "mhc_fused_post_pre":
+        raise KeyError(
+            f"{OPERATOR}: this runner only implements mhc_fused_post_pre"
         )
-        probs = torch.softmax(scores, dim=-1)
-        outputs.append(torch.einsum("hk,khd->hd", probs, value_seq))
-    return torch.stack(outputs).to(inputs["output"].dtype)
-
-
-def _make_gemm(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    m = min(params["m"], 64) if correctness else params["m"]
-    n = params["n"]
-    k = params["k"]
-    torch.manual_seed(9)
-    x = (torch.rand((m, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    weight = (torch.rand((n, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    x_scale = (
-        torch.rand((m, k // 128), device="cuda", dtype=torch.float32) * 0.1
-        + 0.01
-    )
-    w_scale = (
-        torch.rand(
-            (math.ceil(n / 128), k // 128),
-            device="cuda",
-            dtype=torch.float32,
-        )
-        * 0.1
-        + 0.01
-    )
-    return {
-        "cfg": case,
-        "x": x,
-        "weight": weight,
-        "x_scale": x_scale,
-        "w_scale": w_scale,
-        "shape": [m, n, k],
-    }
-
-
-def _run_gemm(inputs: dict):
-    return _import_aiter().gemm_a8w8_blockscale(
-        inputs["x"],
-        inputs["weight"],
-        inputs["x_scale"],
-        inputs["w_scale"],
-        _torch().bfloat16,
-    )
-
-
-def _gemm_reference(inputs: dict):
-    torch = _torch()
-    m, n, k = inputs["shape"]
-    x = (
-        inputs["x"].float()
-        * inputs["x_scale"].repeat_interleave(128, dim=1)[:, :k]
-    )
-    weight = (
-        inputs["weight"].float()
-        * inputs["w_scale"]
-        .repeat_interleave(128, dim=0)
-        .repeat_interleave(128, dim=1)[:n, :k]
-    )
-    return (x @ weight.t()).to(torch.bfloat16)
-
-
-def _make_quant(case: dict) -> dict:
-    torch = _torch()
-    torch.manual_seed(11)
-    shape = tuple(case["params"]["shape"])
-    input_tensor = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
-    output = torch.empty(shape, device="cuda", dtype=torch.float8_e4m3fn)
-    scale = torch.empty(1, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "input": input_tensor,
-        "output": output,
-        "scale": scale,
-    }
-
-
-def _run_quant(inputs: dict):
-    _import_aiter().dynamic_per_tensor_quant(
-        inputs["output"], inputs["input"], inputs["scale"]
-    )
-    return inputs["output"]
 
 
 def _load_mhc_module():
@@ -307,10 +127,10 @@ def _load_mhc_module():
     return module
 
 
-def _make_mhc(case: dict, correctness: bool = False) -> dict:
+def _make_mhc(case: dict) -> dict:
     torch = _torch()
     params = dict(case["params"])
-    tokens = min(params["tokens"], 64) if correctness else params["tokens"]
+    tokens = params["tokens"]
     hidden_size = params["hidden_size"]
     hc_mult = params["hc_mult"]
     torch.manual_seed(13)
@@ -404,353 +224,80 @@ def _mhc_reference(inputs: dict):
     return residual, post_mix, comb_mix, layer_input
 
 
-def _make_mla(case: dict, correctness: bool = False) -> dict:
+def _assert_mhc_close(inputs: dict, got) -> None:
     torch = _torch()
-    params = dict(case["params"])
-    batch = min(params["batch"], 64) if correctness else params["batch"]
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
-    capacity = (
-        min(params["kv_capacity"], batch * ctx_len + 1024)
-        if correctness
-        else params["kv_capacity"]
-    )
-    torch.manual_seed(17)
-    query = torch.randn(
-        (batch, params["num_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    kv = torch.randn(
-        (capacity, params["page_size"], params["kv_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    output = torch.empty(
-        (batch, params["num_heads"], params["v_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    qo_indptr = torch.arange(batch + 1, device="cuda", dtype=torch.int32)
-    kv_indptr = torch.arange(
-        0, (batch + 1) * ctx_len, ctx_len, device="cuda", dtype=torch.int32
-    )
-    kv_indices = (
-        torch.arange(batch * ctx_len, device="cuda", dtype=torch.int32)
-        % capacity
-    )
-    last_page_lens = torch.ones(batch, device="cuda", dtype=torch.int32)
-    return {
-        "cfg": case,
-        "params": params,
-        "query": query,
-        "kv": kv,
-        "output": output,
-        "qo_indptr": qo_indptr,
-        "kv_indptr": kv_indptr,
-        "kv_indices": kv_indices,
-        "last_page_lens": last_page_lens,
-        "ctx_len": ctx_len,
-    }
+    for actual, expected in zip(got, _mhc_reference(inputs)):
+        torch.testing.assert_close(actual, expected, atol=0.08, rtol=0.08)
 
 
-def _run_mla(inputs: dict):
-    params = inputs["params"]
-    return _import_aiter().mla.mla_decode_fwd(
-        inputs["query"],
-        inputs["kv"],
-        inputs["output"],
-        inputs["qo_indptr"],
-        inputs["kv_indptr"],
-        inputs["kv_indices"],
-        inputs["last_page_lens"],
-        1,
-        params["page_size"],
-        params["kv_heads"],
-        params["qk_dim"] ** -0.5,
-        num_kv_splits=None,
-        return_lse=False,
-    )
+def _perturb_mhc_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
 
-
-def _mla_reference(inputs: dict):
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. Fresh values stop an output
+    buffer that the kernel never wrote from matching the reference by accident,
+    which the caching allocator makes surprisingly likely when a recycled block
+    still holds a previous output.
+    """
     torch = _torch()
-    query = inputs["query"].float()
-    outputs = []
-    for seq_idx in range(query.shape[0]):
-        start = seq_idx * inputs["ctx_len"]
-        end = (seq_idx + 1) * inputs["ctx_len"]
-        indices = inputs["kv_indices"][start:end]
-        kv = inputs["kv"][indices].reshape(
-            -1,
-            inputs["params"]["kv_heads"],
-            inputs["params"]["qk_dim"],
-        )
-        key = kv
-        value = kv[..., : inputs["params"]["v_dim"]]
-        ratio = query.shape[1] // key.shape[1]
-        key = key.repeat_interleave(ratio, dim=1)
-        value = value.repeat_interleave(ratio, dim=1)
-        scores = (
-            torch.einsum("hd,khd->hk", query[seq_idx], key.float())
-            * (inputs["params"]["qk_dim"] ** -0.5)
-        )
-        probs = torch.softmax(scores, dim=-1)
-        outputs.append(torch.einsum("hk,khd->hd", probs, value.float()))
-    return torch.stack(outputs).to(inputs["output"].dtype)
-
-
-def _moe_enums(params: dict, aiter):
-    quant_type = {
-        "per_Tensor": aiter.QuantType.per_Tensor,
-        "per_1x128": aiter.QuantType.per_1x128,
-        "per_1x32": aiter.QuantType.per_1x32,
-    }[params["quant_type"]]
-    activation = {
-        "silu": aiter.ActivationType.Silu,
-        "swiglu": aiter.ActivationType.Swiglu,
-    }[params["activation"]]
-    return quant_type, activation
-
-
-def _prepare_moe(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import fused_topk
-    from aiter.ops.shuffle import (
-        shuffle_scale_a16w4,
-        shuffle_weight,
-        shuffle_weight_a16w4,
-    )
-    from aiter.utility import fp4_utils
-
-    params = dict(case["params"])
-    token = min(params["token"], 64) if correctness else params["token"]
-    experts = params["experts"]
-    model_dim = params["model_dim"]
-    inter_dim = params["inter_dim"]
-    topk = params["topk"]
-    quant_type, activation = _moe_enums(params, aiter)
-    activation_dtype = {
-        "fp8": dtypes.fp8,
-        "fp4": dtypes.fp4x2,
-        "bf16": dtypes.bf16,
-    }[params["a_dtype"]]
-    weight_dtype = {"fp8": dtypes.fp8, "fp4": dtypes.fp4x2}[
-        params["w_dtype"]
-    ]
-
-    torch.manual_seed(19)
-    hidden = (
-        torch.randn(
-            (token, model_dim), device="cuda", dtype=dtypes.bf16
-        )
-        * 0.1
-    )
-    w1 = (
-        torch.randn(
-            (experts, inter_dim * 2, model_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    w2 = (
-        torch.randn(
-            (experts, model_dim, inter_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    score = torch.randn((token, experts), device="cuda", dtype=dtypes.bf16)
-    topk_weights, topk_ids = fused_topk(hidden, score, topk, True)
-    torch_quant = aiter.get_torch_quant(quant_type)
-
-    if quant_type == aiter.QuantType.per_Tensor:
-        w1_quant, w1_scale = aiter.pertoken_quant(
-            w1.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w2_quant, w2_scale = aiter.pertoken_quant(
-            w2.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w1_quant = w1_quant.view(w1.shape)
-        w2_quant = w2_quant.view(w2.shape)
-    else:
-        w1_quant, w1_scale = torch_quant(w1, quant_dtype=weight_dtype)
-        w2_quant, w2_scale = torch_quant(w2, quant_dtype=weight_dtype)
-
-    if quant_type == aiter.QuantType.per_1x32:
-        w1_quant = w1_quant.view(
-            experts, w1.shape[1], w1.shape[2] // 2
-        )
-        w2_quant = w2_quant.view(
-            experts, w2.shape[1], w2.shape[2] // 2
-        )
-
-    w1_reference = w1_quant
-    w2_reference = w2_quant
-    if (
-        quant_type == aiter.QuantType.per_1x32
-        and activation_dtype in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and weight_dtype == dtypes.fp4x2
-    ):
-        w1_runtime = shuffle_weight_a16w4(w1_quant, 16, True)
-        w1_scale_runtime = shuffle_scale_a16w4(
-            w1_scale, experts, True
-        )
-        w2_runtime = shuffle_weight_a16w4(w2_quant, 16, False)
-        w2_scale_runtime = shuffle_scale_a16w4(
-            w2_scale, experts, False
-        )
-    else:
-        w1_runtime = shuffle_weight(w1_quant, layout=(16, 16))
-        w2_runtime = shuffle_weight(w2_quant, layout=(16, 16))
-        w1_scale_runtime = fp4_utils.e8m0_shuffle(w1_scale)
-        w2_scale_runtime = fp4_utils.e8m0_shuffle(w2_scale)
-
-    return {
-        "cfg": case,
-        "params": params,
-        "hidden": hidden,
-        "w1": w1_runtime,
-        "w2": w2_runtime,
-        "w1_reference": w1_reference,
-        "w2_reference": w2_reference,
-        "w1_scale": w1_scale,
-        "w2_scale": w2_scale,
-        "w1_scale_runtime": w1_scale_runtime,
-        "w2_scale_runtime": w2_scale_runtime,
-        "topk_weights": topk_weights,
-        "topk_ids": topk_ids,
-        "quant_type": quant_type,
-        "activation": activation,
-        "activation_dtype": activation_dtype,
-        "weight_dtype": weight_dtype,
-    }
-
-
-def _run_moe(inputs: dict):
-    from aiter.fused_moe import fused_moe
-
-    return fused_moe(
-        inputs["hidden"],
-        inputs["w1"],
-        inputs["w2"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        w1_scale=inputs["w1_scale_runtime"],
-        w2_scale=inputs["w2_scale_runtime"],
-        quant_type=inputs["quant_type"],
-        activation=inputs["activation"],
-        dtype=_torch().bfloat16,
+    torch.manual_seed(29)
+    inputs["x"].normal_()
+    inputs["residual"].normal_()
+    inputs["post_mix"].normal_()
+    inputs["comb_mix"].copy_(
+        torch.softmax(torch.randn_like(inputs["comb_mix"]), dim=-1)
     )
 
 
-def _moe_reference(inputs: dict):
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import torch_moe_stage1, torch_moe_stage2
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
 
-    torch_quant = aiter.get_torch_quant(inputs["quant_type"])
-    params = inputs["params"]
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"].view(inputs["hidden"].shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a1_quant = a1_quant.view(inputs["hidden"].shape)
-        a1_scale = a1_scale.squeeze(-1)
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a1_quant = inputs["hidden"].to(inputs["activation_dtype"])
-        a1_scale = None
-    else:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"], quant_dtype=inputs["activation_dtype"]
-        )
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
 
-    stage1 = torch_moe_stage1(
-        a1_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        activation=inputs["activation"],
-        quant_type=inputs["quant_type"],
-        a1_scale=a1_scale,
-        w1_scale=inputs["w1_scale"],
-    )
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a2_quant, a2_scale = torch_quant(
-            stage1.view(stage1.shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a2_scale = a2_scale.view(
-            stage1.shape[0], params["topk"], -1
-        )
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a2_quant = stage1
-        a2_scale = None
-    else:
-        a2_quant, a2_scale = torch_quant(
-            stage1, quant_dtype=inputs["activation_dtype"]
-        )
-    a2_quant = a2_quant.view(stage1.shape[0], params["topk"], -1)
-    return torch_moe_stage2(
-        a2_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        quant_type=inputs["quant_type"],
-        w2_scale=inputs["w2_scale"],
-        a2_scale=a2_scale,
-    )
-
-
-def _make(case: dict, correctness: bool = False) -> dict:
-    if OPERATOR == "unified_attention":
-        return _make_attention(case, correctness)
-    if OPERATOR == "a8w8_blockscale_gemm":
-        return _make_gemm(case, correctness)
-    if OPERATOR == "dynamic_per_tensor_quant":
-        return _make_quant(case)
-    if OPERATOR == "mhc_fused_post_pre":
-        return _make_mhc(case, correctness)
-    if OPERATOR == "mla_decode":
-        return _make_mla(case, correctness)
-    if OPERATOR in ("ck_moe_2stage", "cktile_moe_2stage"):
-        return _prepare_moe(case, correctness)
-    raise KeyError(OPERATOR)
+    Kept as the entry point the task drivers call, alongside :func:`_run`.
+    """
+    _assert_operator()
+    return _make_mhc(case)
 
 
 def _run(inputs: dict):
-    return {
-        "unified_attention": _run_attention,
-        "a8w8_blockscale_gemm": _run_gemm,
-        "dynamic_per_tensor_quant": _run_quant,
-        "mhc_fused_post_pre": _run_mhc,
-        "mla_decode": _run_mla,
-        "ck_moe_2stage": _run_moe,
-        "cktile_moe_2stage": _run_moe,
-    }[OPERATOR](inputs)
+    _assert_operator()
+    return _run_mhc(inputs)
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    smoke_case = {**case, "params": dict(case["params"])}
+    smoke_case["params"]["tokens"] = min(case["params"]["tokens"], 64)
+    return smoke_case
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffers it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+
+    _perturb_mhc_inputs(inputs)
+    if timed.outputs is not None:
+        for tensor in timed.outputs:
+            tensor.fill_(float("nan"))
+    _assert_mhc_close(inputs, timed.rerun())
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(_compile_smoke_case(CASES[0]))
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -759,74 +306,29 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
-        if OPERATOR == "unified_attention":
-            torch.testing.assert_close(
-                got, _attention_reference(inputs), atol=0.08, rtol=0.08
-            )
-        elif OPERATOR == "a8w8_blockscale_gemm":
-            torch.testing.assert_close(
-                got, _gemm_reference(inputs), atol=0.15, rtol=0.12
-            )
-        elif OPERATOR == "dynamic_per_tensor_quant":
-            expected_scale = (
-                inputs["input"].abs().float().max()
-                / torch.finfo(torch.float8_e4m3fn).max
-            )
-            torch.testing.assert_close(
-                inputs["scale"],
-                expected_scale.reshape(1),
-                atol=1e-5,
-                rtol=2e-2,
-            )
-            torch.testing.assert_close(
-                got.float() * inputs["scale"],
-                inputs["input"].float(),
-                atol=0.25,
-                rtol=0.15,
-            )
-        elif OPERATOR == "mhc_fused_post_pre":
-            for actual, expected in zip(got, _mhc_reference(inputs)):
-                torch.testing.assert_close(
-                    actual, expected, atol=0.08, rtol=0.08
-                )
-        elif OPERATOR == "mla_decode":
-            torch.testing.assert_close(
-                inputs["output"],
-                _mla_reference(inputs),
-                atol=0.08,
-                rtol=0.08,
-            )
-        else:
-            expected = _moe_reference(inputs)
-            cosine_error = 1 - torch.nn.functional.cosine_similarity(
-                got.float().flatten(),
-                expected.float().flatten(),
-                dim=0,
-            )
-            assert torch.isfinite(got).all()
-            assert float(cosine_error) < 0.03, (
-                case["id"],
-                float(cosine_error),
-            )
+        _assert_mhc_close(inputs, got)
         print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=3,
             repetition=20,
             target_ms=1.0,
             max_graph_repeats=100,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case["model"],

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/README.md
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/README.md
@@ -1,0 +1,133 @@
+# mi355x-gemma4-26b-vllm-triton-fused-moe-20260801
+
+Image_kernel harness for vLLM's unquantized Triton fused-MoE expert GEMM
+`fused_moe_kernel` (`vllm/model_executor/layers/fused_moe/fused_moe.py:293`).
+
+Generated from the gemma-4-26B-A4B-it Hyperloom 2026-08-01 MI355X session, where
+this kernel is the second largest hot path — 16.75% of GPU time across its three
+token counts, with the decode shape alone at 12.500%.
+
+## This is the BF16 path, not the int4 one
+
+The sibling task `mi355x_vllm_triton_fused_moe_gptq_awq` edits the same file but
+targets `fused_moe_kernel_gptq_awq`, the int4 weight-only WNA16 kernel. That is a
+different `@triton.jit` function with different operands. This task covers the
+unquantized BF16 `fused_moe_kernel`.
+
+## Why Triton at all
+
+The ROCm AITER unquantized MoE backend rejects Gemma4's GELU_TANH activation, so
+the oracle (`fused_moe/oracle/unquantized.py:156`) falls back to Triton.
+`server.log` records it directly:
+
+```text
+unquantized.py:252 Unquantized MoE backend ROCm AITER does not support ...
+                   MoEActivation.GELU_TANH activation. Falling back
+unquantized.py:266 Using TRITON Unquantized MoE backend out of potential
+                   backends: ['TRITON', 'BATCHED_TRITON']
+```
+
+## Workload
+
+TP=2, EP=1, concurrency 64, ISL=1024, OSL=1024. BF16 and unquantized —
+`dtype=torch.bfloat16`, `quantization=None`, no `quantization_config` in
+`config.json`. (The session workload label says `precision: fp8`; that label is
+wrong, and TraceLens' own `metadata/model_info.json` also records BF16.)
+
+`config.json` gives `num_experts` 128, `top_k_experts` 8, `hidden_size` 2816,
+`moe_intermediate_size` 704 and `hidden_activation` `gelu_pytorch_tanh`. EP=1
+keeps all 128 experts on every rank while TP=2 shards the intermediate, so the
+per-rank expert tensors are `w13 (128, 704, 2816)` and `w2 (128, 2816, 352)`.
+Cross-checked against the trace: `gelu_tanh_and_mul` takes `(512, 704)` and
+returns `(512, 352)`, where 512 = 64 tokens × top-8 and 352 = 704 / TP2.
+
+| Case | Tokens | Phase | Session share |
+| --- | --- | --- | --- |
+| `gemma4-moe-decode-m64` | 64 | decode | 12.500% (k010) |
+| `gemma4-moe-prefill-m1080` | 1080 | chunked prefill | 0.926% (k012) |
+| `gemma4-moe-prefill-m7218` | 7218 | chunked prefill | 3.326% (k011) |
+
+Unlike the attention kernels in this session, MoE is token-parallel: the shape is
+fully determined by token count, expert geometry and top-k, with no hidden
+per-sequence composition. All three trace token counts are reproduced directly
+rather than reconstructed.
+
+Each MoE layer launches `fused_moe_kernel` twice — once for the w13 gate_up GEMM
+and once for w2 down — so the trace's 1800 decode calls are 30 layers × 2 GEMMs ×
+30 steps. One harness call through `fused_experts_impl` covers both launches.
+
+Correctness and performance sweep all three cases. Profiling is a single-shape
+probe pinned to `gemma4-moe-decode-m64` via `profile_case` in
+`session_cases.json` (surfaced as `PROFILE_CASE_ID` / `profile_case()` in the task
+runner) — that is the session's hot entry, and pinning keeps the profiled kernel
+from drifting with measurement noise.
+
+## The missing tuned config is a real lever
+
+The session ran with vLLM's fallback MoE config. `server.log` line 89:
+
+```text
+WARNING [fused_moe.py:1071] Using default MoE config. Performance might be
+sub-optimal! Config file not found at .../configs/
+E=128,N=352,device_name=AMD_Instinct_MI355_OAM.json
+```
+
+No such file ships in the image, so the harness reproduces that condition exactly.
+`configs/` is part of the seeded editable tree, which makes supplying a tuned
+config for this shape a legitimate — and probably the highest-leverage —
+optimization alongside changing the kernel.
+
+## Editable surface and JIT
+
+`fused_moe.py` is seeded from the image and loaded from the workspace copy, so
+edits to the `@triton.jit` kernel, `invoke_fused_moe_kernel`, `fused_experts_impl`
+or `configs/` all take effect. Triton re-keys its JIT cache on source, so no
+explicit rebuild step is needed. `_load_kernel_module` suppresses
+`direct_register_custom_op` while executing the copy so its custom-op
+registrations do not clash with the already-imported installed module.
+
+## Benchmark stability
+
+`target_ms` is raised to 10 ms for this task. These cases run 0.16–1.0 ms per
+call, and at the default `target_ms=1.0` the captured repeat count collapses
+toward 1 (exactly 1 for the m7218 case), which stops amortizing the fixed
+graph-replay overhead. Measured consequence: run-to-run swings of 1.7x, and a
+30x outlier on a cold first run — reported as a legitimate `cuda_graph` number.
+At 10 ms the repeat count stays comfortably above 1 and four consecutive runs
+agree to within 0.35%. The sibling attention tasks were checked and do not need
+this: their repeat counts land between 6 and 17 at the default.
+
+## Verified locally
+
+Workspace materialized through `src.preprocessing.setup_workspace` on
+MI355X/gfx950:
+
+```text
+compile      fused_moe compile smoke: PASS
+correctness  PASS x3
+performance  decode m64     0.1565 ms
+             prefill m1080  0.2200 ms
+             prefill m7218  0.9976 ms
+             benchmark_method=cuda_graph on every case
+forge_driver --bench-mode  3x case_ms + mean_ms: 0.458057
+forge_driver --profile-run exit 0
+```
+
+Edit propagation was checked end to end by scaling the kernel's accumulator by 2
+before the output cast: correctness flipped to `allclose: False` and back to
+`allclose: True` after restoring the file. The profile pin was checked against a
+performance report whose slowest case was `gemma4-moe-prefill-m7218`; the driver
+still selected the pinned decode case.
+
+Note that the harness times `fused_experts_impl`, i.e. the whole expert path,
+which also includes `moe_align_block_size`, `moe_sum` and the activation. In the
+session those are separate kernels worth another 4.35% on top of the 12.500%
+attributed to `fused_moe_kernel` itself, so do not compare the harness numbers
+against the 12.500% figure directly. This matches the sibling gptq_awq task,
+which drives the same entry point.
+
+Expected runtime image:
+
+```text
+harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0
+```

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/config.yaml
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/config.yaml
@@ -1,0 +1,46 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe
+repo_subdir: vllm_fused_moe
+image_repo_exclude:
+- __pycache__
+repository_language: triton
+source_file_path:
+- fused_moe.py
+target_kernel_functions:
+- fused_moe_kernel
+kernel_identity:
+  logical_operator: fused_moe
+  kernel_kind: triton
+  source_owner: vllm
+  workload:
+    source: session_cases.json
+    primary_case: gemma4-moe-decode-m64
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: 'Optimize the unquantized Triton fused-MoE expert GEMM kernel
+    fused_moe_kernel (in fused_moe.py) on MI355X/gfx950. This is the BF16 path, not
+    the int4 fused_moe_kernel_gptq_awq that the sibling task
+    mi355x_vllm_triton_fused_moe_gptq_awq targets. Gemma4 lands here because the ROCm
+    AITER unquantized MoE backend rejects its GELU_TANH activation, so the oracle
+    falls back to Triton. The workload is the session''s per-rank geometry under TP=2
+    with EP=1: 128 experts, top-8, hidden 2816, intermediate 352, activation
+    gelu_tanh, BF16, at 64 (decode), 1080 and 7218 (chunked-prefill) tokens. One
+    harness call covers both per-layer launches, the w13 gate_up GEMM and the w2 down
+    GEMM. Worth knowing: the session ran with vLLM''s fallback MoE config because
+    configs/E=128,N=352,device_name=AMD_Instinct_MI355_OAM.json does not exist, and
+    the harness reproduces that; configs/ is part of the editable tree, so adding a
+    tuned config for this shape is a legitimate optimization alongside changing the
+    kernel itself. The decode (M=64) and prefill (M=7218) regimes want very different
+    tiling, so do not tune one at the expense of the other. Cases come from the
+    gemma-4-26B-A4B-it Hyperloom 2026-08-01 MI355X session and are stored in
+    session_cases.json. Preserve all correctness cases and improve CUDA-graph measured
+    performance. Do not change the signature of fused_moe_kernel,
+    invoke_fused_moe_kernel or fused_experts_impl.'
+  cheatsheet: null

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/config.yaml
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/config.yaml
@@ -35,12 +35,10 @@ prompt:
     harness call covers both per-layer launches, the w13 gate_up GEMM and the w2 down
     GEMM. Worth knowing: the session ran with vLLM''s fallback MoE config because
     configs/E=128,N=352,device_name=AMD_Instinct_MI355_OAM.json does not exist, and
-    the harness reproduces that; configs/ is part of the editable tree, so adding a
-    tuned config for this shape is a legitimate optimization alongside changing the
-    kernel itself. The decode (M=64) and prefill (M=7218) regimes want very different
-    tiling, so do not tune one at the expense of the other. Cases come from the
-    gemma-4-26B-A4B-it Hyperloom 2026-08-01 MI355X session and are stored in
-    session_cases.json. Preserve all correctness cases and improve CUDA-graph measured
-    performance. Do not change the signature of fused_moe_kernel,
+    the harness reproduces that. The decode (M=64) and prefill (M=7218) regimes
+    want very different tiling, so do not tune one at the expense of the other.
+    Cases come from the gemma-4-26B-A4B-it Hyperloom 2026-08-01 MI355X session
+    and are stored in session_cases.json. Preserve all correctness cases and
+    improve CUDA-graph measured performance. Do not change the signature of fused_moe_kernel,
     invoke_fused_moe_kernel or fused_experts_impl.'
   cheatsheet: null

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/scripts/forge_driver.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Profiling is a single-shape probe. When the task pins one representative
+    # case, honour it so the profiled kernel does not drift with timing noise.
+    pinned = getattr(tr, "profile_case", None)
+    if callable(pinned):
+        return pinned()
+    # Otherwise prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/scripts/task_runner.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Harness for vLLM's unquantized Triton fused-MoE expert GEMM
+``fused_moe_kernel`` (``vllm/model_executor/layers/fused_moe/fused_moe.py``).
+
+The kernel is loaded from the editable workspace copy of the in-image source tree
+so an optimizing agent's edits to fused_moe.py (and to ``configs/``) take effect;
+Triton re-keys its JIT on the source, so no explicit rebuild step is needed.
+
+This is the BF16 path, not the int4 ``fused_moe_kernel_gptq_awq`` covered by
+``mi355x_vllm_triton_fused_moe_gptq_awq``.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+
+REPO_SUBDIR = "vllm_fused_moe"
+KERNEL_FILE = "fused_moe.py"
+EDIT_MODULE_NAME = "vllm.model_executor.layers.fused_moe._ka_fused_moe"
+
+# Profiling is a single-shape probe, pinned rather than derived from timings so
+# the profiled kernel never drifts between runs. The decode shape is the
+# session's hot entry at 12.5% of GPU time. Correctness and performance still
+# sweep every case in CASES.
+PROFILE_CASE_ID = SPEC.get("profile_case") or CASES[0]["id"]
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _load_kernel_module():
+    # fused_moe.py runs direct_register_custom_op at import; suppress it so loading
+    # the editable copy does not clash with the already-registered installed copy.
+    import vllm.model_executor.layers.fused_moe.fused_moe  # noqa: F401
+    import vllm.utils.torch_utils as torch_utils
+
+    path = WORKSPACE / REPO_SUBDIR / KERNEL_FILE
+    if not path.is_file():
+        raise RuntimeError(f"seeded kernel source not found: {path}")
+    spec = importlib.util.spec_from_file_location(EDIT_MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[EDIT_MODULE_NAME] = module
+    original = torch_utils.direct_register_custom_op
+    torch_utils.direct_register_custom_op = lambda *a, **k: None
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        torch_utils.direct_register_custom_op = original
+    return module
+
+
+def profile_case() -> dict:
+    """The single case profiling runs against (see PROFILE_CASE_ID)."""
+    for case in CASES:
+        if case["id"] == PROFILE_CASE_ID:
+            return case
+    raise KeyError(
+        f"profile_case {PROFILE_CASE_ID!r} is not present in session_cases.json"
+    )
+
+
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+    """
+    torch = _torch()
+    p = dict(case["params"])
+    tokens = p["tokens"]
+    num_experts = p["num_experts"]
+    topk = p["topk"]
+    hidden = p["hidden"]
+    inter = p["inter"]
+
+    torch.manual_seed(31)
+    module = _load_kernel_module()
+
+    # Normalize weights by 1/sqrt(K) so the MoE output stays O(1); a fixed atol
+    # against a tiny output would let a broken kernel pass.
+    x = torch.randn((tokens, hidden), device="cuda", dtype=torch.bfloat16)
+    w1 = torch.randn(
+        (num_experts, 2 * inter, hidden), device="cuda", dtype=torch.bfloat16
+    ) / (hidden**0.5)
+    w2 = torch.randn(
+        (num_experts, hidden, inter), device="cuda", dtype=torch.bfloat16
+    ) / (inter**0.5)
+
+    # Router: Gemma4Router picks top-k over a softmax of fp32 logits.
+    logits = torch.randn((tokens, num_experts), device="cuda", dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(
+        torch.softmax(logits, dim=-1), topk, dim=-1
+    )
+
+    return {
+        "cfg": case,
+        "module": module,
+        "x": x,
+        "w1": w1,
+        "w2": w2,
+        "topk_weights": topk_weights.to(torch.float32).contiguous(),
+        "topk_ids": topk_ids.to(torch.int32).contiguous(),
+        "num_experts": num_experts,
+        "inter": inter,
+        "activation": p["activation"],
+    }
+
+
+def _run(inputs: dict):
+    return inputs["module"].fused_experts_impl(
+        hidden_states=inputs["x"],
+        w1=inputs["w1"],
+        w2=inputs["w2"],
+        topk_weights=inputs["topk_weights"],
+        topk_ids=inputs["topk_ids"],
+        activation=inputs["activation"],
+        global_num_experts=inputs["num_experts"],
+    )
+
+
+def _reference(inputs: dict):
+    """Torch reference for the gated fused MoE.
+
+    Iterates experts rather than (token, slot) pairs: every token routed to an
+    expert is one batched matmul instead of a Python step. The loop this replaces
+    ran M*topk times and synchronised on ``topk_ids``/``topk_weights`` each step,
+    which is what made a full-shape correctness run impractical.
+
+    The weights stay bf16 and are cast per expert, so the reference never
+    materialises an fp32 copy of the whole expert bank.
+    """
+    torch = _torch()
+    import torch.nn.functional as F
+
+    x = inputs["x"].float()  # [M, hidden]
+    w1 = inputs["w1"]  # [E, 2*inter, hidden] bf16
+    w2 = inputs["w2"]  # [E, hidden, inter] bf16
+    tw = inputs["topk_weights"].float()  # [M, topk]
+    tid = inputs["topk_ids"].long()  # [M, topk]
+    inter = inputs["inter"]
+    assert inputs["activation"] == "gelu_tanh", inputs["activation"]
+
+    M, hidden = x.shape
+    topk = tid.shape[1]
+    num_experts = w1.shape[0]
+
+    out = torch.zeros((M, hidden), device="cuda", dtype=torch.float32)
+    flat_expert = tid.reshape(-1)
+    flat_token = torch.arange(
+        M, device=x.device
+    ).unsqueeze(1).expand(M, topk).reshape(-1)
+    flat_weight = tw.reshape(-1)
+
+    order = torch.argsort(flat_expert)
+    counts = torch.bincount(flat_expert[order], minlength=num_experts)
+    offsets = torch.cumsum(counts, dim=0).tolist()
+    start = 0
+    for expert, stop in enumerate(offsets):
+        if stop == start:
+            continue
+        rows = flat_token[order[start:stop]]
+        gate_up = x[rows] @ w1[expert].float().t()  # [n, 2*inter]
+        # gelu_tanh_and_mul: gelu_tanh(first half) * second half
+        act = F.gelu(gate_up[:, :inter], approximate="tanh") * gate_up[:, inter:]
+        contrib = (act @ w2[expert].float().t()) * flat_weight[
+            order[start:stop]
+        ].unsqueeze(-1)
+        out.index_add_(0, rows, contrib)
+        start = stop
+    return out.to(torch.bfloat16)
+
+
+def _assert_close(case: dict, inputs: dict, got) -> None:
+    torch = _torch()
+    assert torch.isfinite(got).all(), case["id"]
+    torch.testing.assert_close(got, _reference(inputs), atol=0.03, rtol=0.03)
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the activation in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input address, so writing through it
+    changes what the scored kernel consumes. Only ``x`` is redrawn: the routing
+    tensors are kernel inputs rather than something the kernel derives, so
+    holding them fixed keeps the kernel and the reference on the same workload.
+    """
+    torch = _torch()
+    torch.manual_seed(61)
+    inputs["x"].normal_()
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    params["tokens"] = min(params["tokens"], 16)
+    params["num_experts"] = min(params["num_experts"], 8)
+    params["topk"] = min(params["topk"], 2)
+    params["hidden"] = min(params["hidden"], 512)
+    params["inter"] = min(params["inter"], 128)
+    return {**case, "params": params}
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against a freshly perturbed
+    activation and checks the buffer it wrote, so work the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(case, inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(case, inputs, got)
+        print("correctness PASS", case["id"])
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            # These cases run 0.16-1.0 ms per call, so the default target_ms=1.0
+            # collapses the captured repeat count toward 1 and stops amortizing
+            # the fixed graph-replay overhead - measured run-to-run swings of
+            # 1.7x, and up to 30x on a cold first run. 10 ms keeps the repeat
+            # count comfortably above 1 for every case.
+            target_ms=10.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(case, inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/session_cases.json
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gemma4/session_cases.json
@@ -1,0 +1,103 @@
+{
+  "source_day": "2026-08-01",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.24.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0",
+  "selection": "vLLM's unquantized Triton fused_moe_kernel, the second largest hot path in the gemma-4-26B-A4B-it roofline trace (16.75% across its three token counts). Cases cover the decode step plus both chunked-prefill steps at the session's per-rank expert geometry.",
+  "task_name": "mi355x-gemma4-26b-vllm-triton-fused-moe-20260801",
+  "operator": "fused_moe",
+  "profile_case": "gemma4-moe-decode-m64",
+  "provenance": {
+    "model": "gemma-4-26B-A4B-it",
+    "session_dir": "/shared_nfs/hyperloom-k8s/safe-opt-claw-top-models-forge-google-ge-45b22e20-a1/45b22e20-cd68-4916-918d-48936ecacc00/gemma-4-26B-A4B-it/20260801T162014Z",
+    "tracelens_snapshot": "kernel-agent/runs/20260801T162014Z/20260801T173050Z_tl-c549cffd/tracelens",
+    "trace": "runs/roofline/32dab7b3267b41b691f2d060d8af1ec4/benchmark_vllm_20260801_171753/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1785605122621332807.pt.trace.json.gz",
+    "device_kernel": "fused_moe_kernel",
+    "entry": "vllm/model_executor/layers/fused_moe/fused_moe.py:293 @triton.jit fused_moe_kernel",
+    "call_chain": "vllm::moe_forward -> runner/moe_runner.py:118 _moe_forward -> :779 _forward_impl -> :534 _apply_quant_method -> routed_experts.py:1063 forward_modular -> unquantized_fused_moe_method.py:295 apply -> :313 forward_native -> modular_kernel.py:1623/1354/1205 -> experts/triton_moe.py:198 TritonExperts.apply -> fused_moe.py:772 fused_moe_kernel[grid] (inside invoke_fused_moe_kernel)",
+    "model_entry": "vllm/model_executor/models/gemma4.py:348 Gemma4MoE (router at :251 Gemma4Router, activation=\"gelu_tanh\" at :361, top_k=config.top_k_experts at :350)",
+    "kernel_ownership": "This is the UNQUANTIZED fused_moe_kernel. The sibling task mi355x_vllm_triton_fused_moe_gptq_awq edits the same file but targets fused_moe_kernel_gptq_awq, the int4 weight-only WNA16 path - a different @triton.jit kernel with different operands.",
+    "why_triton": "The ROCm AITER unquantized MoE backend rejects the GELU_TANH activation, so the oracle falls back to Triton. server.log: unquantized.py:252 'Unquantized MoE backend ROCm AITER does not support ... MoEActivation.GELU_TANH activation. Falling back' then unquantized.py:266 'Using TRITON Unquantized MoE backend out of potential backends: [TRITON, BATCHED_TRITON]'. Selection logic lives at fused_moe/oracle/unquantized.py:156.",
+    "workload": "TP=2, EP=1, concurrency=64, ISL=1024, OSL=1024, max_model_len=6144, NUM_PROMPTS=776.",
+    "dtypes": "BF16, unquantized. server.log reports dtype=torch.bfloat16 and quantization=None; config.json carries no quantization_config. The session workload label precision: fp8 is inaccurate - TraceLens metadata/model_info.json also records BF16.",
+    "geometry": "config.json gives num_experts 128, top_k_experts 8, hidden_size 2816, moe_intermediate_size 704 and hidden_activation gelu_pytorch_tanh. EP=1 keeps all 128 experts on every rank while TP=2 shards the intermediate, so the per-rank expert tensors are w13 (128, 2*352, 2816) and w2 (128, 2816, 352). Cross-checked against the trace: gelu_tanh_and_mul takes (512, 704) and returns (512, 352), where 512 = 64 tokens x top-8 and 352 = 704 / TP2.",
+    "calls_per_step": "Each MoE layer launches fused_moe_kernel twice - once for w13 (gate_up) and once for w2 (down) - so the trace's 1800 decode calls are 30 layers x 2 GEMMs x 30 steps. A single harness call through fused_experts_impl covers both launches, matching the trace's aggregation.",
+    "missing_tuned_config": "The session ran with vLLM's fallback MoE config: server.log line 89 warns 'Using default MoE config. Performance might be sub-optimal! Config file not found at .../configs/E=128,N=352,device_name=AMD_Instinct_MI355_OAM.json'. The harness reproduces that condition exactly - no such file ships in the image. configs/ is part of the seeded editable tree, so supplying a tuned config for this shape is a legitimate and probably the highest-leverage optimization.",
+    "trace_shapes": [
+      "k010 hidden (64, 2816) BF16, router logits (64, 128) FP32, decode, 1800 calls = 30 layers x 2 GEMMs x 30 steps, 12.500%, 77339 us",
+      "k011 hidden (7218, 2816), prefill step, 60 calls = 30 layers x 2, 3.326%, 20581 us",
+      "k012 hidden (1080, 2816), prefill step, 60 calls, 0.926%, 5731 us"
+    ],
+    "shapes_fully_determined": "Unlike the attention kernels in this session, MoE is token-parallel: the kernel's shape is fully determined by the token count, expert geometry and top-k, with no hidden per-sequence composition. All three trace token counts are therefore reproduced directly rather than reconstructed.",
+    "surrounding_overhead": "For context, the MoE periphery in the same trace costs another 4.35%: moe_align_block_size 2.33%, moe_sum 1.20% and gelu_tanh_and_mul 0.82%. Those are separate kernels and are not part of this task."
+  },
+  "cases": [
+    {
+      "id": "gemma4-moe-decode-m64",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k010"],
+      "gpu_pct": 12.5,
+      "params": {
+        "phase": "decode",
+        "tokens": 64,
+        "num_experts": 128,
+        "topk": 8,
+        "hidden": 2816,
+        "inter": 352,
+        "activation": "gelu_tanh",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "hidden (64,2816) bf16",
+        "router logits (64,128) fp32",
+        "w13 (128,704,2816) bf16",
+        "w2 (128,2816,352) bf16"
+      ]
+    },
+    {
+      "id": "gemma4-moe-prefill-m1080",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k012"],
+      "gpu_pct": 0.926,
+      "params": {
+        "phase": "prefill",
+        "tokens": 1080,
+        "num_experts": 128,
+        "topk": 8,
+        "hidden": 2816,
+        "inter": 352,
+        "activation": "gelu_tanh",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "hidden (1080,2816) bf16",
+        "router logits (1080,128) fp32",
+        "w13 (128,704,2816) bf16",
+        "w2 (128,2816,352) bf16"
+      ]
+    },
+    {
+      "id": "gemma4-moe-prefill-m7218",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k011"],
+      "gpu_pct": 3.326,
+      "params": {
+        "phase": "prefill",
+        "tokens": 7218,
+        "num_experts": 128,
+        "topk": 8,
+        "hidden": 2816,
+        "inter": 352,
+        "activation": "gelu_tanh",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "hidden (7218,2816) bf16",
+        "router logits (7218,128) fp32",
+        "w13 (128,704,2816) bf16",
+        "w2 (128,2816,352) bf16"
+      ]
+    }
+  ]
+}

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/forge_driver.py
@@ -17,7 +17,7 @@ entirely and no per-run driver authoring can fail.
 How it satisfies the contract without per-kernel reimplementation
 -----------------------------------------------------------------
 Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
-canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
 / ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
 writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
 ``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
@@ -45,7 +45,7 @@ kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
         real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
 
   * Profiling    ``--profile-run``
-        builds ONE case's inputs (``_make(case, correctness=False)``) and launches
+        builds ONE case's inputs (``_make(case)``) and launches
         ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
         couple of profiled launches, one synchronize, exit 0. No timing printed.
 
@@ -150,7 +150,7 @@ def _pick_profile_case(tr) -> dict:
 def _run_profile(tr) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/standalone_driver.py
@@ -170,6 +170,9 @@ REPO_SUBDIR = "vllm_fused_moe"
 KERNEL_FILE = "fused_moe.py"
 EDIT_MODULE_NAME = "vllm.model_executor.layers.fused_moe._ka_fused_moe"
 
+# How many times run_correctness rotates over the full case suite.
+CORRECTNESS_ROUNDS = 3
+
 
 def _configure() -> None:
     for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
@@ -491,15 +494,25 @@ def run_compile() -> None:
 
 
 def run_correctness() -> None:
+    """Check every case, rotating over the whole suite CORRECTNESS_ROUNDS times.
+
+    A single pass only samples a kernel once, so an implementation that is wrong
+    intermittently — a racy cross-workgroup barrier, a reused global scratch
+    buffer — passes whenever the race happens not to fire. Rotating the suite
+    also exposes state that leaks from one case into the next, which a case run
+    back-to-back with itself would not surface. The suite is cheap next to
+    process start-up and JIT, so the extra rounds cost only a few percent.
+    """
     torch = _torch()
-    for case in CASES:
-        inputs = _make(case)
-        got = _run(inputs)
-        torch.cuda.synchronize()
-        torch.testing.assert_close(
-            got, _reference(inputs), atol=0.02, rtol=0.02
-        )
-        print("correctness PASS", case["id"])
+    for _ in range(CORRECTNESS_ROUNDS):
+        for case in CASES:
+            inputs = _make(case)
+            got = _run(inputs)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(
+                got, _reference(inputs), atol=0.02, rtol=0.02
+            )
+            print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/standalone_driver.py
@@ -384,21 +384,14 @@ def _quant_pack_int4(w: "object", group_size: int):
     return packed, scale.to(torch.bfloat16).contiguous(), deq
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
     torch = _torch()
     p = dict(case["params"])
-    if correctness:
-        tokens = min(p["tokens"], 16)
-        num_experts = min(p["num_experts"], 8)
-        topk = min(p["topk"], 2)
-        hidden = min(p["hidden"], 512)
-        inter = min(p["inter"], 128)
-    else:
-        tokens = p["tokens"]
-        num_experts = p["num_experts"]
-        topk = p["topk"]
-        hidden = p["hidden"]
-        inter = p["inter"]
+    tokens = p["tokens"]
+    num_experts = p["num_experts"]
+    topk = p["topk"]
+    hidden = p["hidden"]
+    inter = p["inter"]
     group_size = p["group_size"]
     assert hidden % group_size == 0 and inter % group_size == 0
 
@@ -437,8 +430,8 @@ def _make(case: dict, correctness: bool = False) -> dict:
         "w2": w2_packed,
         "w1_scale": w1_scale,
         "w2_scale": w2_scale,
-        "w1_deq": w1_deq if correctness else None,
-        "w2_deq": w2_deq if correctness else None,
+        "w1_deq": w1_deq,
+        "w2_deq": w2_deq,
         "topk_weights": topk_weights,
         "topk_ids": topk_ids,
         "num_experts": num_experts,
@@ -491,7 +484,7 @@ def _reference(inputs: dict):
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -500,7 +493,7 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
         torch.testing.assert_close(
@@ -512,7 +505,7 @@ def run_correctness() -> None:
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
@@ -637,7 +630,7 @@ def _pick_profile_case(tr, case_id: str) -> dict:
 def _run_profile(tr, case_id: str) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr, case_id)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/task_runner.py
@@ -25,6 +25,9 @@ REPO_SUBDIR = "vllm_fused_moe"
 KERNEL_FILE = "fused_moe.py"
 EDIT_MODULE_NAME = "vllm.model_executor.layers.fused_moe._ka_fused_moe"
 
+# How many times run_correctness rotates over the full case suite.
+CORRECTNESS_ROUNDS = 3
+
 
 def _configure() -> None:
     for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
@@ -294,13 +297,23 @@ def run_compile() -> None:
 
 
 def run_correctness() -> None:
+    """Check every case, rotating over the whole suite CORRECTNESS_ROUNDS times.
+
+    A single pass only samples a kernel once, so an implementation that is wrong
+    intermittently — a racy cross-workgroup barrier, a reused global scratch
+    buffer — passes whenever the race happens not to fire. Rotating the suite
+    also exposes state that leaks from one case into the next, which a case run
+    back-to-back with itself would not surface. The suite is cheap next to
+    process start-up and JIT, so the extra rounds cost only a few percent.
+    """
     torch = _torch()
-    for case in CASES:
-        inputs = _make(case)
-        got = _run(inputs)
-        torch.cuda.synchronize()
-        _assert_close(inputs, got)
-        print("correctness PASS", case["id"])
+    for _ in range(CORRECTNESS_ROUNDS):
+        for case in CASES:
+            inputs = _make(case)
+            got = _run(inputs)
+            torch.cuda.synchronize()
+            _assert_close(inputs, got)
+            print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:

--- a/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq/scripts/task_runner.py
@@ -103,21 +103,20 @@ def _quant_pack_int4(w: "object", group_size: int):
     return packed, scale.to(torch.bfloat16).contiguous(), deq
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+    """
     torch = _torch()
     p = dict(case["params"])
-    if correctness:
-        tokens = min(p["tokens"], 16)
-        num_experts = min(p["num_experts"], 8)
-        topk = min(p["topk"], 2)
-        hidden = min(p["hidden"], 512)
-        inter = min(p["inter"], 128)
-    else:
-        tokens = p["tokens"]
-        num_experts = p["num_experts"]
-        topk = p["topk"]
-        hidden = p["hidden"]
-        inter = p["inter"]
+    tokens = p["tokens"]
+    num_experts = p["num_experts"]
+    topk = p["topk"]
+    hidden = p["hidden"]
+    inter = p["inter"]
     group_size = p["group_size"]
     assert hidden % group_size == 0 and inter % group_size == 0
 
@@ -156,8 +155,10 @@ def _make(case: dict, correctness: bool = False) -> dict:
         "w2": w2_packed,
         "w1_scale": w1_scale,
         "w2_scale": w2_scale,
-        "w1_deq": w1_deq if correctness else None,
-        "w2_deq": w2_deq if correctness else None,
+        # The dequantized weights back the reference. They are kept for the
+        # performance run too, because the timed invocation is validated as well.
+        "w1_deq": w1_deq,
+        "w2_deq": w2_deq,
         "topk_weights": topk_weights,
         "topk_ids": topk_ids,
         "num_experts": num_experts,
@@ -185,32 +186,108 @@ def _run(inputs: dict):
 
 
 def _reference(inputs: dict):
+    """Dequantized torch reference for the int4 fused MoE.
+
+    Iterates experts rather than (token, slot) pairs: every token routed to an
+    expert is one batched matmul instead of a Python step. The loop this replaces
+    ran M*topk times and synchronised on ``topk_ids`` each step, which is what
+    made a full-shape correctness run impractical.
+
+    The dequantized weights stay bf16 and are cast per expert, so the reference
+    never materialises an fp32 copy of the whole expert bank.
+    """
     torch = _torch()
     import torch.nn.functional as F
 
     x = inputs["x"].float()  # [M, hidden]
-    w1d = inputs["w1_deq"].float()  # [E, 2*inter, hidden]
-    w2d = inputs["w2_deq"].float()  # [E, hidden, inter]
+    w1d = inputs["w1_deq"]  # [E, 2*inter, hidden] bf16
+    w2d = inputs["w2_deq"]  # [E, hidden, inter] bf16
     tw = inputs["topk_weights"].float()  # [M, topk]
-    tid = inputs["topk_ids"]  # [M, topk]
+    tid = inputs["topk_ids"].long()  # [M, topk]
     inter = inputs["inter"]
     M, hidden = x.shape
+    topk = tid.shape[1]
+
     out = torch.zeros((M, hidden), device="cuda", dtype=torch.float32)
-    for m in range(M):
-        acc = torch.zeros((hidden,), device="cuda", dtype=torch.float32)
-        for j in range(tid.shape[1]):
-            e = int(tid[m, j].item())
-            gu = x[m] @ w1d[e].t()  # [2*inter]
-            gate = gu[:inter]
-            up = gu[inter:]
-            act = F.silu(gate) * up  # [inter]
-            acc = acc + float(tw[m, j].item()) * (act @ w2d[e].t())
-        out[m] = acc
+    flat_expert = tid.reshape(-1)
+    flat_token = torch.arange(
+        M, device=x.device
+    ).unsqueeze(1).expand(M, topk).reshape(-1)
+    flat_weight = tw.reshape(-1)
+
+    order = torch.argsort(flat_expert)
+    sorted_expert = flat_expert[order]
+    # One boundary per expert, so slicing needs no per-pair host round trip.
+    counts = torch.bincount(sorted_expert, minlength=w1d.shape[0])
+    offsets = torch.cumsum(counts, dim=0).tolist()
+    start = 0
+    for expert, stop in enumerate(offsets):
+        if stop == start:
+            continue
+        rows = flat_token[order[start:stop]]
+        gate_up = x[rows] @ w1d[expert].float().t()  # [n, 2*inter]
+        act = F.silu(gate_up[:, :inter]) * gate_up[:, inter:]
+        contrib = (act @ w2d[expert].float().t()) * flat_weight[
+            order[start:stop]
+        ].unsqueeze(-1)
+        out.index_add_(0, rows, contrib)
+        start = stop
     return out.to(torch.bfloat16)
 
 
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.02, rtol=0.02)
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the activation in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input address, so writing through it
+    changes what the scored kernel consumes. Only ``x`` is redrawn: the routing
+    tensors are kernel inputs rather than something the kernel derives, and the
+    packed weights have a dequantized twin that would have to be rebuilt in
+    lockstep for no benefit here.
+    """
+    torch = _torch()
+    torch.manual_seed(53)
+    inputs["x"].normal_()
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    group_size = params["group_size"]
+    params["tokens"] = min(params["tokens"], 16)
+    params["num_experts"] = min(params["num_experts"], 8)
+    params["topk"] = min(params["topk"], 2)
+    # Both reductions must stay a whole number of quantization groups.
+    params["hidden"] = max(group_size, min(params["hidden"], 512))
+    params["inter"] = max(group_size, min(params["inter"], 128))
+    return {**case, "params": params}
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against a freshly perturbed
+    activation and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(_compile_smoke_case(CASES[0]))
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -219,28 +296,29 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
-        torch.testing.assert_close(
-            got, _reference(inputs), atol=0.02, rtol=0.02
-        )
+        _assert_close(inputs, got)
         print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=10,
             repetition=100,
             target_ms=1.0,
             max_graph_repeats=1000,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case.get("model"),

--- a/tasks/image_kernel/mi355x_vllm_triton_kda_linear_attn_kimi_k3/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_kda_linear_attn_kimi_k3/scripts/forge_driver.py
@@ -81,7 +81,7 @@ def _run_correctness(tr) -> int:
 
     worst_db = math.inf
     for case in tr.CASES:
-        inp = tr._prepare(case, correctness=True)
+        inp = tr._prepare(case)
         ref = tr._golden(inp)          # BEFORE _run: the kernels mutate the state
         out, _state = tr._run(inp)
         torch.cuda.synchronize()
@@ -102,7 +102,7 @@ def _run_bench(tr, warmup: int, iters: int) -> int:
 
     results = []
     for case in tr.CASES:
-        inp = tr._prepare(case, correctness=False)
+        inp = tr._prepare(case)
         tr._run(inp)                   # settle the Triton JIT before capture
         torch.cuda.synchronize()
         bench = case.get("benchmark", {})
@@ -134,7 +134,7 @@ def _run_profile(tr) -> int:
     import torch
 
     case = max(tr.CASES, key=_case_cost)
-    inp = tr._prepare(case, correctness=False)
+    inp = tr._prepare(case)
     for _ in range(3):                 # settle Triton JIT / autotune selection
         tr._run(inp)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_kda_linear_attn_kimi_k3/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_kda_linear_attn_kimi_k3/scripts/task_runner.py
@@ -105,7 +105,15 @@ def _kda_ops():
 # --------------------------------------------------------------------------- #
 # Inputs
 # --------------------------------------------------------------------------- #
-def _prepare(case: dict, correctness: bool = False) -> dict:
+def _prepare(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one. The golden is an O(T) float64 recurrence, but it
+    costs roughly 65 us per token, so even the 32768-token case stays a couple of
+    seconds.
+    """
     torch = _torch()
     p = dict(case["params"])
     H = p["num_heads"]          # per-rank heads (K3 num_heads=96, TP=8 -> 12)
@@ -113,11 +121,6 @@ def _prepare(case: dict, correctness: bool = False) -> dict:
     mode = p["mode"]            # "chunk" (prefill) | "packed_decode" (k007)
     num_seqs = p["num_seqs"]
     seq_len = p["seq_len"]
-    if correctness:
-        # The golden is an O(T) float64 recurrence, so cap the token count. 320
-        # still spans 5 chunks at chunk_size=64 and exercises the cross-chunk path.
-        seq_len = min(seq_len, 320)
-        num_seqs = min(num_seqs, 4)
     total_t = num_seqs * seq_len
 
     gen = torch.Generator(device="cuda").manual_seed(int(case.get("seed", 23)))
@@ -243,7 +246,7 @@ def _golden(inp: dict):
 # Modes
 # --------------------------------------------------------------------------- #
 def run_compile() -> None:
-    inp = _prepare(CASES[0], correctness=True)
+    inp = _prepare(CASES[0])
     out, _state = _run(inp)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)}")
@@ -252,7 +255,7 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inp = _prepare(case, correctness=True)
+        inp = _prepare(case)
         ref = _golden(inp)          # BEFORE _run: the kernels mutate the state
         out, _state = _run(inp)
         torch.cuda.synchronize()
@@ -282,9 +285,16 @@ def run_correctness() -> None:
 
 
 def run_performance() -> None:
+    # Sibling tasks additionally validate the timed invocation itself (they pass a
+    # `timed_run` collector to the benchmark and assert on the buffers it wrote).
+    # That is not done here yet: KDA advances `inp["state"]` in place, and a
+    # captured graph chains `benchmark_effective_repeats` invocations, so the
+    # timed output corresponds to the recurrence applied that many times rather
+    # than once. Checking it needs a golden that carries state across repeats,
+    # which must be validated on a build that can run the operator.
     rows = []
     for case in CASES:
-        inp = _prepare(case, correctness=False)
+        inp = _prepare(case)
         _run(inp)
         _torch().cuda.synchronize()
         bench = case.get("benchmark", {})

--- a/tasks/image_kernel/mi355x_vllm_triton_paged_attention_2d/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_paged_attention_2d/scripts/task_runner.py
@@ -146,21 +146,9 @@ def _make(case: dict) -> dict:
     phys_block = block_table[seq_idx, pos // block_size].long()
     slot_mapping = (phys_block * block_size + (pos % block_size)).reshape(-1)
 
-    import vllm._custom_ops as ops
-
     one = torch.ones(1, device="cuda", dtype=torch.float32)
-    ops.reshape_and_cache(
-        key.reshape(-1, num_kv_heads, head_size),
-        value.reshape(-1, num_kv_heads, head_size),
-        key_cache,
-        value_cache,
-        slot_mapping,
-        "auto",
-        one,
-        one,
-    )
 
-    return {
+    inputs = {
         "cfg": case,
         "module": _load_kernel_module(),
         "query": query,
@@ -175,7 +163,50 @@ def _make(case: dict) -> dict:
         "max_seq_len": ctx_len,
         "scale": scale,
         "one": one,
+        "slot_mapping": slot_mapping,
+        "num_kv_heads": num_kv_heads,
+        "head_size": head_size,
     }
+    _fill_kv_cache(inputs)
+    return inputs
+
+
+def _fill_kv_cache(inputs: dict) -> None:
+    """Page the contiguous key/value into the cache the kernel reads.
+
+    The reference reads ``key``/``value`` while the kernel reads the paged cache,
+    so the two must be refreshed together or they stop describing the same
+    workload.
+    """
+    import vllm._custom_ops as ops
+
+    num_kv_heads = inputs["num_kv_heads"]
+    head_size = inputs["head_size"]
+    ops.reshape_and_cache(
+        inputs["key"].reshape(-1, num_kv_heads, head_size),
+        inputs["value"].reshape(-1, num_kv_heads, head_size),
+        inputs["key_cache"],
+        inputs["value_cache"],
+        inputs["slot_mapping"],
+        "auto",
+        inputs["one"],
+        inputs["one"],
+    )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. Fresh values stop an output
+    buffer that the kernel never wrote from matching the reference by accident.
+    """
+    torch = _torch()
+    torch.manual_seed(37)
+    inputs["query"].normal_()
+    inputs["key"].normal_()
+    inputs["value"].normal_()
+    _fill_kv_cache(inputs)
 
 
 def _run(inputs: dict):
@@ -217,6 +248,27 @@ def _reference(inputs: dict):
     return torch.stack(outputs).to(inputs["output"].dtype)
 
 
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.08, rtol=0.08)
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    # The output is harness-owned, so poison it directly; a kernel that stops
+    # writing keeps the poison instead of a plausible stale result.
+    inputs["output"].fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
 def run_compile() -> None:
     inputs = _make(_compile_smoke_case(CASES[0]))
     _run(inputs)
@@ -230,9 +282,7 @@ def run_correctness() -> None:
         inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
-        torch.testing.assert_close(
-            got, _reference(inputs), atol=0.08, rtol=0.08
-        )
+        _assert_close(inputs, got)
         print("correctness PASS", case["id"])
 
 
@@ -242,13 +292,16 @@ def run_performance() -> None:
         inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=10,
             repetition=100,
             target_ms=1.0,
             max_graph_repeats=1000,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case.get("model"),

--- a/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/forge_driver.py
@@ -17,7 +17,7 @@ entirely and no per-run driver authoring can fail.
 How it satisfies the contract without per-kernel reimplementation
 -----------------------------------------------------------------
 Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
-canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
 / ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
 writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
 ``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
@@ -45,7 +45,7 @@ kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
         real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
 
   * Profiling    ``--profile-run``
-        builds ONE case's inputs (``_make(case, correctness=False)``) and launches
+        builds ONE case's inputs (``_make(case)``) and launches
         ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
         couple of profiled launches, one synchronize, exit 0. No timing printed.
 
@@ -150,7 +150,7 @@ def _pick_profile_case(tr) -> dict:
 def _run_profile(tr) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/standalone_driver.py
@@ -349,16 +349,16 @@ def _load_kernel_module():
     return module
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
     torch = _torch()
     params = dict(case["params"])
-    num_queries = min(params["num_queries"], 32) if correctness else params["num_queries"]
+    num_queries = params["num_queries"]
     num_heads = params["num_heads"]
     head_dim = params["head_dim"]
     nope_head_dim = params["nope_head_dim"]
     rope_head_dim = params["rope_head_dim"]
-    num_kv = min(params["num_kv"], 1024) if correctness else params["num_kv"]
-    topk = min(params["topk"], 128) if correctness else params["topk"]
+    num_kv = params["num_kv"]
+    topk = params["topk"]
     per_q = min(topk, num_kv)
     dtype = torch.bfloat16
     scale = head_dim**-0.5
@@ -426,7 +426,7 @@ def _reference(inputs: dict):
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -435,7 +435,7 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
         torch.testing.assert_close(
@@ -447,7 +447,7 @@ def run_correctness() -> None:
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
@@ -572,7 +572,7 @@ def _pick_profile_case(tr, case_id: str) -> dict:
 def _run_profile(tr, case_id: str) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr, case_id)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_sparse_attn_prefill_ragged/scripts/task_runner.py
@@ -19,6 +19,10 @@ SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
 OPERATOR = SPEC["operator"]
 CASES = SPEC["cases"]
 
+# Queries processed per reference chunk. Bounds the gathered
+# (chunk, per_q, head_dim) float buffer, which dominates reference memory.
+_REFERENCE_QUERY_CHUNK = 512
+
 REPO_SUBDIR = "vllm_v1_attention_ops"
 KERNEL_FILE = "rocm_aiter_mla_sparse.py"
 EDIT_MODULE_NAME = "vllm.v1.attention.ops._ka_rocm_aiter_mla_sparse"
@@ -77,16 +81,22 @@ def _load_kernel_module():
     return module
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+    """
     torch = _torch()
     params = dict(case["params"])
-    num_queries = min(params["num_queries"], 32) if correctness else params["num_queries"]
+    num_queries = params["num_queries"]
     num_heads = params["num_heads"]
     head_dim = params["head_dim"]
     nope_head_dim = params["nope_head_dim"]
     rope_head_dim = params["rope_head_dim"]
-    num_kv = min(params["num_kv"], 1024) if correctness else params["num_kv"]
-    topk = min(params["topk"], 128) if correctness else params["topk"]
+    num_kv = params["num_kv"]
+    topk = params["topk"]
     per_q = min(topk, num_kv)
     dtype = torch.bfloat16
     scale = head_dim**-0.5
@@ -135,26 +145,89 @@ def _run(inputs: dict):
 
 
 def _reference(inputs: dict):
+    """Sparse MLA attention reference: gather the selected KV, then dense attend.
+
+    ``_make`` emits a uniform CSR (every query selects the same ``per_q``
+    positions), so this batches into gather + einsum instead of walking queries in
+    Python. The loop it replaces synchronised on ``indptr`` once per query, which
+    is what made a full-shape correctness run impractical.
+
+    Queries are chunked because the gathered KV is ``(chunk, per_q, head_dim)``
+    floats, which reaches tens of GB at the scored shape if done in one go.
+    """
     torch = _torch()
-    q = inputs["q"].float()  # (sq, H, D)
+    q = inputs["q"]  # (sq, H, D) bf16
     kv = inputs["kv"].float()  # (skv, D)
-    indices = inputs["indices"]
     indptr = inputs["indptr"]
     scale = inputs["scale"]
-    outputs = []
-    for i in range(q.shape[0]):
-        start = int(indptr[i].item())
-        end = int(indptr[i + 1].item())
-        sel = indices[start:end].long()
-        kv_sel = kv[sel]  # (kv_len, D) — MLA latent used as both K and V
-        scores = (q[i] @ kv_sel.t()) * scale  # (H, kv_len)
+
+    sq = q.shape[0]
+    widths = (indptr[1:] - indptr[:-1]).unique()
+    assert widths.numel() == 1, "reference expects a uniform CSR from _make"
+    per_q = int(widths.item())
+    sel = inputs["indices"].view(sq, per_q).long()
+
+    out = torch.empty_like(q)
+    chunk = max(1, min(sq, _REFERENCE_QUERY_CHUNK))
+    for start in range(0, sq, chunk):
+        stop = min(start + chunk, sq)
+        kv_sel = kv[sel[start:stop]]  # (c, per_q, D), latent is both K and V
+        scores = (
+            torch.einsum("qhd,qkd->qhk", q[start:stop].float(), kv_sel) * scale
+        )
         probs = torch.softmax(scores, dim=-1)
-        outputs.append(probs @ kv_sel)  # (H, D)
-    return torch.stack(outputs).to(torch.bfloat16)
+        out[start:stop] = torch.einsum("qhk,qkd->qhd", probs, kv_sel).to(out.dtype)
+    return out
+
+
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.08, rtol=0.08)
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. The CSR selection is structure
+    rather than data, so it stays fixed.
+    """
+    torch = _torch()
+    torch.manual_seed(47)
+    inputs["q"].normal_()
+    inputs["kv"].normal_()
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    smoke_case = {**case, "params": dict(case["params"])}
+    smoke_case["params"]["num_queries"] = min(case["params"]["num_queries"], 32)
+    smoke_case["params"]["num_kv"] = min(case["params"]["num_kv"], 1024)
+    smoke_case["params"]["topk"] = min(case["params"]["topk"], 128)
+    return smoke_case
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(_compile_smoke_case(CASES[0]))
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -163,28 +236,29 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
-        torch.testing.assert_close(
-            got, _reference(inputs), atol=0.08, rtol=0.08
-        )
+        _assert_close(inputs, got)
         print("correctness PASS", case["id"])
 
 
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=10,
             repetition=100,
             target_ms=1.0,
             max_graph_repeats=1000,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case.get("model"),

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/forge_driver.py
@@ -17,7 +17,7 @@ entirely and no per-run driver authoring can fail.
 How it satisfies the contract without per-kernel reimplementation
 -----------------------------------------------------------------
 Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
-canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
 / ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
 writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
 ``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
@@ -47,7 +47,7 @@ kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
         real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
 
   * Profiling    ``--profile-run``
-        builds ONE case's inputs (``_make(case, correctness=False)``) and launches
+        builds ONE case's inputs (``_make(case)``) and launches
         ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
         couple of profiled launches, one synchronize, exit 0. No timing printed.
 
@@ -152,7 +152,7 @@ def _pick_profile_case(tr) -> dict:
 def _run_profile(tr) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/standalone_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/standalone_driver.py
@@ -365,10 +365,10 @@ def _torch():
     return torch
 
 
-def _make_attention(case: dict, correctness: bool = False) -> dict:
+def _make_attention(case: dict) -> dict:
     torch = _torch()
     params = dict(case["params"])
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
+    ctx_len = params["ctx_len"]
     num_seqs = params["q_tokens"]
     num_q_heads = params["num_q_heads"]
     num_kv_heads = params["num_kv_heads"]
@@ -468,7 +468,7 @@ def _attention_reference(inputs: dict):
 
 
 def run_compile() -> None:
-    inputs = _make(CASES[0], correctness=True)
+    inputs = _make(CASES[0])
     _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -477,7 +477,7 @@ def run_compile() -> None:
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
@@ -518,8 +518,8 @@ def run_performance() -> None:
     _write_report(rows)
 
 
-def _make(case: dict, correctness: bool = False) -> dict:
-    return _make_attention(case, correctness)
+def _make(case: dict) -> dict:
+    return _make_attention(case)
 
 
 def _run(inputs: dict):
@@ -529,7 +529,7 @@ def _run(inputs: dict):
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        inputs = _make(case, correctness=True)
+        inputs = _make(case)
         got = _run(inputs)
         torch.cuda.synchronize()
         torch.testing.assert_close(
@@ -607,7 +607,7 @@ def _pick_profile_case(tr, case_id: str) -> dict:
 def _run_profile(tr, case_id: str) -> int:
     torch = tr._torch()
     case = _pick_profile_case(tr, case_id)
-    inputs = tr._make(case, correctness=False)
+    inputs = tr._make(case)
     for _ in range(5):          # settle Triton JIT / autotune selection
         tr._run(inputs)
     torch.cuda.synchronize()

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention/scripts/task_runner.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
-import math
 import os
 import sys
 from pathlib import Path
@@ -95,27 +93,22 @@ def _torch():
     return torch
 
 
-def _import_aiter():
-    import aiter
-
-    return aiter
-
-
 def _make_attention(
     case: dict,
-    correctness: bool = False,
     *,
     ctx_len_override: int | None = None,
     expected_path: str | None = None,
 ) -> dict:
+    """Build the attention case at its scored ``ctx_len``.
+
+    ``ctx_len_override`` exists only so correctness can additionally exercise the
+    2d dispatch, which the scored ``ctx_len`` does not reach. It is never used to
+    shrink the scored shape itself.
+    """
     torch = _torch()
     params = dict(case["params"])
     ctx_len = (
-        ctx_len_override
-        if ctx_len_override is not None
-        else min(params["ctx_len"], 128)
-        if correctness
-        else params["ctx_len"]
+        ctx_len_override if ctx_len_override is not None else params["ctx_len"]
     )
     num_seqs = params["q_tokens"]
     num_q_heads = params["num_q_heads"]
@@ -175,7 +168,6 @@ def _attention_correctness_inputs(case: dict) -> list[tuple[str, dict]]:
             "2d",
             _make_attention(
                 case,
-                correctness=True,
                 ctx_len_override=min(full_ctx_len, 128),
                 expected_path="2d",
             ),
@@ -184,7 +176,6 @@ def _attention_correctness_inputs(case: dict) -> list[tuple[str, dict]]:
             "3d",
             _make_attention(
                 case,
-                correctness=True,
                 ctx_len_override=full_ctx_len,
                 expected_path="3d",
             ),
@@ -282,550 +273,75 @@ def _attention_reference(inputs: dict):
     return torch.stack(outputs).to(inputs["output"].dtype)
 
 
-def _make_gemm(case: dict, correctness: bool = False) -> dict:
+def _assert_operator() -> None:
+    """Guard against this runner being pointed at a different operator.
+
+    The file was specialized to ``unified_attention``; the other builders, callers and
+    references from the shared template are gone. Failing loudly beats silently
+    running the wrong workload.
+    """
+    if OPERATOR != "unified_attention":
+        raise KeyError(f"{OPERATOR}: this runner only implements unified_attention")
+
+
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one.
+
+    Kept as the entry point the task drivers call, alongside :func:`_run`.
+    """
+    _assert_operator()
+    return _make_attention(case)
+
+
+def _assert_attention_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(
+        got, _attention_reference(inputs), atol=0.08, rtol=0.08
+    )
+
+
+def _perturb_attention_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. Fresh values stop an output
+    buffer that the kernel never wrote from matching the reference by accident.
+    """
     torch = _torch()
-    params = dict(case["params"])
-    m = min(params["m"], 64) if correctness else params["m"]
-    n = params["n"]
-    k = params["k"]
-    torch.manual_seed(9)
-    x = (torch.rand((m, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    weight = (torch.rand((n, k), device="cuda") * 0.2 - 0.1).to(
-        torch.float8_e4m3fn
-    )
-    x_scale = (
-        torch.rand((m, k // 128), device="cuda", dtype=torch.float32) * 0.1
-        + 0.01
-    )
-    w_scale = (
-        torch.rand(
-            (math.ceil(n / 128), k // 128),
-            device="cuda",
-            dtype=torch.float32,
-        )
-        * 0.1
-        + 0.01
-    )
-    return {
-        "cfg": case,
-        "x": x,
-        "weight": weight,
-        "x_scale": x_scale,
-        "w_scale": w_scale,
-        "shape": [m, n, k],
-    }
-
-
-def _run_gemm(inputs: dict):
-    return _import_aiter().gemm_a8w8_blockscale(
-        inputs["x"],
-        inputs["weight"],
-        inputs["x_scale"],
-        inputs["w_scale"],
-        _torch().bfloat16,
-    )
-
-
-def _gemm_reference(inputs: dict):
-    torch = _torch()
-    m, n, k = inputs["shape"]
-    x = (
-        inputs["x"].float()
-        * inputs["x_scale"].repeat_interleave(128, dim=1)[:, :k]
-    )
-    weight = (
-        inputs["weight"].float()
-        * inputs["w_scale"]
-        .repeat_interleave(128, dim=0)
-        .repeat_interleave(128, dim=1)[:n, :k]
-    )
-    return (x @ weight.t()).to(torch.bfloat16)
-
-
-def _make_quant(case: dict) -> dict:
-    torch = _torch()
-    torch.manual_seed(11)
-    shape = tuple(case["params"]["shape"])
-    input_tensor = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
-    output = torch.empty(shape, device="cuda", dtype=torch.float8_e4m3fn)
-    scale = torch.empty(1, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "input": input_tensor,
-        "output": output,
-        "scale": scale,
-    }
-
-
-def _run_quant(inputs: dict):
-    _import_aiter().dynamic_per_tensor_quant(
-        inputs["output"], inputs["input"], inputs["scale"]
-    )
-    return inputs["output"]
-
-
-def _load_mhc_module():
-    # Import the installed package first so its custom ops are registered once.
-    # Then suppress registration while loading the editable workspace copy;
-    # otherwise both copies call direct_register_custom_op with the same names.
-    import vllm.model_executor.kernels.mhc.tilelang_kernels  # noqa: F401
-    import vllm.utils.torch_utils as torch_utils
-
-    path = WORKSPACE / "mhc" / "tilelang.py"
-    spec = importlib.util.spec_from_file_location("ka_mhc_tilelang", path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    original_register = torch_utils.direct_register_custom_op
-    torch_utils.direct_register_custom_op = lambda *args, **kwargs: None
-    try:
-        spec.loader.exec_module(module)
-    finally:
-        torch_utils.direct_register_custom_op = original_register
-    return module
-
-
-def _make_mhc(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    tokens = min(params["tokens"], 64) if correctness else params["tokens"]
-    hidden_size = params["hidden_size"]
-    hc_mult = params["hc_mult"]
-    torch.manual_seed(13)
-    x = torch.randn(
-        (tokens, hidden_size), device="cuda", dtype=torch.bfloat16
-    )
-    residual = torch.randn(
-        (tokens, hc_mult, hidden_size),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    post_mix = torch.randn(
-        (tokens, hc_mult, 1), device="cuda", dtype=torch.float32
-    )
-    comb_mix = torch.softmax(
-        torch.randn(
-            (tokens, hc_mult, hc_mult),
-            device="cuda",
-            dtype=torch.float32,
-        ),
-        dim=-1,
-    )
-    hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
-    fn = (
-        torch.randn(
-            (hc_mult3, hc_mult * hidden_size),
-            device="cuda",
-            dtype=torch.float32,
-        )
-        * 0.001
-    )
-    hc_scale = torch.ones(3, device="cuda", dtype=torch.float32)
-    hc_base = torch.zeros(hc_mult3, device="cuda", dtype=torch.float32)
-    return {
-        "cfg": case,
-        "params": params,
-        "x": x,
-        "residual": residual,
-        "post_mix": post_mix,
-        "comb_mix": comb_mix,
-        "fn": fn,
-        "hc_scale": hc_scale,
-        "hc_base": hc_base,
-        "module": _load_mhc_module(),
-    }
-
-
-def _run_mhc(inputs: dict):
-    params = inputs["params"]
-    return inputs["module"].mhc_fused_post_pre_tilelang(
-        inputs["x"],
-        inputs["residual"],
-        inputs["post_mix"],
-        inputs["comb_mix"],
-        inputs["fn"],
-        inputs["hc_scale"],
-        inputs["hc_base"],
-        params["rms_eps"],
-        params["hc_pre_eps"],
-        params["hc_sinkhorn_eps"],
-        params["hc_post_mult"],
-        params["sinkhorn_repeat"],
-        1,
-        1,
-        None,
-        0.0,
-    )
-
-
-def _mhc_reference(inputs: dict):
-    from vllm.model_executor.kernels.mhc.torch import mhc_post_torch, mhc_pre_torch
-
-    params = inputs["params"]
-    residual = mhc_post_torch(
-        inputs["x"],
-        inputs["residual"],
-        inputs["post_mix"],
-        inputs["comb_mix"],
-    )
-    post_mix, comb_mix, layer_input = mhc_pre_torch(
-        residual,
-        inputs["fn"],
-        inputs["hc_scale"],
-        inputs["hc_base"],
-        params["rms_eps"],
-        params["hc_pre_eps"],
-        params["hc_sinkhorn_eps"],
-        params["hc_post_mult"],
-        params["sinkhorn_repeat"],
-    )
-    return residual, post_mix, comb_mix, layer_input
-
-
-def _make_mla(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    params = dict(case["params"])
-    batch = min(params["batch"], 64) if correctness else params["batch"]
-    ctx_len = min(params["ctx_len"], 128) if correctness else params["ctx_len"]
-    capacity = (
-        min(params["kv_capacity"], batch * ctx_len + 1024)
-        if correctness
-        else params["kv_capacity"]
-    )
-    torch.manual_seed(17)
-    query = torch.randn(
-        (batch, params["num_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
+    torch.manual_seed(41)
+    inputs["query"].normal_()
+    # key/value may be fp8 views of one bf16 draw, so rebuild them the same way
+    # _make_attention did instead of writing noise straight into the fp8 buffers.
     kv = torch.randn(
-        (capacity, params["page_size"], params["kv_heads"], params["qk_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
+        inputs["key"].shape, device="cuda", dtype=torch.bfloat16
     )
-    output = torch.empty(
-        (batch, params["num_heads"], params["v_dim"]),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
-    qo_indptr = torch.arange(batch + 1, device="cuda", dtype=torch.int32)
-    kv_indptr = torch.arange(
-        0, (batch + 1) * ctx_len, ctx_len, device="cuda", dtype=torch.int32
-    )
-    kv_indices = (
-        torch.arange(batch * ctx_len, device="cuda", dtype=torch.int32)
-        % capacity
-    )
-    last_page_lens = torch.ones(batch, device="cuda", dtype=torch.int32)
-    return {
-        "cfg": case,
-        "params": params,
-        "query": query,
-        "kv": kv,
-        "output": output,
-        "qo_indptr": qo_indptr,
-        "kv_indptr": kv_indptr,
-        "kv_indices": kv_indices,
-        "last_page_lens": last_page_lens,
-        "ctx_len": ctx_len,
-    }
+    inputs["key"].copy_(kv.to(inputs["key"].dtype))
+    inputs["value"].copy_((kv * 0.7).to(inputs["value"].dtype))
 
 
-def _run_mla(inputs: dict):
-    params = inputs["params"]
-    return _import_aiter().mla.mla_decode_fwd(
-        inputs["query"],
-        inputs["kv"],
-        inputs["output"],
-        inputs["qo_indptr"],
-        inputs["kv_indptr"],
-        inputs["kv_indices"],
-        inputs["last_page_lens"],
-        1,
-        params["page_size"],
-        params["kv_heads"],
-        params["qk_dim"] ** -0.5,
-        num_kv_splits=None,
-        return_lse=False,
-    )
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
 
-
-def _mla_reference(inputs: dict):
-    torch = _torch()
-    query = inputs["query"].float()
-    outputs = []
-    for seq_idx in range(query.shape[0]):
-        start = seq_idx * inputs["ctx_len"]
-        end = (seq_idx + 1) * inputs["ctx_len"]
-        indices = inputs["kv_indices"][start:end]
-        kv = inputs["kv"][indices].reshape(
-            -1,
-            inputs["params"]["kv_heads"],
-            inputs["params"]["qk_dim"],
-        )
-        key = kv
-        value = kv[..., : inputs["params"]["v_dim"]]
-        ratio = query.shape[1] // key.shape[1]
-        key = key.repeat_interleave(ratio, dim=1)
-        value = value.repeat_interleave(ratio, dim=1)
-        scores = (
-            torch.einsum("hd,khd->hk", query[seq_idx], key.float())
-            * (inputs["params"]["qk_dim"] ** -0.5)
-        )
-        probs = torch.softmax(scores, dim=-1)
-        outputs.append(torch.einsum("hk,khd->hd", probs, value.float()))
-    return torch.stack(outputs).to(inputs["output"].dtype)
-
-
-def _moe_enums(params: dict, aiter):
-    quant_type = {
-        "per_Tensor": aiter.QuantType.per_Tensor,
-        "per_1x128": aiter.QuantType.per_1x128,
-        "per_1x32": aiter.QuantType.per_1x32,
-    }[params["quant_type"]]
-    activation = {
-        "silu": aiter.ActivationType.Silu,
-        "swiglu": aiter.ActivationType.Swiglu,
-    }[params["activation"]]
-    return quant_type, activation
-
-
-def _prepare_moe(case: dict, correctness: bool = False) -> dict:
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import fused_topk
-    from aiter.ops.shuffle import (
-        shuffle_scale_a16w4,
-        shuffle_weight,
-        shuffle_weight_a16w4,
-    )
-    from aiter.utility import fp4_utils
-
-    params = dict(case["params"])
-    token = min(params["token"], 64) if correctness else params["token"]
-    experts = params["experts"]
-    model_dim = params["model_dim"]
-    inter_dim = params["inter_dim"]
-    topk = params["topk"]
-    quant_type, activation = _moe_enums(params, aiter)
-    activation_dtype = {
-        "fp8": dtypes.fp8,
-        "fp4": dtypes.fp4x2,
-        "bf16": dtypes.bf16,
-    }[params["a_dtype"]]
-    weight_dtype = {"fp8": dtypes.fp8, "fp4": dtypes.fp4x2}[
-        params["w_dtype"]
-    ]
-
-    torch.manual_seed(19)
-    hidden = (
-        torch.randn(
-            (token, model_dim), device="cuda", dtype=dtypes.bf16
-        )
-        * 0.1
-    )
-    w1 = (
-        torch.randn(
-            (experts, inter_dim * 2, model_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    w2 = (
-        torch.randn(
-            (experts, model_dim, inter_dim),
-            device="cuda",
-            dtype=dtypes.bf16,
-        )
-        * 0.03
-    )
-    score = torch.randn((token, experts), device="cuda", dtype=dtypes.bf16)
-    topk_weights, topk_ids = fused_topk(hidden, score, topk, True)
-    torch_quant = aiter.get_torch_quant(quant_type)
-
-    if quant_type == aiter.QuantType.per_Tensor:
-        w1_quant, w1_scale = aiter.pertoken_quant(
-            w1.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w2_quant, w2_scale = aiter.pertoken_quant(
-            w2.view(experts, -1), quant_dtype=weight_dtype
-        )
-        w1_quant = w1_quant.view(w1.shape)
-        w2_quant = w2_quant.view(w2.shape)
-    else:
-        w1_quant, w1_scale = torch_quant(w1, quant_dtype=weight_dtype)
-        w2_quant, w2_scale = torch_quant(w2, quant_dtype=weight_dtype)
-
-    if quant_type == aiter.QuantType.per_1x32:
-        w1_quant = w1_quant.view(
-            experts, w1.shape[1], w1.shape[2] // 2
-        )
-        w2_quant = w2_quant.view(
-            experts, w2.shape[1], w2.shape[2] // 2
-        )
-
-    w1_reference = w1_quant
-    w2_reference = w2_quant
-    if (
-        quant_type == aiter.QuantType.per_1x32
-        and activation_dtype in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and weight_dtype == dtypes.fp4x2
-    ):
-        w1_runtime = shuffle_weight_a16w4(w1_quant, 16, True)
-        w1_scale_runtime = shuffle_scale_a16w4(
-            w1_scale, experts, True
-        )
-        w2_runtime = shuffle_weight_a16w4(w2_quant, 16, False)
-        w2_scale_runtime = shuffle_scale_a16w4(
-            w2_scale, experts, False
-        )
-    else:
-        w1_runtime = shuffle_weight(w1_quant, layout=(16, 16))
-        w2_runtime = shuffle_weight(w2_quant, layout=(16, 16))
-        w1_scale_runtime = fp4_utils.e8m0_shuffle(w1_scale)
-        w2_scale_runtime = fp4_utils.e8m0_shuffle(w2_scale)
-
-    return {
-        "cfg": case,
-        "params": params,
-        "hidden": hidden,
-        "w1": w1_runtime,
-        "w2": w2_runtime,
-        "w1_reference": w1_reference,
-        "w2_reference": w2_reference,
-        "w1_scale": w1_scale,
-        "w2_scale": w2_scale,
-        "w1_scale_runtime": w1_scale_runtime,
-        "w2_scale_runtime": w2_scale_runtime,
-        "topk_weights": topk_weights,
-        "topk_ids": topk_ids,
-        "quant_type": quant_type,
-        "activation": activation,
-        "activation_dtype": activation_dtype,
-        "weight_dtype": weight_dtype,
-    }
-
-
-def _run_moe(inputs: dict):
-    from aiter.fused_moe import fused_moe
-
-    return fused_moe(
-        inputs["hidden"],
-        inputs["w1"],
-        inputs["w2"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        w1_scale=inputs["w1_scale_runtime"],
-        w2_scale=inputs["w2_scale_runtime"],
-        quant_type=inputs["quant_type"],
-        activation=inputs["activation"],
-        dtype=_torch().bfloat16,
-    )
-
-
-def _moe_reference(inputs: dict):
-    torch = _torch()
-    aiter = _import_aiter()
-    from aiter import dtypes
-    from aiter.fused_moe import torch_moe_stage1, torch_moe_stage2
-
-    torch_quant = aiter.get_torch_quant(inputs["quant_type"])
-    params = inputs["params"]
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"].view(inputs["hidden"].shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a1_quant = a1_quant.view(inputs["hidden"].shape)
-        a1_scale = a1_scale.squeeze(-1)
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a1_quant = inputs["hidden"].to(inputs["activation_dtype"])
-        a1_scale = None
-    else:
-        a1_quant, a1_scale = torch_quant(
-            inputs["hidden"], quant_dtype=inputs["activation_dtype"]
-        )
-
-    stage1 = torch_moe_stage1(
-        a1_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        activation=inputs["activation"],
-        quant_type=inputs["quant_type"],
-        a1_scale=a1_scale,
-        w1_scale=inputs["w1_scale"],
-    )
-    if inputs["quant_type"] == aiter.QuantType.per_1x128:
-        a2_quant, a2_scale = torch_quant(
-            stage1.view(stage1.shape[0], -1, 128),
-            quant_dtype=inputs["activation_dtype"],
-        )
-        a2_scale = a2_scale.view(
-            stage1.shape[0], params["topk"], -1
-        )
-    elif (
-        inputs["quant_type"] == aiter.QuantType.per_1x32
-        and inputs["activation_dtype"]
-        in (dtypes.bf16, dtypes.fp16, dtypes.fp8)
-        and inputs["weight_dtype"] == dtypes.fp4x2
-    ):
-        a2_quant = stage1
-        a2_scale = None
-    else:
-        a2_quant, a2_scale = torch_quant(
-            stage1, quant_dtype=inputs["activation_dtype"]
-        )
-    a2_quant = a2_quant.view(stage1.shape[0], params["topk"], -1)
-    return torch_moe_stage2(
-        a2_quant,
-        inputs["w1_reference"],
-        inputs["w2_reference"],
-        inputs["topk_weights"],
-        inputs["topk_ids"],
-        dtype=torch.bfloat16,
-        quant_type=inputs["quant_type"],
-        w2_scale=inputs["w2_scale"],
-        a2_scale=a2_scale,
-    )
-
-
-def _make(case: dict, correctness: bool = False) -> dict:
-    if OPERATOR == "unified_attention":
-        return _make_attention(case, correctness)
-    if OPERATOR == "a8w8_blockscale_gemm":
-        return _make_gemm(case, correctness)
-    if OPERATOR == "dynamic_per_tensor_quant":
-        return _make_quant(case)
-    if OPERATOR == "mhc_fused_post_pre":
-        return _make_mhc(case, correctness)
-    if OPERATOR == "mla_decode":
-        return _make_mla(case, correctness)
-    if OPERATOR in ("ck_moe_2stage", "cktile_moe_2stage"):
-        return _prepare_moe(case, correctness)
-    raise KeyError(OPERATOR)
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote, so work that the scored path skips
+    cannot hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_attention_inputs(inputs)
+    # The output is harness-owned, so poison it directly; a kernel that stops
+    # writing keeps the poison instead of a plausible stale result.
+    inputs["output"].fill_(float("nan"))
+    _assert_attention_close(inputs, timed.rerun())
 
 
 def _run(inputs: dict):
-    return {
-        "unified_attention": _run_attention,
-        "a8w8_blockscale_gemm": _run_gemm,
-        "dynamic_per_tensor_quant": _run_quant,
-        "mhc_fused_post_pre": _run_mhc,
-        "mla_decode": _run_mla,
-        "ck_moe_2stage": _run_moe,
-        "cktile_moe_2stage": _run_moe,
-    }[OPERATOR](inputs)
+    _assert_operator()
+    return _run_attention(inputs)
 
 
 def run_compile() -> None:
@@ -833,7 +349,7 @@ def run_compile() -> None:
         for _, inputs in _attention_correctness_inputs(CASES[0]):
             _run_attention(inputs)
     else:
-        inputs = _make(CASES[0], correctness=True)
+        inputs = _make(CASES[0])
         _run(inputs)
     _torch().cuda.synchronize()
     print(f"{OPERATOR} compile smoke: PASS")
@@ -842,80 +358,29 @@ def run_compile() -> None:
 def run_correctness() -> None:
     torch = _torch()
     for case in CASES:
-        if OPERATOR == "unified_attention":
-            for path, inputs in _attention_correctness_inputs(case):
-                got = _run_attention(inputs)
-                torch.cuda.synchronize()
-                torch.testing.assert_close(
-                    got, _attention_reference(inputs), atol=0.08, rtol=0.08
-                )
-                print("correctness PASS", case["id"], f"path={path}")
-            continue
-
-        inputs = _make(case, correctness=True)
-        got = _run(inputs)
-        torch.cuda.synchronize()
-        if OPERATOR == "a8w8_blockscale_gemm":
-            torch.testing.assert_close(
-                got, _gemm_reference(inputs), atol=0.15, rtol=0.12
-            )
-        elif OPERATOR == "dynamic_per_tensor_quant":
-            expected_scale = (
-                inputs["input"].abs().float().max()
-                / torch.finfo(torch.float8_e4m3fn).max
-            )
-            torch.testing.assert_close(
-                inputs["scale"],
-                expected_scale.reshape(1),
-                atol=1e-5,
-                rtol=2e-2,
-            )
-            torch.testing.assert_close(
-                got.float() * inputs["scale"],
-                inputs["input"].float(),
-                atol=0.25,
-                rtol=0.15,
-            )
-        elif OPERATOR == "mhc_fused_post_pre":
-            for actual, expected in zip(got, _mhc_reference(inputs)):
-                torch.testing.assert_close(
-                    actual, expected, atol=0.08, rtol=0.08
-                )
-        elif OPERATOR == "mla_decode":
-            torch.testing.assert_close(
-                inputs["output"],
-                _mla_reference(inputs),
-                atol=0.08,
-                rtol=0.08,
-            )
-        else:
-            expected = _moe_reference(inputs)
-            cosine_error = 1 - torch.nn.functional.cosine_similarity(
-                got.float().flatten(),
-                expected.float().flatten(),
-                dim=0,
-            )
-            assert torch.isfinite(got).all()
-            assert float(cosine_error) < 0.03, (
-                case["id"],
-                float(cosine_error),
-            )
-        print("correctness PASS", case["id"])
+        for path, inputs in _attention_correctness_inputs(case):
+            got = _run_attention(inputs)
+            torch.cuda.synchronize()
+            _assert_attention_close(inputs, got)
+            print("correctness PASS", case["id"], f"path={path}")
 
 
 def run_performance() -> None:
     rows = []
     for case in CASES:
-        inputs = _make(case, correctness=False)
+        inputs = _make(case)
         _run(inputs)
         _torch().cuda.synchronize()
+        timed = _TimedRun()
         execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
             lambda: _run(inputs),
             warmup=3,
             repetition=20,
             target_ms=1.0,
             max_graph_repeats=100,
+            timed_run=timed,
         )
+        _assert_timed_outputs(inputs, timed)
         metadata = {
             **case["params"],
             "model": case["model"],

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/README.md
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/README.md
@@ -1,0 +1,121 @@
+# mi355x-gemma4-26b-vllm-triton-unified-attention-20260801
+
+Image_kernel harness for vLLM's Triton attention kernel `kernel_unified_attention`
+(`vllm/v1/attention/ops/triton_unified_attention.py:179`).
+
+Generated from the gemma-4-26B-A4B-it Hyperloom 2026-08-01 MI355X session, where
+this kernel is the largest single leaf in the trace — 27.59% of GPU time across all
+its shapes, with the sliding/head_size-256 decode shape alone at 19.550%.
+
+## This is vLLM's kernel, not AITER's
+
+The sibling task `mi355x_vllm_triton_unified_attention` covers AITER's
+`aiter/ops/triton/_triton_kernels/attention/unified_attention.py`, which defines
+only `kernel_unified_attention_2d` and `kernel_unified_attention_3d`. The trace
+records the **unsuffixed** `kernel_unified_attention`, which exists only in the
+vLLM file. AITER's variant is reachable solely from the
+`ROCM_AITER_UNIFIED_ATTN` backend, and this session ran `TRITON_ATTN`. The two
+tasks therefore measure different kernels.
+
+## Why Triton at all
+
+Gemma4 on ROCm has no hand-written paged-attention path:
+`use_rocm_custom_paged_attention` accepts `head_size` 64/128 on gfx9, and this
+model uses 256 for sliding layers and 512 for full layers. Every attention layer
+falls back to this one Triton kernel, which is what makes it the trace's top
+entry.
+
+## Workload
+
+TP=2, EP=1, concurrency 64, ISL=1024, OSL=1024, `max_model_len=6144`. BF16
+throughout — `dtype=torch.bfloat16`, `quantization=None`, `kv_cache_dtype=auto`,
+and the checkpoint carries no `quantization_config`. (The session workload label
+says `precision: fp8`; that label is wrong, and TraceLens' own
+`metadata/model_info.json` also records BF16.)
+
+`config.json` gives 16 q heads / 8 kv heads / `head_dim` 256 for sliding layers
+and `global_head_dim` 512 / `num_global_key_value_heads` 2 for full layers, with
+`layer_types` = 5×sliding + 1×full repeated five times (25 sliding, 5 full),
+`sliding_window` 1024 and `attn_logit_softcapping` null. Under TP=2 the per-rank
+slice is:
+
+| Layer type | Q heads | KV heads | head_size | Window | Session decode share |
+| --- | --- | --- | --- | --- | --- |
+| sliding | 8 | 4 | 256 | 1024 | 19.550% (k002) |
+| full | 8 | 1 | 512 | none | 3.965% (k009) |
+
+Both geometries go through the same kernel but with very different
+queries-per-KV ratios (2 vs 8), which drive `BLOCK_M` / `BLOCK_Q`.
+`_get_tile_size` also has a Gemma-specific branch keyed on
+`(head_size, sliding_window)`.
+
+Four cases cover both geometries at two context lengths. `ctx_len` is
+reconstructed from the decode regime (context grows across 1024–2048 with
+ISL/OSL 1024); the trace records query/output/step shapes but not the
+per-sequence KV context length. ctx 2048 is where the 1024-token sliding window
+actually clips.
+
+Correctness and performance sweep all four cases. Profiling is a single-shape
+probe pinned to `gemma4-sliding-decode-m64-ctx1024` via `profile_case` in
+`session_cases.json` (surfaced as `PROFILE_CASE_ID` / `profile_case()` in the task
+runner) — that is the session's largest single leaf, and pinning keeps the
+profiled kernel from drifting with measurement noise.
+
+### Prefill is deliberately not covered
+
+The trace also holds four prefill entries for this kernel (7218- and 1080-token
+steps at both head sizes, 4.078% combined). They are chunked-prefill steps whose
+per-sequence query-length composition is not recorded — the slice is labelled
+`mixed_steady_state_prefill_0_prefilldecode_2_decode_30_bs319_conc63` — so a case
+would be guesswork about the batch mix rather than a reconstruction. The two
+decode shapes are exactly determined (64 tokens = 64 sequences × 1 query token at
+concurrency 64) and account for 23.5% of the trace.
+
+## Editable surface and JIT
+
+`triton_unified_attention.py` is seeded from the image and loaded from the
+workspace copy, so edits to the `@triton.jit` kernel, its helpers, `_get_tile_size`
+or the `unified_attention` host wrapper all take effect. Triton re-keys its JIT
+cache on source, so no explicit rebuild step is needed. Every import in the file
+is absolute, so the edited copy resolves against the installed `vllm`.
+
+`seq_threshold_3D` / `num_par_softmax_segments` / `softmax_segm_*` are left unset,
+so `unified_attention` takes the 2D path (`use_3d` False at
+`triton_unified_attention.py:969`). That matches the trace, which records
+`kernel_unified_attention` with no `reduce_segments` companion.
+
+## Verified locally
+
+Workspace materialized through `src.preprocessing.setup_workspace` on
+MI355X/gfx950:
+
+```text
+compile      unified_attention compile smoke: PASS
+correctness  PASS x4
+performance  sliding ctx1024/2048  0.0597 / 0.0596 ms
+             full    ctx1024/2048  0.0767 / 0.1508 ms
+             benchmark_method=cuda_graph on every case
+forge_driver --bench-mode  4x case_ms + mean_ms: 0.086725
+forge_driver --profile-run exit 0
+```
+
+The sliding cases are flat across context length while the full cases roughly
+double, which is the expected signature of a 1024-token window capping the work —
+a useful check that the SWA path is genuinely active.
+
+Edit propagation was checked end to end by scaling the kernel's output by 2
+(`acc = acc / L[:, None]`): correctness flipped to `allclose: False` and back to
+`allclose: True` after restoring the file. The profile pin was checked against a
+performance report whose slowest case was `gemma4-full-decode-m64-ctx2048`; the
+driver still selected the pinned sliding case.
+
+Harness timings are not expected to reproduce the session's per-call time
+(k002 averaged 161 µs/call there). The harness measures the kernel in isolation
+with a compact, contiguous block table, whereas the session ran it against a
+fully populated paged cache under TP=2.
+
+Expected runtime image:
+
+```text
+harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0
+```

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/config.yaml
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/config.yaml
@@ -1,0 +1,42 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/vllm/v1/attention/ops
+repo_subdir: vllm_v1_attention_ops
+image_repo_exclude:
+- __pycache__
+repository_language: triton
+source_file_path:
+- triton_unified_attention.py
+target_kernel_functions:
+- kernel_unified_attention
+kernel_identity:
+  logical_operator: unified_attention_with_output
+  kernel_kind: triton
+  source_owner: vllm
+  workload:
+    source: session_cases.json
+    primary_case: gemma4-sliding-decode-m64-ctx1024
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: 'Optimize the vLLM Triton attention kernel kernel_unified_attention
+    (in triton_unified_attention.py) on MI355X/gfx950. This is vLLM''s own kernel,
+    not AITER''s kernel_unified_attention_2d/_3d. Gemma4 on ROCm has no hand-written
+    paged-attention path - use_rocm_custom_paged_attention only accepts head_size
+    64/128 on gfx9 - so every attention layer falls back to this Triton kernel and it
+    becomes the largest single leaf in the trace. One kernel serves two geometries:
+    sliding layers at head_size 256 with a 1024-token window (8 query heads over 4 KV
+    heads) and full layers at head_size 512 with no window (8 query heads over 1 KV
+    head), both BF16 decode with 64 sequences and 1024-2048 tokens of KV context. Note
+    the very different queries-per-KV ratios (2 vs 8), which drive BLOCK_M/BLOCK_Q, and
+    that _get_tile_size already has a Gemma-specific branch. Do not tune one geometry
+    at the expense of the other. Cases come from the gemma-4-26B-A4B-it Hyperloom
+    2026-08-01 MI355X session and are stored in session_cases.json. Preserve all
+    correctness cases and improve CUDA-graph measured performance. Do not change the
+    public signature of unified_attention.'
+  cheatsheet: null

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/scripts/forge_driver.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/scripts/forge_driver.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case, correctness)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Profiling is a single-shape probe. When the task pins one representative
+    # case, honour it so the profiled kernel does not drift with timing noise.
+    pinned = getattr(tr, "profile_case", None)
+    if callable(pinned):
+        return pinned()
+    # Otherwise prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/scripts/task_runner.py
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/scripts/task_runner.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Harness for vLLM's Triton attention kernel ``kernel_unified_attention``
+(``vllm/v1/attention/ops/triton_unified_attention.py``).
+
+The kernel is loaded from the editable workspace copy of the in-image source tree
+so an optimizing agent's edits to triton_unified_attention.py take effect; Triton
+re-keys its JIT on the source, so no explicit rebuild step is needed.
+
+This is vLLM's kernel, not AITER's ``kernel_unified_attention_2d``/``_3d`` - see
+``session_cases.json`` ``provenance.kernel_ownership``.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+
+REPO_SUBDIR = "vllm_v1_attention_ops"
+KERNEL_FILE = "triton_unified_attention.py"
+# Dotted name so the edited copy is importable under the installed vllm package;
+# every import in the file is absolute, so it resolves against the install.
+EDIT_MODULE_NAME = "vllm.v1.attention.ops._ka_triton_unified_attention"
+
+# Profiling is a single-shape probe, pinned rather than derived from timings so
+# the profiled kernel never drifts between runs. The sliding/head_size-256 decode
+# shape is the session's largest single leaf at 19.55% of GPU time. Correctness
+# and performance still sweep every case in CASES.
+PROFILE_CASE_ID = SPEC.get("profile_case") or CASES[0]["id"]
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _load_kernel_module():
+    # Import the installed module first so the vllm.v1.attention.ops package (the
+    # parent of the edited module) is initialized.
+    import vllm.v1.attention.ops.triton_unified_attention  # noqa: F401
+
+    path = WORKSPACE / REPO_SUBDIR / KERNEL_FILE
+    if not path.is_file():
+        raise RuntimeError(f"seeded kernel source not found: {path}")
+    spec = importlib.util.spec_from_file_location(EDIT_MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[EDIT_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def profile_case() -> dict:
+    """The single case profiling runs against (see PROFILE_CASE_ID)."""
+    for case in CASES:
+        if case["id"] == PROFILE_CASE_ID:
+            return case
+    raise KeyError(
+        f"profile_case {PROFILE_CASE_ID!r} is not present in session_cases.json"
+    )
+
+
+def _make(case: dict) -> dict:
+    """Build a case at its scored shape.
+
+    There is deliberately no correctness/performance switch here: a shape that is
+    timed must also be the shape that is validated, or the scored code path can
+    differ from the checked one. It matters twice over on this operator: the
+    sliding window only clips once ``ctx_len`` exceeds it, so a shortened context
+    silently turns a windowed layer into a full-attention one.
+    """
+    torch = _torch()
+    params = dict(case["params"])
+    num_seqs = params["num_seqs"]
+    ctx_len = params["ctx_len"]
+    num_query_heads = params["num_query_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    head_size = params["head_size"]
+    block_size = params["block_size"]
+    sliding_window = params["sliding_window"]
+    dtype = torch.bfloat16
+    scale = head_size**-0.5
+
+    # TritonAttentionImpl maps a causal SWA layer to (window-1, 0); a full
+    # attention layer disables the window entirely.
+    window_size = (sliding_window - 1, 0) if sliding_window else (-1, -1)
+
+    torch.manual_seed(31)
+
+    # Decode: one query token per sequence.
+    query = torch.randn(
+        (num_seqs, num_query_heads, head_size), device="cuda", dtype=dtype
+    )
+    output = torch.empty_like(query)
+
+    # Contiguous per-sequence context KV, used both to fill the paged cache and
+    # to compute the reference.
+    key = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+    value = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+
+    pages_per_seq = (ctx_len + block_size - 1) // block_size
+    num_blocks = num_seqs * pages_per_seq + 1
+
+    # TritonAttentionBackend.get_kv_cache_shape:
+    # (num_blocks, 2, block_size, num_kv_heads, head_size), unbound on dim 1.
+    kv_cache = torch.zeros(
+        (num_blocks, 2, block_size, num_kv_heads, head_size),
+        device="cuda",
+        dtype=dtype,
+    )
+    block_table = torch.arange(
+        num_seqs * pages_per_seq, device="cuda", dtype=torch.int32
+    ).view(num_seqs, pages_per_seq)
+
+    seq_idx = torch.arange(num_seqs, device="cuda").view(-1, 1).expand(-1, ctx_len)
+    pos = torch.arange(ctx_len, device="cuda").view(1, -1).expand(num_seqs, -1)
+    phys_block = block_table[seq_idx, pos // block_size].long().reshape(-1)
+    offset = (pos % block_size).reshape(-1)
+    key_cache, value_cache = kv_cache.unbind(1)
+
+    # Non-quantized KV still receives expanded per-(seq, kv_head) descales, the
+    # same way TritonAttentionImpl.forward builds them from layer._k_scale.
+    descale = torch.ones(
+        (num_seqs, num_kv_heads), device="cuda", dtype=torch.float32
+    )
+
+    inputs = {
+        "cfg": case,
+        "module": _load_kernel_module(),
+        "query": query,
+        "output": output,
+        "key": key,
+        "value": value,
+        "kv_cache": kv_cache,
+        "key_cache": key_cache,
+        "value_cache": value_cache,
+        "block_table": block_table,
+        "cu_seqlens_q": torch.arange(
+            num_seqs + 1, device="cuda", dtype=torch.int32
+        ),
+        "seqused_k": torch.full(
+            (num_seqs,), ctx_len, device="cuda", dtype=torch.int32
+        ),
+        "descale": descale,
+        "ctx_len": ctx_len,
+        "sliding_window": sliding_window,
+        "window_size": window_size,
+        "scale": scale,
+        "phys_block": phys_block,
+        "offset": offset,
+        "num_kv_heads": num_kv_heads,
+        "head_size": head_size,
+    }
+    _fill_kv_cache(inputs)
+    return inputs
+
+
+def _fill_kv_cache(inputs: dict) -> None:
+    """Page the contiguous key/value into the cache the kernel reads.
+
+    The reference reads ``key``/``value`` while the kernel reads the paged cache,
+    so the two have to be refreshed together or they stop describing the same
+    workload.
+    """
+    num_kv_heads = inputs["num_kv_heads"]
+    head_size = inputs["head_size"]
+    kv_cache = inputs["kv_cache"]
+    kv_cache[inputs["phys_block"], 0, inputs["offset"]] = inputs["key"].reshape(
+        -1, num_kv_heads, head_size
+    )
+    kv_cache[inputs["phys_block"], 1, inputs["offset"]] = inputs["value"].reshape(
+        -1, num_kv_heads, head_size
+    )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes. Fresh values stop an output
+    buffer that the kernel never wrote from matching the reference by accident.
+    """
+    torch = _torch()
+    torch.manual_seed(67)
+    inputs["query"].normal_()
+    inputs["key"].normal_()
+    inputs["value"].normal_()
+    _fill_kv_cache(inputs)
+
+
+def _run(inputs: dict):
+    inputs["module"].unified_attention(
+        q=inputs["query"],
+        k=inputs["key_cache"],
+        v=inputs["value_cache"],
+        out=inputs["output"],
+        cu_seqlens_q=inputs["cu_seqlens_q"],
+        max_seqlen_q=1,
+        seqused_k=inputs["seqused_k"],
+        max_seqlen_k=inputs["ctx_len"],
+        softmax_scale=inputs["scale"],
+        causal=True,
+        window_size=inputs["window_size"],
+        block_table=inputs["block_table"],
+        softcap=0.0,
+        q_descale=None,
+        k_descale=inputs["descale"],
+        v_descale=inputs["descale"],
+    )
+    return inputs["output"]
+
+
+def _reference(inputs: dict):
+    torch = _torch()
+    query = inputs["query"].float()  # (S, num_query_heads, head_size)
+    key = inputs["key"].float()  # (S, ctx, num_kv_heads, head_size)
+    value = inputs["value"].float()
+    ctx_len = inputs["ctx_len"]
+    window = inputs["sliding_window"]
+    # The single decode query sits at position ctx_len-1, so a (window-1, 0)
+    # causal window admits exactly the last `window` context tokens.
+    lo = max(0, ctx_len - window) if window else 0
+    ratio = query.shape[1] // key.shape[2]
+    outputs = []
+    for s in range(query.shape[0]):
+        k = key[s, lo:].repeat_interleave(ratio, dim=1)
+        v = value[s, lo:].repeat_interleave(ratio, dim=1)
+        scores = torch.einsum("hd,khd->hk", query[s], k) * inputs["scale"]
+        probs = torch.softmax(scores, dim=-1)
+        outputs.append(torch.einsum("hk,khd->hd", probs, v))
+    return torch.stack(outputs).to(inputs["output"].dtype)
+
+
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.02, rtol=0.02)
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance must share one
+    shape, otherwise the scored path is not the validated path.
+    """
+    params = dict(case["params"])
+    params["num_seqs"] = min(params["num_seqs"], 8)
+    params["ctx_len"] = min(params["ctx_len"], 256)
+    return {**case, "params": params}
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote, so work the scored path skips cannot
+    hide behind a correctness call that took a different branch.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    inputs["output"].fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        # The output buffer is written, never accumulated: poison it so an
+        # implementation that leaves rows untouched cannot pass on allocator
+        # leftovers.
+        inputs["output"].fill_(float("nan"))
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/session_cases.json
+++ b/tasks/image_kernel/mi355x_vllm_triton_unified_attention_gemma4/session_cases.json
@@ -1,0 +1,127 @@
+{
+  "source_day": "2026-08-01",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.24.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/sync/vllm-openai-rocm:v0.24.0",
+  "selection": "vLLM's own Triton kernel_unified_attention, the largest single leaf in the gemma-4-26B-A4B-it roofline trace (27.59% across all shapes). Cases cover the two head geometries Gemma4 drives through this one kernel: sliding layers at head_dim 256 with a 1024-token window, and full layers at head_dim 512 with no window.",
+  "task_name": "mi355x-gemma4-26b-vllm-triton-unified-attention-20260801",
+  "operator": "unified_attention",
+  "profile_case": "gemma4-sliding-decode-m64-ctx1024",
+  "provenance": {
+    "model": "gemma-4-26B-A4B-it",
+    "session_dir": "/shared_nfs/hyperloom-k8s/safe-opt-claw-top-models-forge-google-ge-45b22e20-a1/45b22e20-cd68-4916-918d-48936ecacc00/gemma-4-26B-A4B-it/20260801T162014Z",
+    "tracelens_snapshot": "kernel-agent/runs/20260801T162014Z/20260801T173050Z_tl-c549cffd/tracelens",
+    "trace": "runs/roofline/32dab7b3267b41b691f2d060d8af1ec4/benchmark_vllm_20260801_171753/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1785605122621332807.pt.trace.json.gz",
+    "device_kernel": "kernel_unified_attention",
+    "entry": "vllm/v1/attention/ops/triton_unified_attention.py:179 @triton.jit kernel_unified_attention",
+    "call_chain": "vllm::unified_attention_with_output (vllm/model_executor/layers/attention/attention.py:755) -> vllm/v1/attention/backends/triton_attn.py:530 TritonAttentionImpl.forward -> :642 -> vllm/v1/attention/ops/triton_unified_attention.py:780 unified_attention -> grid launch at :1019 -> kernel_unified_attention",
+    "kernel_ownership": "This is vLLM's kernel, NOT AITER's. AITER's aiter/ops/triton/_triton_kernels/attention/unified_attention.py defines only kernel_unified_attention_2d and kernel_unified_attention_3d; the trace records the unsuffixed kernel_unified_attention, which exists only in the vLLM file. AITER's variant is reachable only from the ROCM_AITER_UNIFIED_ATTN backend, while this trace ran TRITON_ATTN. The sibling task mi355x_vllm_triton_unified_attention covers the AITER implementation and is a different kernel.",
+    "why_triton": "Gemma4 on ROCm has no hand-written paged-attention path: use_rocm_custom_paged_attention accepts head_size 64/128 on gfx9, and this model uses 256 (sliding layers) and 512 (full layers), so all attention falls back to the Triton kernel. One kernel therefore serves both head_dim values, and the 256 decode shape alone is the single largest entry in the trace.",
+    "workload": "TP=2, EP=1, concurrency=64, ISL=1024, OSL=1024, max_model_len=6144, NUM_PROMPTS=776. Decode steps carry 64 tokens, i.e. 64 sequences with one query token each.",
+    "dtypes": "BF16 throughout. server.log reports dtype=torch.bfloat16, quantization=None and kv_cache_dtype=auto; the model is a BF16 checkpoint with no quantization_config. The session workload label precision: fp8 is inaccurate - TraceLens metadata/model_info.json also records BF16.",
+    "geometry": "config.json gives 16 q heads, 8 kv heads and head_dim 256 for sliding layers, plus global_head_dim 512 with num_global_key_value_heads 2 for full layers; layer_types is 5x sliding + 1x full repeated 5 times (25 sliding, 5 full) with sliding_window 1024 and attn_logit_softcapping null. Under TP=2 the per-rank slice is 8 q heads with 4 kv heads at head_dim 256 (sliding) and 8 q heads with 1 kv head at head_dim 512 (full), matching the Q/O and K/V shapes recorded in the trace.",
+    "sliding_window_convention": "TritonAttentionImpl maps a causal SWA layer to window_size=(sliding_window-1, 0), so 1024 becomes (1023, 0) and the kernel's SLIDING_WINDOW constexpr is 1+window_size[0]=1024. A decode query at position ctx-1 therefore attends to the last 1024 context tokens. Full layers use (-1, -1).",
+    "trace_shapes": [
+      "k002 Q/O (64,8,256) K/V (64,4,256) sliding decode, 750 calls = 25 layers x 30 steps, 19.550%, 120958 us",
+      "k009 Q/O (64,8,512) K/V (64,1,512) full decode, 150 calls = 5 layers x 30 steps, 3.965%, 24531 us",
+      "k007 Q/O (7218,8,256) sliding prefill step, 25 calls, 2.464%",
+      "k001 Q/O (1080,8,256) sliding prefill step, 25 calls, 0.828%",
+      "k006 Q/O (7218,8,512) full prefill step, 5 calls, 0.598%",
+      "k008 Q/O (1080,8,512) full prefill step, 5 calls, 0.188%"
+    ],
+    "prefill_not_covered": "Only the two decode shapes are turned into cases. They are exactly determined (64 tokens = 64 sequences x 1 query token at concurrency 64) and account for 23.5% of the trace. The four prefill entries are chunked-prefill steps whose per-sequence query-length composition is not recorded in the trace, so any case would be guesswork about the batch mix rather than a reconstruction; the aggregate slice label is mixed_steady_state_prefill_0_prefilldecode_2_decode_30_bs319_conc63.",
+    "ctx_len_note": "ctx_len is reconstructed from the decode regime (ISL=1024, OSL=1024, so per-sequence context grows across 1024..2048). The trace records query/output/step shapes but not the per-sequence KV context length. ctx 2048 is the case where the 1024-token sliding window actually clips.",
+    "path_3d": "seq_threshold_3D / num_par_softmax_segments / softmax_segm_* are left unset so unified_attention takes the 2D path (use_3d False at triton_unified_attention.py:969). That matches the trace, which records kernel_unified_attention with no reduce_segments companion."
+  },
+  "cases": [
+    {
+      "id": "gemma4-sliding-decode-m64-ctx1024",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k002"],
+      "gpu_pct": 19.55,
+      "params": {
+        "layer_type": "sliding_attention",
+        "num_seqs": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 4,
+        "head_size": 256,
+        "block_size": 16,
+        "ctx_len": 1024,
+        "sliding_window": 1024,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,256) bf16",
+        "K/V step (64,4,256) bf16"
+      ]
+    },
+    {
+      "id": "gemma4-sliding-decode-m64-ctx2048",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k002"],
+      "gpu_pct": null,
+      "params": {
+        "layer_type": "sliding_attention",
+        "num_seqs": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 4,
+        "head_size": 256,
+        "block_size": 16,
+        "ctx_len": 2048,
+        "sliding_window": 1024,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,256) bf16",
+        "K/V step (64,4,256) bf16"
+      ]
+    },
+    {
+      "id": "gemma4-full-decode-m64-ctx1024",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k009"],
+      "gpu_pct": 3.965,
+      "params": {
+        "layer_type": "full_attention",
+        "num_seqs": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 512,
+        "block_size": 16,
+        "ctx_len": 1024,
+        "sliding_window": 0,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,512) bf16",
+        "K/V step (64,1,512) bf16"
+      ]
+    },
+    {
+      "id": "gemma4-full-decode-m64-ctx2048",
+      "model": "gemma-4-26B-A4B-it",
+      "kernel_ids": ["k009"],
+      "gpu_pct": null,
+      "params": {
+        "layer_type": "full_attention",
+        "num_seqs": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 512,
+        "block_size": 16,
+        "ctx_len": 2048,
+        "sliding_window": 0,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,512) bf16",
+        "K/V step (64,1,512) bf16"
+      ]
+    }
+  ]
+}

--- a/tests/test_timing_and_harness_guard.py
+++ b/tests/test_timing_and_harness_guard.py
@@ -1,6 +1,108 @@
+import importlib.util
 import json
+import sys
+from pathlib import Path
 
 import pytest
+
+
+def _load_grouped_gemm_runner():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "tasks/image_kernel/mi355x_sglang_triton_mxfp8_grouped_gemm"
+        / "scripts/task_runner.py"
+    )
+    spec = importlib.util.spec_from_file_location("_test_grouped_gemm_runner", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_grouped_gemm_timed_validation_checks_both_outputs(monkeypatch):
+    import torch
+
+    runner = _load_grouped_gemm_runner()
+    ref1 = torch.ones(2, 3)
+    ref2 = torch.ones(2, 4)
+    out1 = torch.zeros_like(ref1)
+    out2 = torch.zeros_like(ref2)
+    timed = runner._TimedRun()
+
+    def _rerun_with_corrupt_gemm1():
+        out2.copy_(ref2)
+        return out1, out2
+
+    timed._bind(_rerun_with_corrupt_gemm1, (out1, out2))
+    monkeypatch.setattr(
+        runner,
+        "_timed_references",
+        lambda _inputs: (ref1, ref2),
+    )
+    inputs = {"cfg": {"id": "shape0", "params": {"max_relerr": 0.08}}}
+
+    with pytest.raises(AssertionError, match="timed_gemm1"):
+        runner._assert_timed_outputs(inputs, timed)
+
+
+def test_grouped_gemm_timed_run_rejects_event_fallback(monkeypatch):
+    import torch
+
+    runner = _load_grouped_gemm_runner()
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    def _reject_stream():
+        raise RuntimeError("capture unavailable")
+
+    monkeypatch.setattr(torch.cuda, "Stream", _reject_stream)
+
+    with pytest.raises(RuntimeError, match="timed outputs cannot be validated"):
+        runner._benchmark_cuda_graph(
+            lambda: None,
+            warmup=0,
+            repetition=1,
+            timed_run=runner._TimedRun(),
+        )
+
+
+def test_timed_run_fails_closed_without_cuda(monkeypatch):
+    import torch
+
+    from src.tools.perf.vllm_cuda_graph_block import (
+        _TimedRun,
+        _benchmark_cuda_graph_or_events,
+    )
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="requires an observable CUDA-graph replay"):
+        _benchmark_cuda_graph_or_events(
+            lambda: None,
+            warmup=0,
+            repetition=1,
+            timed_run=_TimedRun(),
+        )
+
+
+def test_timed_run_fails_closed_when_cuda_graph_is_disabled(monkeypatch):
+    import torch
+
+    from src.tools.perf.vllm_cuda_graph_block import (
+        _TimedRun,
+        _benchmark_cuda_graph_or_events,
+    )
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    with pytest.raises(RuntimeError, match="CUDA-graph timing is disabled"):
+        _benchmark_cuda_graph_or_events(
+            lambda: None,
+            warmup=0,
+            repetition=1,
+            use_cuda_graph=False,
+            timed_run=_TimedRun(),
+        )
 
 
 def test_device_timing_preferred_over_host_time(tmp_path):


### PR DESCRIPTION
Two things: close a scoring hole in the existing image-kernel tasks, and add three new tasks that do not have it.

## 1. Fix the existing tasks

A kernel could collect a speedup on these tasks without the scored code path ever being checked. Two independent gaps allowed it.

**The scored shapes were never validated.** Correctness built inputs at truncated shapes while performance used the full session shapes, so on any operator that branches on size the two modes exercised different code. `fused_moe_gptq_awq` validated at 16 tokens / 8 experts / top-2 and scored at 7211 tokens / 384 experts / top-8; `unified_attention` validated at ctx_len 128 and scored at 2048. A kernel that skipped work on the long-prompt path alone passed correctness and kept the speedup.

**The scored invocation was never observed.** Correctness and performance are separate calls, and nothing ever looked at what the timed call produced: the benchmark owns the captured graph and returns only a duration. A kernel could tell the two apart and do less work in the one that is scored.

What changed:

- The correctness/performance shape switch is removed from the ten scored operators. `_make` / `_prepare` no longer take a `correctness` flag, so the two modes cannot diverge by construction. Compile keeps a cheap smoke shape through an explicit helper, which is what `paged_attention_2d` already did.
- `vllm_cuda_graph_block` gains an optional `timed_run` collector that binds a handle to the buffers the timed unit last wrote, plus a way to re-run that same unit. Every return path binds it, including the four fallbacks. Performance then asserts on those buffers after perturbing the inputs and poisoning the outputs, so work the scored path skips cannot hide behind a correctness call that took a different branch.
- Four references walked (token, slot) pairs in Python and synchronised on the routing tensor every step, which is what made a full-shape check impractical. They now batch per expert or per query chunk, so `sparse_attn` at 7211 queries and `fused_moe_gptq_awq` at 7211 tokens / 384 experts both validate in seconds.
- `fused_moe_gptq_awq` rotates the whole case suite three times instead of running each case once. A single pass samples a kernel once against a fixed seed, so an implementation that is only intermittently wrong passes whenever the defect does not fire.
- Two tasks opt out of the timed-output assertion and say why in place: `kda` advances state in place and a captured graph chains several invocations, so its golden has to carry state across repeats; `mxfp8_grouped_gemm` freezes GEMM2's activation at setup, so the timed result cannot witness whether GEMM1 ran.
- Three runners copied from the multi-operator template drop the branches their operator cannot reach.

One unrelated fix rides along because it blocked the E2E validation: aiter treats any non-zero `AITER_REBUILD` as "rebuild this module", never checking whether the source changed, and the profiler re-spawns the driver once per counter pass. Forcing the rebuild only once an editable source no longer matches its in-image original takes a single `--profile-run` from 19s to 4s, and the profiling stage of an arena + forge-loop run from not completing after 540s to finishing in 210s.

## 2. Add three tasks

`paged_attention_rocm`, the Gemma4 fused MoE and the Gemma4 unified attention, brought over from `feat/add-new-image-kernel-0804` with the shape split already closed rather than inherited. All three truncated correctness inputs the same way: the MoE shrank every dimension (7218 tokens / 128 experts / top-8 / hidden 2816 down to 16 / 8 / 2 / 512), and both attention tasks cut num_seqs 64 to 8 and ctx_len up to 2048 down to 256.

`unified_attention_gemma4` is the sharpest case and not only a "less work" hole. Its reference clips the window with `lo = max(0, ctx_len - window)`, so at the scored ctx_len 2048 with sliding_window 1024 it drops half the context, while a correctness ctx_len of 256 makes `lo` zero and clips nothing. The sliding-window behaviour was therefore never validated at all, and a kernel that got it wrong could still score. `paged_attention_decode` has a milder version: ctx_len also sets the split-K partition count, so a shortened context changes which reduction path runs.

## Validation

On gfx950, compile / correctness / performance pass at full shapes for the nine vllm tasks this container can build, and arena + forge-loop runs clean through baseline, task-prepare skip, source map, profiling and KB warm start on each. Timings are unchanged from before the change. The remaining four (`mxfp8_linear`, `mxfp8_grouped_gemm`, `mxfp4_moe_2stage`, `kda_linear_attn`) need images this container cannot provide.

The gates now catch things they used to admit. Four stored KB solutions for `mhc_fused_post_pre`, claiming 11x to 3808x, fail full-shape correctness; the best surviving entry is 1.667x. The top KB solution for `fused_moe_gptq_awq` folds the moe_align prefix sum into the histogram kernel behind a cross-workgroup software barrier with no sound ordering guarantee, and caches the counter buffer in a module global that the barrier is supposed to re-zero; it produced wrong results 5 times in 12 full-shape runs. Suite rotation takes detection on it from 3/8 to 6/8 while the pristine kernel stays at 8/8, so the gate gains samples without gaining false rejections, at no measurable wall-clock cost.
