### PR TITLE
Remove Arena-generated Forge program prompt

### DIFF
--- a/agents/forge/README.md
+++ b/agents/forge/README.md
@@ -26,8 +26,11 @@ drivers run the task's complete case suite.
 
 `source_file_path[0]` is the anchor implementation. Additional entries in
 `source_file_path` and the optional `editable_sources` list form one complete
-edit allowlist passed through `--source-files`. Agents may inspect other
-dependencies but must not edit files absent from that allowlist.
+edit allowlist. Arena passes these paths through `--source-files` for Forge's
+orientation and KB identity, then rejects the final result if its Git diff
+escapes that allowlist. Non-ignored untracked scratch files are discarded before
+scoring. Agents may inspect other dependencies but must not edit files absent
+from that allowlist.
 `target_kernel_functions` remains the concrete symbol list; it is not a
 substitute for `logical_operator`. Keep it focused on useful edit/profile hints
 defined in the editable sources. Reuse identity is based on KernelForge's
@@ -45,10 +48,11 @@ Multi-stage MoE and KDA tasks intentionally use one task-level logical operator
 covering their complete measured pipeline. Their Solution patch and workload
 therefore represent the combined operation rather than an individual stage.
 
-`mi355x_vllm_triton_unified_attention` and
-`mi355x_vllm_triton_paged_attention_2d` share the logical operation
-`unified_attention_with_output`, while their source-owner component keeps the
-AITER and vLLM implementations on separate Kernel pages.
+`mi355x_vllm_triton_unified_attention` uses the logical operation
+`unified_attention_with_output`, while
+`mi355x_vllm_triton_paged_attention_2d` uses `paged_attention_2d`. Keeping the
+logical operations distinct prevents paged-attention recipes from being reused
+as unified-attention implementations.
 
 TileLang metadata uses `kernel_kind: tilelang`, so Arena forwards
 `tilelang-fellow` without substituting another backend. KernelForge decides

--- a/agents/forge/launch_agent.py
+++ b/agents/forge/launch_agent.py
@@ -11,8 +11,7 @@ that loop's contract:
   2. Materialize a driver shim implementing the KernelForge driver contract
      (prints ``SNR: <db> dB`` for correctness and ``wall_ms: <ms>`` for bench).
   3. ``git init`` + initial commit the workspace (the loop uses git keep/revert).
-  4. Generate a ``forge_program.md`` from the task prompt for agent guidance.
-  5. Shell out to ``kernel-agents forge-loop`` (streaming output), which leaves
+  4. Shell out to ``kernel-agents forge-loop`` (streaming output), which leaves
      the workspace at the best-kept kernel.
 
 After this returns, Arena re-materializes its perf helpers and re-scores the
@@ -485,7 +484,6 @@ performance_report.json
 perf_report.json
 forge_experiments/
 forge_driver.py
-forge_program.md
 .pytest_cache/
 *.log
 """
@@ -511,80 +509,6 @@ def _init_git_workspace(workspace: str, logger: logging.Logger) -> None:
     _git(workspace, "rm", "-r", "--cached", "--quiet", ".", logger=logger)
     _git(workspace, "add", "-A", logger=logger)
     _git(workspace, "commit", "-m", "forge: initial workspace snapshot", logger=logger)
-
-
-def _write_program_md(
-    task_config: dict[str, Any],
-    target_funcs,
-    gpu_arch: str,
-    backend: str,
-    editable_sources: list[Path],
-    dest: Path,
-) -> None:
-    """Generate a program.md for the forge agent from the Arena task prompt."""
-    prompt_cfg = task_config.get("prompt") or {}
-    instructions = prompt_cfg.get("instructions") or ""
-    funcs = ", ".join(target_funcs) if target_funcs else "the target kernel"
-
-    # Level-3 tasks (repository / image_kernel) give the agent a full source tree,
-    # so the target kernel file is often only an ENTRY POINT: the code that governs
-    # its performance may live in other files it includes/imports. Tell the agent
-    # it may follow the implementation across the workspace and edit those files
-    # too. Snippet tasks copy a single self-contained file, so the note is omitted
-    # there to avoid pointing the agent at unrelated files.
-    task_type = str(task_config.get("task_type") or "").strip().lower()
-    scope_section = ""
-    if task_type in ("repository", "image_kernel"):
-        source_allowlist = "\n".join(
-            f"- `{path}`" for path in editable_sources
-        )
-        scope_section = f"""
-## Editable Source Scope
-`{funcs}` lives in the target kernel file, but the code that governs its
-performance may span OTHER files in this workspace (headers it includes, modules
-it imports, dispatch/config layers, or JIT template sources).
-
-The complete editable source allowlist is:
-{source_allowlist}
-
-You may inspect any dependency, but edit ONLY files in this allowlist. If an
-additional dependency must be editable, stop and report that the task's
-`editable_sources` declaration is incomplete. Do not edit measurement files.
-"""
-
-    dest.write_text(
-        f"""# Program: optimize {funcs}
-
-**GPU**: {gpu_arch}
-**Backend**: {backend}
-
-## Objective
-Optimize the body of `{funcs}` for maximum performance on {gpu_arch} while
-keeping numerical results correct (the loop gates on an SNR threshold).
-{scope_section}
-## Modification Rules
-1. You MAY make multiple changes across several places in the kernel this
-   iteration (not just one); group them under a clear hypothesis so the
-   iteration's effect stays attributable.
-2. Do NOT change the kernel's function signature or parameter list.
-3. Do NOT remove imports or helper utilities in the file.
-4. Do NOT edit task harness, test, scoring, or measurement files (`config.yaml`,
-   `script/`, `scripts/`, `test/`, `tests/`, `conftest.py`,
-   `performance_utils_pytest.py`, `*_test.py`, `*_test.cpp`, `*_test.cu`,
-   `*_test.hip`, `*_harness.py`). The Arena runner hashes these files and rejects
-   the score if they change. Directory rules match any path component; filename and
-   suffix rules match anywhere in the workspace, so both `dev/config.yaml` and
-   `dev/extra_test.py` are protected. Name your own scratch scripts outside those
-   patterns (`dev/sweep.py`) — a file you create that matches is deleted before
-   scoring.
-5. Build, run, and verify your edit YOURSELF (compile, run the driver, profile)
-   before finishing. The loop additionally runs a canonical correctness (SNR gate)
-   and benchmark pass on your final kernel after you stop.
-
-## Task instructions (from AgentKernelArena)
-{instructions}
-"""
-    )
 
 
 def _render_driver_shim(drivers_dir: str, workspace: str, task_config: str, arena_root: str) -> str:
@@ -623,7 +547,6 @@ def _build_forge_command(
     workspace: str,
     experiments_dir: Path,
     result_json: Path,
-    program_md: Path,
     agent_config: dict[str, Any],
     gpu_arch: str,
     fellow: str,
@@ -659,8 +582,6 @@ def _build_forge_command(
         fellow,
         "--git-branch",
         "forge-optimize",
-        "--program-md-file",
-        str(program_md),
         "--model",
         str(agent_config.get("model", "claude-opus-4-8")),
         "--permission-mode",
@@ -902,17 +823,6 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
         ))
         logger.info(f"Forge: generated driver shim -> {driver_dest} (task paths baked in)")
 
-    # program.md for agent guidance.
-    program_md = Path(workspace) / "forge_program.md"
-    _write_program_md(
-        task_config,
-        target_funcs,
-        gpu_arch,
-        backend,
-        all_source_files,
-        program_md,
-    )
-
     # Repository / image_kernel tasks bring a cloned repo (with its own nested
     # .git) into the workspace. Strip it before outer git init so keep/revert
     # tracks the real source files.
@@ -934,7 +844,6 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
         workspace=workspace,
         experiments_dir=experiments_dir,
         result_json=result_json,
-        program_md=program_md,
         agent_config=agent_config,
         gpu_arch=gpu_arch,
         fellow=fellow,

--- a/agents/forge/launch_agent.py
+++ b/agents/forge/launch_agent.py
@@ -40,6 +40,13 @@ from agents import register_agent
 _FORGE_RESULT_SENTINEL = "__FORGE_RESULT__"
 _KB_STATUS_FILE = "arena_forge_status.json"
 _FORGE_SHUTDOWN_MARGIN_SECONDS = 900
+_GPU_TYPE_ALIASES = {
+    # Arena historically accepts the family-style names below for the X SKUs.
+    # KernelForge addresses KB records by exact hardware model, so normalize the
+    # aliases before they become distinct, non-interoperable recipe identities.
+    "mi300": "mi300x",
+    "mi325": "mi325x",
+}
 
 
 def _normalize_gfx_arch(arch: str) -> str:
@@ -92,7 +99,7 @@ def _resolve_gpu_type(eval_config: dict[str, Any]) -> str:
             "target_gpu_model must be a non-empty hardware model token "
             f"for Forge KB identity; got {eval_config.get('target_gpu_model')!r}"
         )
-    return raw
+    return _GPU_TYPE_ALIASES.get(raw, raw)
 
 
 def _process_group_exists(pgid: int) -> bool:
@@ -475,6 +482,95 @@ def _git(workspace: str, *args: str, logger: logging.Logger) -> None:
         logger.debug(f"git {' '.join(args)} -> {result.returncode}: {result.stderr.strip()}")
 
 
+def _git_required(workspace: str, *args: str) -> str:
+    """Run a git query whose failure must reject the Forge result."""
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Forge workspace integrity check failed: git {' '.join(args)} "
+            f"returned {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _capture_forge_edit_baseline(workspace: str) -> str:
+    """Return the immutable commit Arena created before Forge starts editing."""
+    baseline = _git_required(workspace, "rev-parse", "--verify", "HEAD").strip()
+    if not re.fullmatch(r"[0-9a-f]{40,64}", baseline):
+        raise RuntimeError(f"Invalid Forge workspace baseline commit: {baseline!r}")
+    return baseline
+
+
+def _verify_forge_edit_scope(
+    workspace: str,
+    baseline_commit: str,
+    editable_sources: list[Path],
+    logger: logging.Logger | None = None,
+) -> None:
+    """Enforce Arena's declared source allowlist before final scoring.
+
+    KernelForge treats ``--source-files`` as orientation and KB metadata rather
+    than an edit boundary. Arena owns that boundary: only files resolved from
+    ``source_file_path`` plus ``editable_sources`` may differ from the initial
+    workspace snapshot. The check includes committed, staged, unstaged, deleted,
+    and renamed paths. Non-ignored untracked scratch files are discarded, matching
+    Arena's harness guard: they did not exist at baseline and cannot influence the
+    score after removal.
+    """
+    root = Path(workspace).resolve()
+    allowed: set[str] = set()
+    for source in editable_sources:
+        resolved = Path(source).resolve()
+        try:
+            relative = resolved.relative_to(root)
+        except ValueError as error:
+            raise RuntimeError(
+                f"Editable source escapes the Forge workspace: {resolved}"
+            ) from error
+        allowed.add(relative.as_posix())
+
+    changed_output = _git_required(
+        workspace,
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "-z",
+        baseline_commit,
+        "--",
+    )
+    untracked_output = _git_required(
+        workspace,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    )
+    changed = {path for path in changed_output.split("\0") if path}
+    untracked = {path for path in untracked_output.split("\0") if path}
+    for relative in sorted(untracked - allowed):
+        scratch = root / relative
+        try:
+            scratch.unlink()
+        except OSError as error:
+            raise RuntimeError(
+                f"Could not discard undeclared Forge scratch file: {relative}"
+            ) from error
+        if logger is not None:
+            logger.warning(
+                "Discarded undeclared Forge scratch file before scoring: %s",
+                relative,
+            )
+
+    violations = sorted(changed - allowed)
+    if violations:
+        raise RuntimeError(
+            "Forge changed files outside source_file_path/editable_sources; "
+            f"Arena refuses to score this result: {violations}"
+        )
+
+
 # Build artifacts / regenerated reports / forge scaffolding must NOT be tracked:
 # if they are, a validation or benchmark run that regenerates them dirties the
 # tree and makes the loop's `git revert` fail — leaking a reverted (often broken)
@@ -845,6 +941,7 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
 
     # The loop needs a git repo for the keep/revert pattern.
     _init_git_workspace(workspace, logger)
+    edit_baseline = _capture_forge_edit_baseline(workspace)
 
     experiments_dir = Path(workspace) / "forge_experiments"
     result_json = experiments_dir / "forge_result.json"
@@ -956,6 +1053,12 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
     # The loop runs on the 'forge-optimize' branch; ensure no partial/uncommitted
     # revert leaves the tree dirty before Arena re-scores.
     _git(workspace, "checkout", "--", ".", logger=logger)
+    _verify_forge_edit_scope(
+        workspace,
+        edit_baseline,
+        all_source_files,
+        logger,
+    )
 
     output = "\n".join(stdout_lines)
     if stderr_lines:

--- a/agents/forge/launch_agent.py
+++ b/agents/forge/launch_agent.py
@@ -84,6 +84,17 @@ def _resolve_gpu_arch(eval_config: dict[str, Any]) -> str:
     )
 
 
+def _resolve_gpu_type(eval_config: dict[str, Any]) -> str:
+    """Return Arena's hardware model in Forge's canonical KB token form."""
+    raw = str(eval_config.get("target_gpu_model") or "").strip().lower()
+    if not raw or not re.fullmatch(r"[a-z0-9][a-z0-9._+-]*", raw):
+        raise ValueError(
+            "target_gpu_model must be a non-empty hardware model token "
+            f"for Forge KB identity; got {eval_config.get('target_gpu_model')!r}"
+        )
+    return raw
+
+
 def _process_group_exists(pgid: int) -> bool:
     """Return whether a process group still has signalable members."""
     try:
@@ -549,6 +560,7 @@ def _build_forge_command(
     result_json: Path,
     agent_config: dict[str, Any],
     gpu_arch: str,
+    gpu_type: str,
     fellow: str,
     task_type: str,
     source_files: list[Path],
@@ -578,6 +590,8 @@ def _build_forge_command(
         str(_forge_max_hours(agent_config)),
         "--gpu-target",
         gpu_arch,
+        "--gpu-type",
+        gpu_type,
         "--fellow",
         fellow,
         "--git-branch",
@@ -786,8 +800,8 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
     task_type = str(task_config.get("task_type") or "").strip()
 
     gpu_arch = _resolve_gpu_arch(eval_config)
+    gpu_type = _resolve_gpu_type(eval_config)
     fellow = _resolve_fellow(task_config, agent_config)
-    backend = fellow.split("-")[0]
     logical_operator = _logical_operator(task_config)
     kernel_kind = _resolve_kernel_kind(task_config)
     framework = _resolve_framework(task_config)
@@ -846,6 +860,7 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
         result_json=result_json,
         agent_config=agent_config,
         gpu_arch=gpu_arch,
+        gpu_type=gpu_type,
         fellow=fellow,
         task_type=task_type,
         source_files=all_source_files,
@@ -862,6 +877,7 @@ def launch_agent(eval_config: dict[str, Any], task_config_dir: str, workspace: s
     logger.info(f"  kernel:      {kernel_file}")
     logger.info(f"  driver:      {driver_dest}")
     logger.info(f"  gpu target:  {gpu_arch}")
+    logger.info(f"  gpu type:    {gpu_type}")
     logger.info(f"  model:       {model}")
     logger.info(f"  fellow:      {fellow} (resolved from task configuration)")
     logger.info(f"  operator:    {logical_operator or '<forge inference>'}")

--- a/tasks/glm-5-2/.gitignore
+++ b/tasks/glm-5-2/.gitignore
@@ -1,0 +1,7 @@
+# Run artifacts. Task dirs are copied into a per-run workspace; nothing produced
+# by compile / correctness / performance belongs in the committed task source.
+build/
+__pycache__/
+*.pyc
+*.so
+.rocprofv3/

--- a/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/config.yaml
+++ b/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/config.yaml
@@ -1,0 +1,119 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/aiter
+repo_subdir: aiter
+# Paths are matched REPO-RELATIVE and exactly (preprocessing.py:_image_repo_copy_ignore),
+# so the aiter build scratch is `aiter/jit/build`, not `jit/build`. Getting this
+# wrong silently seeds an extra 2.9 GB into every run workspace; the prebuilt
+# .so that actually matter live in aiter/jit/ itself and are kept.
+image_repo_exclude:
+  - __pycache__
+  - aiter/jit/build
+# The compute cores are FlyDSL (mfma_moe1_* / mfma_moe2_*). Must be one of the
+# keys under `knowledge` in src/prompts/cheatsheet/default_cheatsheet.yaml
+# (flydsl/hip/triton) -- that is also forge's fellow set.
+repository_language: flydsl
+# The timed callable launches 7 device kernels in TWO languages. Both are listed:
+#   FlyDSL (.py, JIT re-keys on source, no rebuild needed)
+#     mfma_moe1_silu_mul_afp4_wfp4_*   ops/flydsl/kernels/mixed_moe_gemm_2stage.py:313
+#     mfma_moe2_afp4_wfp4_*_cshuffle   ops/flydsl/kernels/mixed_moe_gemm_2stage.py:7432
+#     moe_reduction_kernel_plain_*     ops/flydsl/kernels/moe_gemm_2stage.py:3591
+#   HIP C++ (aiter ships a prebuilt .so that shadows source edits)
+#     fused_mx_quant_moe_sort_kernel   csrc/kernels/quant_kernels.cu
+#     opus_moe_sorting_entry<P0_v2/P23> csrc/include/moe_sorting_opus.h
+# The two C/C++ entries are load-bearing, not documentation: src/jit_rebuild.py
+# only arms AITER_REBUILD=1 (and the stale-.so sweep) when source_file_path
+# contains a C/C++ extension. Drop them and an agent's edit to the HIP aux
+# kernels is silently ignored -- the benchmark keeps running the prebuilt .so.
+source_file_path:
+  - fused_moe.py
+  - ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+  - ops/flydsl/kernels/moe_gemm_2stage.py
+  - ops/shuffle.py
+  - csrc/kernels/quant_kernels.cu
+  - csrc/include/moe_sorting_opus.h
+# NOTE: `editable_sources` is not read by the framework (no reference anywhere in
+# src/ or main.py). The real edit surface is the whole copied aiter tree; this key
+# is kept only to record author intent about where the leverage is.
+editable_sources:
+  - configs/model_configs/glm5_fp4_tuned_fmoe.csv
+  - ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+  - ops/flydsl/kernels/moe_gemm_2stage.py
+  - csrc/kernels/quant_kernels.cu
+  - csrc/include/moe_sorting_opus.h
+  - fused_moe.py
+target_kernel_functions:
+  - fused_moe
+  - fused_moe_
+  - fused_moe_2stages
+kernel_identity:
+  logical_operator: mxfp4_moe_2stage
+  kernel_kind: flydsl
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: prefill-t16384
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 600
+correctness_timeout: 600
+performance_timeout: 600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the GLM-5.2 routed-expert MoE on MI355X/gfx950, as it executed in
+    Hyperloom session GLM-5.2-MXFP4_20260814T163244Z. Per-rank (TP=8) config:
+    model_dim=6144, inter_dim=256, 257 experts (256 routed + 1 fused shared),
+    topk=9, MXFP4 group_size=32 (QuantType.per_1x32), SiLU, bf16 output.
+
+    This is the **afp4_wfp4** path -- BOTH operands are MXFP4. The weights arrive
+    pre-quantized from the quark checkpoint and the activation is dynamically
+    quantized inside fused_moe. It is NOT the a16w4 path used by the Kimi-K3 MoE
+    task (`shuffle_weight_a16w4` / `shuffle_scale_a16w4`); GLM-5.2 uses
+    `shuffle_weight(w, (16,16))` + `e8m0_shuffle(scale)`, copied from
+    sglang quark_w4a4_mxfp4_moe.py:562-597.
+
+    The timed callable is the whole `aiter.fused_moe` for one MoE layer. That is
+    deliberate: the session's MoE cost is the two FlyDSL grouped GEMMs
+    (decode 15.08% + 7.86% of GPU time) AND the HIP family around them --
+    opus_moe_sorting_entry<P0_v2> and <P23>, the two fused_mx_quant_moe_sort
+    passes, grouped_topk, moe_reduction_kernel_plain_bf16_topk9_md6144,
+    _fused_append_shared_experts (another 12.5% of decode combined). All of it is
+    on the scoreboard, so fusing across those launches counts.
+
+    Two concrete, measured pieces of headroom:
+
+    (1) At the prefill shape stage-2 is broken. aiter's own GLM-5 tuning table
+    (configs/model_configs/glm5_fp4_tuned_fmoe.csv, TP=8 row inter_dim=256) has
+    stage-2 at 894.91 us against stage-1's 367.41 us at token=16384, despite
+    stage-2 having HALF the FLOPs, and it scales superlinearly (239 us @4096,
+    452 @8192, 895 @16384). The tuner's large-M pick is
+    flydsl_moe2_afp4_wfp4_bf16_t64x256x256_reduce_bnt2_sbm12 and that reduce
+    variant is the regression. This is invisible from a decode-only trace.
+
+    (2) At the decode shape M = 64 x 9 = 576 rows spread over 257 experts, about
+    2 rows per expert. Stage-1 measures 70 TFLOP/s versus 1102 TFLOP/s at the
+    prefill shape. Under CUDA graph the whole layer measures ~115 us while the
+    two GEMMs are ~78 us of it, so the sort/quant/reduce chain is the rest.
+
+    Useful levers: the MFMA pipeline and tile/block loop structure in
+    ops/flydsl/kernels/mixed_moe_gemm_2stage.py, stage-2's reduction strategy
+    (atomic vs reduce vs persist), the per-M-bucket tuned-config lookup in the
+    CSV, and the aiter Python dispatch in fused_moe.py.
+
+    Preserve the dispatch contract (block_m / ksplit semantics, moe_sorting
+    behaviour, the SEPARATED gate/up layout implied by shuffle_weight((16,16)),
+    doweight_stage1=False so the top-k weights are applied in the stage-2
+    reduction). Correctness compares against aiter's own torch_moe_stage1 /
+    torch_moe_stage2 at the same MXFP4 contract; the measured baseline error is
+    0.0016 mean relative and the gate is 0.01. Do not edit the harness under
+    scripts/.
+  cheatsheet: null

--- a/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/scripts/forge_driver.py
+++ b/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/scripts/task_runner.py
+++ b/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/scripts/task_runner.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the GLM-5.2 routed-expert MoE (aiter MXFP4 2-stage).
+
+Reproduces the MoE path of Hyperloom session GLM-5.2-MXFP4_20260814T163244Z on
+MI355X/gfx950. The timed callable is the whole ``aiter.fused_moe`` for one MoE
+layer, which is deliberate: the session's MoE cost is not just the two FlyDSL
+grouped GEMMs (decode 15.08% + 7.86%) but also the HIP family fused_moe launches
+around them -- ``opus_moe_sorting_entry<P0_v2>`` and ``<P23>``, the two
+``fused_mx_quant_moe_sort_kernel`` passes, ``grouped_topk_kernel``,
+``moe_reduction_kernel_plain_bf16_topk9_md6144`` and
+``_fused_append_shared_experts_kernel`` (another 12.5% of decode GPU time
+combined). Timing the whole op keeps all of that on the scoreboard.
+
+Quantization contract, verified against the in-image sources rather than assumed:
+
+  * GLM-5.2 is **afp4_wfp4** -- BOTH operands are MXFP4. The weights come
+    pre-quantized from the quark checkpoint; the activation is dynamically
+    quantized inside ``fused_moe``. This is a different path from the Kimi-K3
+    task's a16w4 (``shuffle_weight_a16w4`` / ``shuffle_scale_a16w4``), and the
+    two are not interchangeable.
+  * Weight prep is ``e8m0_shuffle`` on the scales (viewed 2D and restored) plus
+    ``shuffle_weight(w, (16, 16))`` on the packed weights, copied from
+    quark_w4a4_mxfp4_moe.py:562-597.
+  * The activation is ``ActivationType.Silu``. sglang's aiter runner only sets
+    ``gate_mode`` / ``beta`` / ``swiglu_limit`` for situ or swiglu_limit>0
+    models, and GLM-5.2 is neither, so the defaults are the session behaviour.
+  * ``doweight_stage1=False``: the top-k weights are applied in the stage-2
+    reduction, which is what ``moe_reduction_kernel_plain_bf16_topk9_md6144``
+    is doing in the trace.
+
+Routing structure is faithful too: topk=9 is 8 routed experts plus the shared
+expert, which sglang fuses in as expert id 256 (hence expert count 257 and the
+``_fused_append_shared_experts_kernel`` at 75 calls/step). Column 8 of
+``topk_ids`` is always the shared expert.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+CFG = SPEC["moe_config"]
+
+HIDDEN = CFG["model_dim"]
+INTER = CFG["inter_dim"]
+EXPERTS = CFG["experts"]
+ROUTED = CFG["n_routed_experts"]
+TOPK = CFG["topk"]
+SHARED_ID = CFG["shared_expert_id"]
+ROUTED_SCALE = CFG["routed_scaling_factor"]
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.environ.setdefault("SGLANG_USE_AITER", "1")
+
+    # The agent edits the workspace-seeded copy of aiter, so it must shadow the
+    # in-image install. Three details, each of which silently benchmarks the
+    # WRONG code if you get it wrong:
+    #
+    #  * ``image_repo_path`` is the aiter REPO ROOT, so the package lives at
+    #    <ws>/aiter/aiter/__init__.py and the path entry has to be <ws>/aiter,
+    #    not <ws>. Pointing at <ws> makes `import aiter` see <ws>/aiter as a
+    #    namespace portion (no __init__.py); Python then keeps scanning and the
+    #    in-image regular package at /sgl-workspace/aiter wins.
+    #  * aiter is an editable install whose .pth appends /sgl-workspace/aiter to
+    #    sys.path, so inserting at position 0 is what puts the copy in front.
+    #  * Do NOT set AITER_JIT_DIR. get_user_jit_dir() (jit/core.py:438) returns
+    #    it verbatim, and an empty dir means every aiter module rebuilds from
+    #    scratch. Left unset it falls through to `this_dir` -- the workspace's own
+    #    <ws>/aiter/aiter/jit, which is writable AND already holds the copied
+    #    prebuilt .so and flydsl_cache. Builds stay inside the workspace either
+    #    way; this way they start warm.
+    seeded_root = WORKSPACE / "aiter"
+    if (seeded_root / "aiter" / "__init__.py").is_file():
+        sys.path.insert(0, str(seeded_root))
+    os.chdir(WORKSPACE)
+
+
+def _assert_aiter_is_workspace_copy() -> None:
+    """Refuse to run against the in-image aiter when a workspace copy was seeded.
+
+    Failing closed here is the whole point: if the import resolves past the
+    workspace, an agent's edits are invisible and every number this harness
+    prints describes the original kernel.
+    """
+    import aiter
+
+    seeded_root = WORKSPACE / "aiter"
+    if not (seeded_root / "aiter" / "__init__.py").is_file():
+        return  # standalone run against the image tree; nothing to shadow
+    resolved = Path(aiter.__file__).resolve()
+    if seeded_root.resolve() not in resolved.parents:
+        raise RuntimeError(
+            f"aiter resolved to {resolved}, not the workspace copy under "
+            f"{seeded_root}. Source edits would be ignored. Check sys.path[0] "
+            f"and the __editable__ .pth for amd-aiter."
+        )
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _assert_weight_prep_contract() -> None:
+    """Fail loudly if the sglang weight-prep this harness copies has moved.
+
+    quark_w4a4_mxfp4_moe.py:562-597 is the source of truth for how GLM-5.2's
+    MoE weights reach aiter. If a patch (or an image bump) changes the shuffle,
+    the harness would silently benchmark a layout the server never produces.
+    """
+    from aiter.ops.shuffle import shuffle_weight  # noqa: F401
+    from aiter.utility.fp4_utils import e8m0_shuffle  # noqa: F401
+
+
+def _aiter_torch_quant():
+    """aiter's own torch-side MXFP4 quantizer for the per-1x32 scheme.
+
+    This is the quantizer aiter validates ``fused_moe`` against
+    (op_tests/test_moe_2stage.py:106 ``torch_quant = aiter.get_torch_quant(qType)``).
+    It is NOT interchangeable with ``fp4_utils.dynamic_mxfp4_quant``: the triton
+    quantizer rounds the e8m0 block scale differently, and substituting it leaves
+    a ~15% mean relative error against the kernel that has nothing to do with the
+    kernel being wrong.
+    """
+    import aiter
+
+    return aiter.get_torch_quant(aiter.QuantType.per_1x32)
+
+
+def _make(case: dict) -> dict:
+    """Build one case at its scored shape.
+
+    No correctness/performance switch: the shape that is timed is the shape that
+    is validated. Only ``compile`` shrinks anything.
+    """
+    torch = _torch()
+    import aiter
+    from aiter import ActivationType, QuantType
+    from aiter.ops.shuffle import shuffle_weight
+    from aiter.utility.fp4_utils import dynamic_mxfp4_quant, e8m0_shuffle
+
+    _assert_weight_prep_contract()
+    _assert_aiter_is_workspace_copy()
+
+    tokens = int(case["params"]["tokens"])
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(int(case["params"]["seed"]))
+
+    x = torch.randn(
+        (tokens, HIDDEN), device="cuda", dtype=torch.bfloat16, generator=gen
+    ) * 0.25
+
+    w1_bf16 = (
+        torch.randn(
+            (EXPERTS, INTER * 2, HIDDEN), device="cuda", dtype=torch.bfloat16,
+            generator=gen,
+        )
+        * 0.125
+    )
+    w2_bf16 = (
+        torch.randn(
+            (EXPERTS, HIDDEN, INTER), device="cuda", dtype=torch.bfloat16,
+            generator=gen,
+        )
+        * 0.125
+    )
+
+    # Quantize to the checkpoint layout: MXFP4, group_size=32, e8m0 scales.
+    q1, s1 = dynamic_mxfp4_quant(w1_bf16.reshape(-1, HIDDEN))
+    q1 = q1.view(EXPERTS, INTER * 2, -1)
+    s1 = s1.view(EXPERTS, INTER * 2, -1)
+    q2, s2 = dynamic_mxfp4_quant(w2_bf16.reshape(-1, INTER))
+    q2 = q2.view(EXPERTS, HIDDEN, -1)
+    s2 = s2.view(EXPERTS, HIDDEN, -1)
+
+    # sglang quark_w4a4_mxfp4_moe.py:576-596 -- scales e8m0_shuffle'd through a
+    # 2D view, weights shuffle_weight'd with (16, 16).
+    a, b, _ = s1.shape
+    s1_rt = e8m0_shuffle(s1.reshape(a * b, -1)).view(a, b, -1)
+    a, b, _ = s2.shape
+    s2_rt = e8m0_shuffle(s2.reshape(a * b, -1)).view(a, b, -1)
+    w1_rt = shuffle_weight(q1.contiguous(), (16, 16))
+    w2_rt = shuffle_weight(q2.contiguous(), (16, 16))
+
+    # Routing: 8 distinct routed experts + the fused shared expert in column 8.
+    scores = torch.rand((tokens, ROUTED), device="cuda", generator=gen)
+    routed_ids = scores.topk(TOPK - 1, dim=-1).indices.to(torch.int32)
+    routed_w = torch.softmax(
+        scores.gather(1, routed_ids.long()).float(), dim=-1
+    ) * ROUTED_SCALE
+    shared_ids = torch.full(
+        (tokens, 1), SHARED_ID, device="cuda", dtype=torch.int32
+    )
+    shared_w = torch.ones((tokens, 1), device="cuda", dtype=torch.float32)
+    topk_ids = torch.cat([routed_ids, shared_ids], dim=1).contiguous()
+    topk_weight = torch.cat([routed_w, shared_w], dim=1).contiguous()
+
+    return {
+        "cfg": case,
+        "aiter": aiter,
+        "fused_moe": __import__(
+            "aiter.fused_moe", fromlist=["fused_moe"]
+        ).fused_moe,
+        "quant_type": QuantType.per_1x32,
+        "activation": ActivationType.Silu,
+        "x": x,
+        "w1": w1_rt,
+        "w2": w2_rt,
+        "w1_scale": s1_rt,
+        "w2_scale": s2_rt,
+        "topk_weight": topk_weight,
+        "topk_ids": topk_ids,
+        # Unshuffled copies drive the torch reference.
+        "w1_q": q1,
+        "w1_s": s1,
+        "w2_q": q2,
+        "w2_s": s2,
+    }
+
+
+def _run(inputs: dict):
+    return inputs["fused_moe"](
+        hidden_states=inputs["x"],
+        w1=inputs["w1"],
+        w2=inputs["w2"],
+        topk_weight=inputs["topk_weight"],
+        topk_ids=inputs["topk_ids"],
+        quant_type=inputs["quant_type"],
+        activation=inputs["activation"],
+        doweight_stage1=False,
+        w1_scale=inputs["w1_scale"],
+        w2_scale=inputs["w2_scale"],
+    )
+
+
+def _reference(inputs: dict):
+    """aiter's own two-stage torch reference, driven at the session's config.
+
+    Uses ``torch_moe_stage1`` / ``torch_moe_stage2`` rather than a hand-rolled
+    dequant-and-matmul. They unpack the MXFP4 nibbles, apply the per-1x32 e8m0
+    group scales and accumulate in fp32, and they are the references aiter itself
+    validates ``fused_moe`` against, so the harness cannot drift from the kernel
+    over a detail of the quantization contract.
+
+    They are also fully batched -- one grouped GEMM per stage over all
+    (token, topk) rows, no Python loop over tokens or experts -- so the full
+    16384-token case stays affordable.
+
+    Both activations are quantized with aiter's torch quantizer because this is
+    the **a4w4** path: the activation is MXFP4 too, once going into stage 1 and
+    again on the stage-1 output going into stage 2 (the trace's two
+    ``fused_mx_quant_moe_sort_kernel`` launches).
+    """
+    torch = _torch()
+    import aiter
+    from aiter import dtypes
+    from aiter.fused_moe import torch_moe_stage1, torch_moe_stage2
+
+    torch_quant = _aiter_torch_quant()
+    x = inputs["x"]
+    tokens = x.shape[0]
+
+    a1_qt, a1_scale = torch_quant(x, quant_dtype=dtypes.fp4x2)
+    out1 = torch_moe_stage1(
+        a1_qt,
+        inputs["w1_q"],
+        inputs["w2_q"],
+        inputs["topk_weight"],
+        inputs["topk_ids"],
+        dtype=torch.bfloat16,
+        activation=inputs["activation"],
+        quant_type=aiter.QuantType.per_1x32,
+        a1_scale=a1_scale,
+        w1_scale=inputs["w1_s"],
+        doweight=False,
+    )
+    a2_qt, a2_scale = torch_quant(out1, quant_dtype=dtypes.fp4x2)
+    a2_qt = a2_qt.view(tokens, TOPK, -1)
+    if a2_scale is not None:
+        a2_scale = a2_scale.view(tokens, TOPK, -1)
+    return torch_moe_stage2(
+        a2_qt,
+        inputs["w1_q"],
+        inputs["w2_q"],
+        inputs["topk_weight"],
+        inputs["topk_ids"],
+        dtype=torch.bfloat16,
+        quant_type=aiter.QuantType.per_1x32,
+        w2_scale=inputs["w2_s"],
+        a2_scale=a2_scale,
+        doweight=True,
+    )
+
+
+def _assert_close(inputs: dict, got) -> None:
+    torch = _torch()
+    ref = _reference(inputs)
+    got = got.reshape(ref.shape).float()
+    ref = ref.float()
+    # MXFP4 on both operands plus a 257-way fp32 accumulation ordering
+    # difference: compare on a relative-error basis against the reference's own
+    # scale rather than elementwise absolute tolerance.
+    denom = ref.abs().mean().clamp_min(1e-6)
+    rel = (got - ref).abs().mean() / denom
+    max_rel = float(inputs["cfg"]["params"].get("max_relerr", 0.01))
+    if not torch.isfinite(got).all():
+        raise AssertionError("kernel output contains non-finite values")
+    if rel.item() > max_rel:
+        raise AssertionError(
+            f"mean relative error {rel.item():.4f} exceeds {max_rel} "
+            f"for case {inputs['cfg']['id']}"
+        )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the activation through its captured address.
+
+    Only ``x`` is data. The weights and the routing are workload structure: a
+    replayed graph captured the expert assignment, and re-drawing it would change
+    the sorting/padding work the benchmark is measuring.
+    """
+    torch = _torch()
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(47)
+    inputs["x"].normal_(generator=gen)
+    inputs["x"].mul_(0.25)
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Expert count, hidden and inter dims are left
+    alone because they select the FlyDSL kernel variant.
+    """
+    smoke = {**case, "params": dict(case["params"])}
+    smoke["params"]["tokens"] = min(int(case["params"]["tokens"]), 64)
+    return smoke
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed."""
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()  # noqa: F821 - injected with the AKA-GENERATED block
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=30,
+            target_ms=1.0,
+            max_graph_repeats=200,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "regime": case.get("regime"),
+            "model": SPEC.get("model"),
+            "session_id": SPEC.get("session_id"),
+            "gpu_pct": case.get("gpu_pct"),
+            "m_routed": int(case["params"]["tokens"]) * TOPK,
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness, "performance": run_performance}[
+        mode
+    ]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/session_cases.json
+++ b/tasks/glm-5-2/mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5/session_cases.json
@@ -1,0 +1,128 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.17 (ROCm 7.2.0) + aiter d9e5ef7ce",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/hyperloom-image/sglang:v0.5.17-rocm720-mi35x-profilerfix",
+  "model": "GLM-5.2-MXFP4",
+  "session_id": "GLM-5.2-MXFP4_20260814T163244Z_06452039",
+  "session_root": "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260814T163244Z",
+  "run": "runs/roofline/0c88d5c74d7d4031b1ed2f17bc8677b1/benchmark_sglang_20260814_190004",
+  "operator": "mxfp4_moe_2stage",
+  "timed_callable": "aiter.fused_moe -- one MoE layer. Profiled on the target part: 7 device kernels per call (2 FlyDSL grouped GEMMs + FlyDSL moe_reduction + 2 HIP mx-quant/sort + 2 HIP opus_moe_sorting phases).",
+  "task_name": "mi355x-glm52-flydsl-mxfp4-moe-2stage-20260814",
+  "selection": "Second-highest-E2E operator family of the GLM-5.2 session. The timed callable is the whole aiter fused_moe, so it covers the two FlyDSL grouped GEMMs (decode 15.08% + 7.86%) plus the five aux kernels fused_moe itself launches (moe_reduction, 2x mx-quant/sort, 2x opus sorting; 7.92% combined) -- 30.86% of decode GPU time, E2E ~19%.",
+  "e2e_attribution": {
+    "wall_clock_s": 719.61,
+    "prefill_pct": 52.9,
+    "decode_pct": 43.9,
+    "prefill_pct_of_prefill_gpu": 9.64,
+    "e2e_pct": 19.1,
+    "method": "decode: 8-rank torch trace, 128 x step[DECODE bs=64], kernel-sum 3283.7 ms/rank. prefill: aiter's own GLM-5 tuning table (configs/model_configs/glm5_fp4_tuned_fmoe.csv, TP=8 row inter_dim=256) at token=16384 gives us1=367.41 / us2=894.91 per layer -> 94.7 ms over 75 layers against the 982.0 ms measured prefill forward. Replaying fused_moe at the same shape on this part gives 1318 us/layer = 98.9 ms, i.e. within 4.4% of the table. In-scope decode share is 30.86%, not the full 33.49% MoE section: grouped_topk, _fused_append_shared_experts and the router gate GEMM sit upstream of fused_moe.",
+    "decode_pct_in_scope": 30.86
+  },
+  "headroom": {
+    "prefill_stage2_regression": "In glm5_fp4_tuned_fmoe.csv (TP=8 row) stage-2 costs 894.91 us at token=16384 versus stage-1's 367.41 us, despite having HALF the FLOPs. It scales superlinearly: 239 us @4096, 452 us @8192, 895 us @16384. The tuner's pick at large M is flydsl_moe2_afp4_wfp4_bf16_t64x256x256_reduce_bnt2_sbm12, and that reduce variant is the regression. This is invisible from the decode trace, which is why no prior pass found it.",
+    "decode_efficiency": "At the decode shape M = 64 x 9 = 576 rows spread over 257 experts -- about 2 rows per expert. Stage-1 measures 70 TFLOP/s versus 1102 TFLOP/s at the prefill shape: a 16x gap.",
+    "decode_aux_share": "At T=64 the whole fused_moe measures ~290 us eager while the two GEMMs account for ~78 us of it. The sort/quant/reduce family and launch overhead dominate the decode regime; there are two separate sorting launches (P0_v2, P23) and two separate MX-quant launches (stage-1 and stage-2 inputs)."
+  },
+  "provenance": {
+    "model_config": "/shared_nfs/hyperloom/models/GLM-5.2-MXFP4/config.json",
+    "entry": "aiter/fused_moe.py:441 fused_moe",
+    "compute_core": "aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py:313 (mfma_moe1_silu_mul_a{a}_w{b}_*) and :7432 (mfma_moe2_a{a}_w{b}_*_cshuffle)",
+    "call_chain": "GlmMoeDsaForCausalLM -> Quark w4a4 MXFP4 MoE (srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py) -> AiterRunnerCore (srt/layers/moe/moe_runner/aiter.py:196) -> aiter.fused_moe",
+    "weight_prep": "quark_w4a4_mxfp4_moe.py:562-597 process_weights_after_loading -- e8m0_shuffle on both scales (reshaped to 2D and back), shuffle_weight(w, (16,16)) on both packed weights. Reproduced verbatim in the harness.",
+    "quant_scheme": "afp4_wfp4: BOTH operands are MXFP4. Weights are pre-quantized (quark checkpoint, group_size=32, e8m0 scales); the activation is dynamically quantized inside fused_moe by fused_mx_quant_moe_sort_kernel. This is NOT the a16w4 path used by the Kimi-K3 task.",
+    "activation": "ActivationType.Silu (GLM-5.2 hidden_act=silu). No SiTUv2, no swiglu_limit, no gate_mode override -- the sglang aiter runner only sets those for situ / swiglu_limit>0 models.",
+    "doweight_stage1": false,
+    "verified_shapes": "Building the weights with aiter's own dynamic_mxfp4_quant reproduces the trace-recorded dims byte for byte: w1 [257,512,3072] float4_e2m1fn_x2, w1_scale [257,512,192] float8_e8m0fnu, w2 [257,6144,128] float4_e2m1fn_x2, w2_scale [257,6144,8] float8_e8m0fnu."
+  },
+  "moe_config": {
+    "model_dim": 6144,
+    "inter_dim": 256,
+    "inter_dim_full": 2048,
+    "tp_size": 8,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "experts": 257,
+    "num_experts_per_tok": 8,
+    "topk": 9,
+    "shared_expert_id": 256,
+    "routed_scaling_factor": 2.5,
+    "norm_topk_prob": true,
+    "scoring_func": "sigmoid",
+    "topk_method": "noaux_tc",
+    "activation": "silu",
+    "quant_type": "QuantType.per_1x32",
+    "group_size": 32,
+    "weight_dtype": "torch.float4_e2m1fn_x2",
+    "scale_dtype": "torch.float8_e8m0fnu",
+    "act_dtype": "torch.bfloat16",
+    "out_dtype": "torch.bfloat16",
+    "moe_layers": 75,
+    "dense_layers": 3
+  },
+  "cases": [
+    {
+      "id": "decode-t64",
+      "regime": "decode",
+      "gpu_pct": 33.49,
+      "trace_input_shapes": "x[64,6144] bf16 / w1[257,512,3072] fp4x2 / w2[257,6144,128] fp4x2 / w1_scale[257,512,192] e8m0 / w2_scale[257,6144,8] e8m0 / topk_weight[64,9] fp32 / topk_ids[64,9] int32",
+      "measured_session_us": 78.5,
+      "notes": "bs=64 decode CUDA-graph step; M_routed = 64 x 9 = 576. measured_session_us is the two GEMMs only (3.87 + 2.02 ms per 128 steps over 75 layers); the aux family adds another ~12.5% of decode GPU time on top.",
+      "params": {
+        "tokens": 64,
+        "seed": 29,
+        "max_relerr": 0.01
+      }
+    },
+    {
+      "id": "prefill-t16384",
+      "regime": "prefill",
+      "gpu_pct": 9.64,
+      "trace_input_shapes": "x[16384,6144] bf16 / weights as above / topk_weight[16384,9] fp32 / topk_ids[16384,9] int32",
+      "measured_table_us": 1262.3,
+      "notes": "chunked_prefill_size = max_prefill_tokens = 16384. M_routed = 147,456. measured_table_us = us1 367.41 + us2 894.91 from glm5_fp4_tuned_fmoe.csv at token=16384.",
+      "params": {
+        "tokens": 16384,
+        "seed": 31,
+        "max_relerr": 0.01
+      }
+    },
+    {
+      "id": "prefill-t8192",
+      "regime": "prefill",
+      "gpu_pct": 9.64,
+      "trace_input_shapes": "x[8192,6144] bf16 / weights as above / topk_weight[8192,9] fp32 / topk_ids[8192,9] int32",
+      "measured_table_us": 675.3,
+      "notes": "The 8192-token prefill bucket (23 of 399 in-window batches). M_routed = 73,728.",
+      "params": {
+        "tokens": 8192,
+        "seed": 37,
+        "max_relerr": 0.01
+      }
+    }
+  ],
+  "tolerance_note": "max_relerr is the MEAN relative error against aiter's own torch_moe_stage1/stage2 reference driven at the same MXFP4 contract. Measured 0.0016 at decode-t64 on the session image, so 0.01 is ~6x headroom. Using fp4_utils.dynamic_mxfp4_quant instead of aiter.get_torch_quant(per_1x32) for the activations pushes this to 0.15 -- the two quantizers round the e8m0 block scale differently. Do not swap them.",
+  "kernels_inside_timed_region": {
+    "flydsl": {
+      "mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32": 15.08,
+      "mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_vscale_fix3_fp4opt_v1_persist_cu256_acc0": 7.86,
+      "moe_reduction_kernel_plain_bf16_topk9_md6144": 1.29
+    },
+    "hip_cpp": {
+      "fused_mx_quant_moe_sort_kernel<bf16,fp4_t,256,32>": 2.32,
+      "fused_mx_quant_moe_sort_kernel<bf16,fp4_t,64,8>": 1.79,
+      "opus_moe_sorting_entry<P23>": 1.3,
+      "opus_moe_sorting_entry<P0_v2>": 1.22
+    },
+    "decode_pct_total": 30.86,
+    "note": "Percentages are share of decode GPU time in the scored run."
+  },
+  "kernels_outside_timed_region": {
+    "grouped_topk_kernel": 1.41,
+    "_fused_append_shared_experts_kernel": 1.22,
+    "hgemm_bf16_32x64x128x5_SPK8 (router gate 6144->256)": 1.92,
+    "note": "These run in sglang's select_experts path BEFORE fused_moe, so they are not in the timed region. The harness synthesizes topk_ids / topk_weight directly, matching their output structure (8 routed experts + shared expert 256 in column 8)."
+  }
+}

--- a/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/config.yaml
+++ b/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/config.yaml
@@ -1,0 +1,82 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/sglang/python/sglang
+repo_subdir: sglang
+image_repo_exclude:
+  - __pycache__
+repository_language: tilelang
+source_file_path:
+  - kernels/ops/attention/dsa/tilelang_kernel.py
+editable_sources:
+  - kernels/ops/attention/dsa/tilelang_kernel.py
+  - srt/layers/attention/dsa_backend.py
+target_kernel_functions:
+  - sparse_mla_fwd_decode_partial
+  - sparse_mla_fwd_decode_combine
+  - tilelang_sparse_fwd
+kernel_identity:
+  logical_operator: dsa_sparse_mla
+  kernel_kind: tilelang
+  source_owner: sglang
+  workload:
+    source: session_cases.json
+    primary_case: prefill-16384
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 600
+correctness_timeout: 600
+performance_timeout: 600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the GLM-5.2 DeepSeek-Sparse-Attention (DSA) sparse-MLA TileLang
+    kernels on MI355X/gfx950. This is the highest-E2E operator of Hyperloom
+    session GLM-5.2-MXFP4_20260814T163244Z: 21.46% of decode GPU time and
+    (measured by replay at the session's prefill shape) about 58% of the prefill
+    forward, i.e. roughly 40% end to end (range 36-52%).
+
+    IMPORTANT -- `main_kernel` in the session trace is TWO kernels, not one. Both
+    TileLang prim_funcs are named `main`, so roctracer records
+    `sparse_mla_fwd_decode_partial` (tilelang_kernel.py:811) and
+    `sparse_mla_fwd_decode_combine` (:989) under the same name. In the trace they
+    alternate 66.43 us / 4.21 us at 78 pairs per decode step. The hot one is
+    `partial` (20.18% of decode); `combine` is 1.28%. Prior analyses of this
+    session reported the sum as a single 21.5% kernel.
+
+    Both phases go through the same entry, `tilelang_sparse_fwd`
+    (tilelang_kernel.py:1317) -- server.log line 12 of the scored run reads
+    "Set DSA backends for bfloat16 KV Cache: prefill=tilelang, decode=tilelang".
+    The three harness cases are the session's real buckets: decode bs=64 (S=64),
+    and chunked prefill at S=16384 and S=8192. The whole entry function is timed,
+    so the partial/combine split, the `_pick_inner_iter` heuristic
+    (tilelang_kernel.py:75) and the launch geometry are all inside the edit
+    surface -- you may restructure them as long as the numerics hold.
+
+    Contract that must be preserved: Q is [1,S,8,576] bf16 where dims [0:512] are
+    the MLA latent and [512:576] the RoPE tail; K is the full 576-dim latent and V
+    is dims [0:512] of the SAME KV tensor; a NEGATIVE index means padding and must
+    be masked out of the softmax (a fully-masked row outputs 0, not NaN); topk is
+    2048 and `tilelang_sparse_fwd` asserts it.
+
+    Measured facts worth knowing: at the decode shape the kernel runs at
+    34.4 TFLOP/s (1.4% of bf16 peak) and moves KV at 2.27 TB/s -- it is
+    gather/latency bound, not compute bound. At the prefill shape inner_iter
+    becomes 32 and N_GROUPS becomes 1, which makes `combine` a 32768-block copy
+    over a single split -- pure overhead in that regime. Known trap: a previous
+    attempt on this session replaced the entry with an authored Triton kernel and
+    failed integration with
+    "HIP error: operation not permitted when stream is capturing" -- whatever you
+    write must still be capturable into sglang's decode CUDA graph, and the
+    harness times under CUDA graph so a non-capturable patch fails there too.
+
+    Preserve all correctness cases and improve the CUDA-graph measured
+    performance. Do not edit the harness under scripts/.
+  cheatsheet: null

--- a/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/scripts/forge_driver.py
+++ b/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/scripts/task_runner.py
+++ b/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/scripts/task_runner.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the GLM-5.2 DSA sparse-MLA TileLang kernel.
+
+Reproduces the highest-E2E operator of Hyperloom session
+GLM-5.2-MXFP4_20260814T163244Z on MI355X/gfx950.
+
+The timed callable is ``tilelang_sparse_fwd`` -- one MLA layer's worth of DSA
+attention, i.e. the ``sparse_mla_fwd_decode_partial`` + ``sparse_mla_fwd_decode_combine``
+pair. Both TileLang prim_funcs are named ``main``, so roctracer records both as
+``main_kernel``; in the session trace they alternate 66.43 us / 4.21 us at 78
+pairs per decode step.
+
+Both phases go through this same entry point. server.log line 12 of the scored
+run reads:
+
+    Set DSA backends for bfloat16 KV Cache: prefill=tilelang, decode=tilelang
+
+so the prefill cases below are the real prefill path, not a decode kernel run at
+a prefill shape.
+
+Two things this harness is deliberate about:
+
+  * **Index locality is part of the workload.** The kernel is gather-bound
+    (34.4 TFLOP/s = 1.4% of peak; 2.27 TB/s of KV gather at the decode shape).
+    Drawing top-k slots uniformly from the whole 1.81M-slot pool measures a
+    regime the model never enters -- it came out ~52% slower than the
+    session-faithful pattern at the prefill shape (11.13 vs 7.32 ms/layer).
+    ``_make`` therefore draws every query's top-k causally from its own
+    sequence's contiguous slot range, and sorts it, which is what sglang's
+    ``topk_transform`` emits.
+  * **Padding is exercised.** Queries at position p < 2048 get min(p+1, 2048)
+    valid entries and -1 for the rest; the kernel masks negatives out of the
+    softmax (tilelang_kernel.py:913). The prefill cases hit this on their first
+    2048 positions, so a patch that drops the mask fails correctness.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+COMMON = SPEC["params_common"]
+
+HEADS = COMMON["heads"]
+DIM = COMMON["dim"]
+TAIL_DIM = COMMON["tail_dim"]
+TOPK = COMMON["topk"]
+LATENT = DIM + TAIL_DIM
+KV_POOL_SLOTS = COMMON["kv_pool_slots"]
+SM_SCALE = LATENT**-0.5
+
+# Queries per reference chunk. The gathered buffer is (chunk, TOPK, 576) in fp32,
+# so 128 keeps it near 600 MB while staying wide enough that the reference is a
+# handful of large matmuls rather than a Python loop.
+_REFERENCE_QUERY_CHUNK = 128
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    # The DSA backend selection in tilelang_sparse_fwd is gated on aiter being
+    # active, exactly as in the session (EXTRA_ENV=SGLANG_USE_AITER=1).
+    os.environ.setdefault("SGLANG_USE_AITER", "1")
+    # Prefer the workspace-seeded copy of sglang so the agent's edits to
+    # kernels/ops/attention/dsa/tilelang_kernel.py take effect. TileLang JIT
+    # recompiles on source change.
+    seeded = WORKSPACE / "sglang"
+    if (seeded / "__init__.py").is_file():
+        sys.path.insert(0, str(WORKSPACE))
+    else:
+        sys.path.insert(0, os.environ.get("SGLANG_PYTHON", "/sgl-workspace/sglang/python"))
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _load_entry():
+    """Resolve ``tilelang_sparse_fwd`` from the (possibly edited) workspace copy.
+
+    Fails closed if the import resolved past the seeded copy: sglang is an
+    editable install with a PEP 660 finder, and if the workspace copy ever stops
+    winning, an agent's edits become invisible and every number this harness
+    prints describes the original kernel.
+    """
+    import sglang
+
+    from sglang.kernels.ops.attention.dsa.tilelang_kernel import tilelang_sparse_fwd
+
+    seeded = WORKSPACE / "sglang"
+    if (seeded / "__init__.py").is_file():
+        resolved = Path(sglang.__file__).resolve()
+        if seeded.resolve() not in resolved.parents:
+            raise RuntimeError(
+                f"sglang resolved to {resolved}, not the workspace copy under "
+                f"{seeded}. Source edits would be ignored."
+            )
+    return tilelang_sparse_fwd
+
+
+def _make(case: dict) -> dict:
+    """Build one case at its scored shape.
+
+    There is no correctness/performance switch: the shape that is timed is the
+    shape that is validated. Only ``compile`` shrinks anything, via
+    ``_compile_smoke_case``.
+    """
+    torch = _torch()
+    p = case["params"]
+    num_seqs = int(p["num_seqs"])
+    q_per_seq = int(p["q_per_seq"])
+    ctx_len = int(p["ctx_len"])
+    pool = int(p.get("kv_pool_slots", KV_POOL_SLOTS))
+    topk = int(p.get("topk", TOPK))
+    seq = num_seqs * q_per_seq
+
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(int(p["seed"]))
+
+    q = torch.randn(
+        (seq, HEADS, LATENT), device="cuda", dtype=torch.bfloat16, generator=gen
+    )
+    kv = torch.randn(
+        (pool, 1, LATENT), device="cuda", dtype=torch.bfloat16, generator=gen
+    )
+
+    # Each sequence owns a contiguous slot range in the paged pool.
+    base = torch.randint(
+        0, max(1, pool - ctx_len), (num_seqs,), device="cuda", dtype=torch.int64,
+        generator=gen,
+    )
+    sid = torch.arange(seq, device="cuda") // q_per_seq
+    # Absolute position of each query inside its own sequence. A prefill chunk
+    # covers the whole sequence; a decode step appends one token at the end.
+    within = torch.arange(seq, device="cuda") % q_per_seq
+    pos = within + (ctx_len - q_per_seq)
+    n_valid = torch.clamp(pos + 1, max=topk)
+
+    # Causal draw from [0, pos] of the query's own sequence, then sorted.
+    #
+    # The sort is not cosmetic. sglang's top-k selector
+    # (kernels/aot/csrc/elementwise/topk.hip) emits its 2048 slots in ascending
+    # order: `naive_topk_transform` (context <= 2048) copies the page table
+    # straight through, and `fast_topk_cuda_tl` is a radix-select that appends
+    # via atomicAdd while threads scan idx in strided order, so the output is
+    # monotone at block granularity. Leaving the draw unsorted scatters each
+    # 64-slot tile over the sequence's whole KV range and inflates the prefill
+    # case by 13% (8.30 ms/layer vs 7.31); block-shuffling within 64 measures the
+    # same as a full sort, so a plain sort is the faithful and simpler choice.
+    u = torch.rand((seq, topk), device="cuda", generator=gen)
+    sel_pos = (u * (pos + 1)[:, None].to(u.dtype)).long().clamp_(max=ctx_len - 1)
+    sel_pos, _ = sel_pos.sort(dim=1)
+    slots = (base[sid][:, None] + sel_pos).to(torch.int32)
+    ar = torch.arange(topk, device="cuda")[None, :]
+    indices = torch.where(
+        ar < n_valid[:, None], slots, torch.full_like(slots, -1)
+    ).unsqueeze(1).contiguous()
+
+    return {
+        "cfg": case,
+        "entry": _load_entry(),
+        "q": q,
+        "kv": kv,
+        "indices": indices,
+        "sm_scale": SM_SCALE,
+        "d_v": DIM,
+    }
+
+
+def _run(inputs: dict):
+    return inputs["entry"](
+        q=inputs["q"],
+        kv=inputs["kv"],
+        indices=inputs["indices"],
+        sm_scale=inputs["sm_scale"],
+        d_v=inputs["d_v"],
+    )
+
+
+def _reference(inputs: dict):
+    """Dense-gather sparse MLA reference.
+
+    Vectorized: the top-k set is gathered per chunk of queries and the two
+    contractions run as batched einsums, so the whole reference is a few dozen
+    large matmuls rather than a per-query Python loop. Chunking bounds the
+    gathered (chunk, topk, 576) fp32 buffer.
+
+    Matches the kernel semantics read off tilelang_kernel.py:900-968:
+      * K is the full 576-dim latent, V is dims [0:512] of the SAME tensor;
+      * ``sm_scale`` multiplies the raw QK dot before the softmax;
+      * a negative index is masked (-inf) and, if a whole row is masked, the
+        kernel divides by 1 so the output is 0 rather than NaN.
+    """
+    torch = _torch()
+    q = inputs["q"]
+    kv = inputs["kv"]
+    idx = inputs["indices"]
+    scale = inputs["sm_scale"]
+
+    seq = q.shape[0]
+    sel_all = idx[:, 0]  # (S, topk) int32, negatives = padding
+    out = torch.empty((seq, HEADS, DIM), device=q.device, dtype=q.dtype)
+
+    chunk = max(1, min(seq, _REFERENCE_QUERY_CHUNK))
+    for start in range(0, seq, chunk):
+        stop = min(start + chunk, seq)
+        sel = sel_all[start:stop].long()
+        valid = sel >= 0
+        gathered = kv[sel.clamp_(min=0), 0].float()  # (c, topk, 576)
+        scores = torch.einsum(
+            "qhd,qkd->qhk", q[start:stop].float(), gathered
+        ).mul_(scale)
+        scores.masked_fill_(~valid[:, None, :], float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        # An all-masked row softmaxes to NaN; the kernel emits 0 there.
+        probs = torch.nan_to_num(probs, nan=0.0)
+        out[start:stop] = torch.einsum(
+            "qhk,qkd->qhd", probs, gathered[:, :, :DIM]
+        ).to(out.dtype)
+    return out
+
+
+def _assert_close(inputs: dict, got) -> None:
+    torch = _torch()
+    ref = _reference(inputs)
+    # tilelang_sparse_fwd keeps the leading batch dim; the reference does not.
+    got = got.reshape(ref.shape)
+    torch.testing.assert_close(got.float(), ref.float(), atol=0.05, rtol=0.05)
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh data through the captured addresses.
+
+    A replayed CUDA graph reads the buffers it captured, so writing through them
+    changes what the scored kernel consumes. The index set is workload structure,
+    not data, so it stays fixed -- re-drawing it would change the locality the
+    benchmark is measuring.
+    """
+    torch = _torch()
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(47)
+    inputs["q"].normal_(generator=gen)
+    inputs["kv"].normal_(generator=gen)
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Shrink a case so the compile smoke test stays cheap.
+
+    Only ``compile`` may use this. Correctness and performance share one shape.
+    ``topk`` and the 576-dim latent are left alone because they change which
+    TileLang kernel gets specialized (topk must stay 2048 -- see the assert in
+    tilelang_sparse_fwd).
+    """
+    smoke = {**case, "params": dict(case["params"])}
+    smoke["params"]["num_seqs"] = min(int(case["params"]["num_seqs"]), 2)
+    smoke["params"]["q_per_seq"] = min(int(case["params"]["q_per_seq"]), 16)
+    smoke["params"]["ctx_len"] = min(int(case["params"]["ctx_len"]), 4096)
+    smoke["params"]["kv_pool_slots"] = 65536
+    return smoke
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    ``run_correctness`` checks a separate call, which a kernel can tell apart
+    from the scored one. This re-runs the timed unit against freshly perturbed
+    inputs and checks the buffer it wrote.
+    """
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()  # noqa: F821 - injected with the AKA-GENERATED block
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=5,
+            repetition=30,
+            target_ms=1.0,
+            max_graph_repeats=200,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "regime": case.get("regime"),
+            "model": SPEC.get("model"),
+            "session_id": SPEC.get("session_id"),
+            "gpu_pct": case.get("gpu_pct"),
+            "measured_session_us": case.get("measured_session_us"),
+            "measured_replay_us": case.get("measured_replay_us"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness, "performance": run_performance}[
+        mode
+    ]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/session_cases.json
+++ b/tasks/glm-5-2/mi355x_sglang_tilelang_dsa_sparse_mla_glm5/session_cases.json
@@ -1,0 +1,128 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.17 (ROCm 7.2.0)",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/hyperloom-image/sglang:v0.5.17-rocm720-mi35x-profilerfix",
+  "model": "GLM-5.2-MXFP4",
+  "session_id": "GLM-5.2-MXFP4_20260814T163244Z_06452039",
+  "session_root": "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260814T163244Z",
+  "run": "runs/roofline/0c88d5c74d7d4031b1ed2f17bc8677b1/benchmark_sglang_20260814_190004",
+  "operator": "dsa_sparse_mla",
+  "kernel": "main_kernel (TileLang prim_func `main`; partial + combine share the name)",
+  "timed_callable": "tilelang_sparse_fwd (partial + combine, one MLA layer)",
+  "task_name": "mi355x-glm52-tilelang-dsa-sparse-mla-20260814",
+  "selection": "Highest-E2E kernel of the GLM-5.2 session. Both phases run it: server.log line 12 -- 'Set DSA backends for bfloat16 KV Cache: prefill=tilelang, decode=tilelang'. E2E ~40% (36-52%).",
+  "e2e_attribution": {
+    "wall_clock_s": 719.61,
+    "prefill_s": 381.0,
+    "prefill_pct": 52.9,
+    "decode_s": 316.1,
+    "decode_pct": 43.9,
+    "scheduler_gap_s": 22.5,
+    "decode_measured_pct_of_decode_gpu": 21.46,
+    "decode_split": {
+      "partial": 20.18,
+      "combine": 1.28
+    },
+    "prefill_pct_of_prefill_gpu": 58.1,
+    "e2e_pct": 40.1,
+    "method": "decode side: 8-rank torch trace, 128 x step[DECODE bs=64], kernel-sum 3283.7 ms/rank, inter-rank spread <1%. prefill side: no kernel trace exists in the session (profiler window start_step=6080 caught 128 decode steps only), so the prefill share was measured directly by replaying this kernel at the session's prefill shape on the same gfx950 part: 7.317 ms/layer x 78 layers = 570.7 ms, against the 982.0 ms measured prefill forward (server.log, 376 batches, p10-p90 spread 0.7%) -> 58.1%. Range: the replay reuses one KV buffer across iterations so it runs L2-warm while the real forward touches a different per-layer KV slice each time, making 58.1% an OPTIMISTIC (low) estimate. Lower bound from the budget side: 982.0 - 185 ms of GEMM (measured from aiter's GLM-5 tuning table) - at most ~300 ms of all-reduce + norm/elementwise + indexer = 497 ms = 50.6%. Upper bound 982.0 - 185 = 797 ms = 81%. So E2E is 36-52%, centred on 40%.",
+    "e2e_pct_range": [
+      36,
+      52
+    ]
+  },
+  "provenance": {
+    "model_config": "/shared_nfs/hyperloom/models/GLM-5.2-MXFP4/config.json",
+    "entry": "sglang/kernels/ops/attention/dsa/tilelang_kernel.py:1317 tilelang_sparse_fwd",
+    "kernels": {
+      "partial": "tilelang_kernel.py:811 sparse_mla_fwd_decode_partial -- 78 calls/step, 66.43 us each, 663.31 ms/128 steps",
+      "combine": "tilelang_kernel.py:989 sparse_mla_fwd_decode_combine -- 78 calls/step, 4.21 us each, 42.07 ms/128 steps"
+    },
+    "call_chain": "GlmMoeDsaForCausalLM (models/glm4_moe.py:1447, subclass of DeepseekV2ForCausalLM) -> DSA attention backend (srt/layers/attention/dsa_backend.py) -> _forward_tilelang (:2923) -> tilelang_sparse_fwd",
+    "trace_evidence": "main_kernel durations alternate strictly 66.9 / 4.4 / 65.8 / 4.2 ... at 156 calls per decode step = 78 layers x (partial, combine). Both compile from a TileLang prim_func named `main`, which is why roctracer records one name.",
+    "server_args": "tp_size=8, kv_cache_dtype='bfloat16', attention_backend='dsa', dsa_prefill_backend='tilelang', dsa_decode_backend='tilelang', page_size=64, chunked_prefill_size=16384, max_prefill_tokens=16384, context_length=11264, disable_radix_cache=True, quantization='quark'",
+    "model_dims": {
+      "num_hidden_layers": 78,
+      "hidden_size": 6144,
+      "num_attention_heads": 64,
+      "tp_size": 8,
+      "heads_per_rank": 8,
+      "kv_lora_rank": 512,
+      "qk_rope_head_dim": 64,
+      "latent_dim": 576,
+      "v_head_dim_effective": 512,
+      "index_topk": 2048,
+      "kv_pool_slots": 1810496
+    }
+  },
+  "kernel_contract": {
+    "q": "[1, S, H=8, 576] bf16 -- MLA-absorbed query; dims [0:512] pair with the latent, [512:576] with the RoPE tail",
+    "kv": "[1, kv_pool_slots, 1, 576] bf16 -- the paged latent KV pool; K is all 576 dims, V is dims [0:512]",
+    "indices": "[1, S, 1, 2048] int32 -- DSA top-k slot ids; a NEGATIVE entry means padding and is masked out of the softmax (tilelang_kernel.py:913)",
+    "sm_scale": "(512+64)**-0.5, applied to the raw QK dot before softmax (the kernel folds log2(e) into it internally)",
+    "output": "[1, S, H, 512] bf16",
+    "launch_geometry": "block_I=64, threads=256, block_per_cu=2, cu=256, ni = 2048/64 = 32, inner_iter = _pick_inner_iter(S, 32, 256, 2), N_GROUPS = 32/inner_iter"
+  },
+  "workload_construction": {
+    "why_it_matters": "This kernel is gather-bound (34.4 TFLOP/s = 1.4% of peak, 2.27 TB/s of KV gather at the decode shape). Its runtime is dominated by the LOCALITY and ORDER of the top-k index set, not by the shape alone. Two independent ways to get this wrong, both measured: drawing indices uniformly from the whole 1.81M-slot pool instead of from the query's own sequence, and leaving the 2048 slots unsorted.",
+    "rule": "Every query draws its top-k from ITS OWN sequence's contiguous slot range, causally (positions 0..p), which is what sglang's topk_transform emits. Queries at position p < 2048 get min(p+1, 2048) valid entries and -1 padding for the rest.",
+    "decode": "64 concurrent requests, 1 new token each, each with its own ~8704-token context -> 64 disjoint working sets, no cross-query reuse (matches the trace's 2.27 TB/s).",
+    "prefill": "chunked_prefill_size=16384 over ISL=8192 requests -> one chunk covers 2 whole sequences, so 16384 queries share 2 x 9.4 MB of KV and get heavy L2 reuse.",
+    "index_order": "The 2048 slots of each row are SORTED ascending. sglang's selector (kernels/aot/csrc/elementwise/topk.hip) emits them that way: naive_topk_transform (context <= 2048) copies the page table straight through, and fast_topk_cuda_tl is a radix-select appending via atomicAdd while threads scan idx in strided order, so the output is monotone at block granularity. Measured cost of getting this wrong: an unsorted draw inflates prefill-16384 by 13% (8.30 ms/layer vs 7.32) and would have put the prefill share at 66% instead of 58%. Block-shuffling within 64 measures the same as a full sort (7.26 vs 7.31 ms)."
+  },
+  "params_common": {
+    "heads": 8,
+    "dim": 512,
+    "tail_dim": 64,
+    "topk": 2048,
+    "kv_pool_slots": 1810496,
+    "dtype": "bfloat16",
+    "index_dtype": "int32"
+  },
+  "cases": [
+    {
+      "id": "decode-bs64",
+      "regime": "decode",
+      "gpu_pct": 21.46,
+      "trace_input_shapes": "Q[1,64,8,576] bf16 / KV[1,1810496,1,576] bf16 / Indices[1,64,1,2048] int32",
+      "measured_session_us": 70.64,
+      "notes": "66.43 us partial + 4.21 us combine, 78x per decode step. inner_iter=4, N_GROUPS=8, partial grid (64,8)=512 blocks on 256 CUs.",
+      "params": {
+        "num_seqs": 64,
+        "q_per_seq": 1,
+        "ctx_len": 8704,
+        "seed": 29
+      }
+    },
+    {
+      "id": "prefill-16384",
+      "regime": "prefill",
+      "gpu_pct": 58.1,
+      "trace_input_shapes": "Q[1,16384,8,576] bf16 / KV[1,1810496,1,576] bf16 / Indices[1,16384,1,2048] int32",
+      "measured_replay_us": 7316.5,
+      "notes": "chunked_prefill_size=16384 = 2 x ISL 8192. inner_iter=32, N_GROUPS=1, partial grid (16384,1); combine degenerates to a 32768-block copy over NI=1 and is pure overhead here.",
+      "params": {
+        "num_seqs": 2,
+        "q_per_seq": 8192,
+        "ctx_len": 8192,
+        "seed": 31
+      }
+    },
+    {
+      "id": "prefill-8192",
+      "regime": "prefill",
+      "gpu_pct": 58.1,
+      "trace_input_shapes": "Q[1,8192,8,576] bf16 / KV[1,1810496,1,576] bf16 / Indices[1,8192,1,2048] int32",
+      "measured_replay_us": 3601.3,
+      "notes": "The 8192-token prefill bucket (23 of 399 in-window batches; server.log median 512.1 ms forward).",
+      "params": {
+        "num_seqs": 1,
+        "q_per_seq": 8192,
+        "ctx_len": 8192,
+        "seed": 37
+      }
+    }
+  ]
+}

--- a/tasks/glm-5-2/task-overview.md
+++ b/tasks/glm-5-2/task-overview.md
@@ -1,0 +1,425 @@
+# GLM-5.2-MXFP4 kernel tasks
+
+抽取自 Hyperloom session `100127` / `GLM-5.2-MXFP4_20260814T163244Z`
+（`/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260814T163244Z`），scored run
+`runs/roofline/0c88d5c74d7d4031b1ed2f17bc8677b1/benchmark_sglang_20260814_190004`
+—— 776 请求 · ISL 8192 / OSL 1024 / conc 64 · TP=8 · 8×MI355X · mxfp4(quark) ·
+719.61 s · 1104.24 tok/s。
+
+完整负载分析：
+`/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/glm-5.2-hot-kernels.md`
+
+| task | 算子 | **任务类型** | E2E 占比 | 模型里的位置 | 语言 | device kernel/次 | 状态 |
+|---|---|---|---|---|---|---|---|
+| [`mi355x_sglang_tilelang_dsa_sparse_mla_glm5`](#task-1--mi355x_sglang_tilelang_dsa_sparse_mla_glm5) | DSA 稀疏 MLA 注意力核 | **单算子** | **~40%** | 全部 78 层的 attention 主体 | TileLang | 2 | verified |
+| [`mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5`](#task-2--mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5) | MoE 专家 FFN（两段 grouped GEMM + 排序/量化/归约） | **多算子连接** | **~19%** | 第 3–77 层（75 层）的 FFN | FlyDSL + HIP C++ | 7 | verified |
+
+两个加起来约占端到端 GPU 时间的 **57%**。
+
+### 单算子 vs 多算子连接的判据
+
+两个 task 的粒度都是**一层**，都不止一个 device kernel，但性质不同 ——
+区别在于这些 kernel 之间是「同一个算子的实现拆分」还是「不同算子串起来」：
+
+* **Task 1 是单算子任务。** 2 个 kernel（`partial` + `combine`）是同一个 attention
+  的 **split-K 分解**：把 2048 个 key 切成 `N_GROUPS` 组各算一个局部 online softmax，
+  再按 LSE 合并。数学上就是一个 attention，拆成两个 kernel 纯粹是实现选择 ——
+  prefill 下 `N_GROUPS=1` 时 combine 已经退化成一次拷贝。agent 完全可以把两者
+  合并成一个 kernel 而不改变算子语义。
+* **Task 2 是多算子连接任务。** 7 个 kernel 覆盖 **5 类不同的算子**：
+  MXFP4 动态量化、按专家排序（拆成 P0/P23 两阶段）、grouped GEMM（stage-1/stage-2
+  两段）、SiLU·mul 激活（融进 stage-1）、topk 加权归约。它们各有独立的功能契约，
+  是一条真正的流水线，不是一个算子的拆分。
+
+两种情况下都是**整条链一起计时**，所以跨内部 launch 的重构和融合都算收益。
+kernel 数是在目标卡上 profile 实测的，不是推断。
+
+### 实测：编辑生效 + 耗时
+
+在**带 repo seed 的完整 workspace**（和 arena 的 `setup_workspace()` 一致：拷贝
+`image_repo_path` 到 `<ws>/<repo_subdir>/` + 注入 perf helper）上跑过：
+
+| task | compile | correctness | performance | 结果 |
+|---|---|---|---|---|
+| `dsa_sparse_mla` | 12 s | 13 s（×3 PASS） | 14 s | 0.0531 / 7.313 / 3.623 ms，全 `cuda_graph` |
+| `mxfp4_moe_2stage` | 7 s | 9 s（×3 PASS） | 10 s | 0.1149 / 1.274 / 0.697 ms，全 `cuda_graph` |
+
+最坏情况也远低于 5 分钟：DSA 清空 tilelang 全局缓存冷跑是 18 / 29 / 14 s；
+MoE 改了 HIP 源码触发重编是 33 s。三个阶段的 `*_timeout` 都设成 **600 s**，
+既是 2× 余量也是跑飞时的硬闸。
+
+**编辑生效验证（往源码里注入数值扰动，看 correctness 是否因此失败）：**
+
+| 语言 | 注入点 | 结果 |
+|---|---|---|
+| TileLang | `sparse_mla_fwd_decode_combine` 的累加 ×2 | correctness **FAIL** ✅ 生效 |
+| FlyDSL | `mixed_moe_gemm_2stage.py:2012` `silu_elem` ×2 | correctness **FAIL**（rel err 1.00）✅ 生效 |
+| HIP C++ | `quant_kernels.cu` 的 `absMax ×4` | 不 rebuild → **PASS**（跑旧 `.so`）<br>`AITER_REBUILD=1` → **FAIL**（rel err 0.67）✅ 生效 |
+
+HIP 那一行是这两个 task 里唯一需要外力的：aiter 带预编译 `.so`，不 rebuild 就会
+静默跑旧产物。`src/jit_rebuild.py` 会在 C/C++ 源码与镜像副本不一致时自动
+arm `AITER_REBUILD=1`（`_sources_match_image()`），三个阶段
+（`evaluator.py:52/87`、`performance.py:293`）都把它作为 `extra_env` 传给子进程 ——
+已实测确认这条链通。而且它**不是全量 aiter 编译**：只重编本次运行实际加载的模块，
+本任务是 `module_quant` + `module_moe_sorting_opus` 两个，33 秒。基线（未编辑）跑
+不会触发任何重编。
+
+### 实测：Arena + forge-loop 端到端
+
+run config 在 `/shared_nfs/jqliu/run_arena/config.forge_glm5_{dsa,moe}.yaml`
+（log/workspace 放 `/tmp`，理由同 `config.forge_mxfp4.yaml` 的注释）。
+环境变量 `source /shared_nfs/jqliu/set_env.sh`，
+启动 `python3 main.py --config_name <cfg>`。
+
+两个 task 都跑到 forge-loop 的主业务里，没有秒挂：
+
+| 检查点 | DSA | MoE |
+|---|---|---|
+| workspace seed + perf helper 注入 | ✅ | ✅ |
+| baseline compile / performance | ✅ 11 s / 13.5 s | ✅ |
+| arena baseline | 3 case，avg **3.6494 ms** | 3 case，avg **0.7167 ms** |
+| fellow 解析 | `tilelang-fellow` ⚠️ 见下 | `flydsl-fellow` ✅ |
+| `[prepare] task already conforms to the driver contract` | ✅ skip | ✅ skip |
+| `Starting autonomous iteration loop` | ✅ | ✅ |
+| forge 自测 baseline | **3.651 ms** | **0.714 ms** |
+| **`pristine anchor agrees with the task reference on 3 of 3 cases`** | ✅ | ✅ |
+| `[analysis] building commit-bound analysis bundle` | ✅ 进入 | ✅ 进入 |
+
+`prepare` 直接 skip 说明这两个 harness 天生就符合 forge 的 driver 契约，不需要
+forge 先改写任务；anchor 三个 case 全对上说明 forge 自己的 driver 调用和本 harness
+测的是同一件事。
+
+**两个已知问题：**
+
+1. **`Unknown fellow backend 'tilelang'; falling back to 'flydsl-fellow'`（DSA）。**
+   Arena 侧没问题 —— `src/prompts/cheatsheet/default_cheatsheet.yaml` 的 `knowledge`
+   里有 `tilelang`。是 KernelForge 的 `loop/campaign_config.py` 只认
+   flydsl / triton / hip / aiter / ck / hipblaslt，没有 tilelang，于是回落。
+   属于 KernelForge 的既有缺口：已有的
+   `image_kernel/mi355x_vllm_tilelang_mhc_fused_post_pre` 同样是
+   `repository_language: tilelang`，行为一致。只是 warning，不影响跑通，但 agent 拿到
+   的是 FlyDSL 的知识而不是 TileLang 的。
+
+2. **MoE 第一次跑被 OOM kill（`Forge loop completed with exit code: -9`）。**
+   两个原因叠加：当时机器上还有另一个同类 aiter MoE 任务在并发跑；以及
+   `image_repo_exclude` 的路径写错了（见 `config.yaml` 里的注释），
+   `aiter/jit/build` 的 2.9 GB 一直在被 seed 进每个 run 的 workspace。
+   修掉路径后 workspace 从 **7.1 GB 降到 3.8 GB**，单独跑时内存稳在 ~50 GiB
+   （cgroup 上限 128 GiB），顺利进入主循环。
+   注意 forge 挂掉之后 arena 的集中评测仍然正常跑完 3/3 —— 也就是说这类崩溃
+   会安静地退化成"没有优化"，不会报错，看 `exit code: -9` 才知道。
+
+---
+
+## 模型结构与两个 task 的位置
+
+GLM-5.2（`GlmMoeDsaForCausalLM`，继承 `DeepseekV2ForCausalLM`）：
+**78 层** · hidden **6144** · MLA(`q_lora_rank=2048, kv_lora_rank=512, qk_rope_head_dim=64`)
+· 64 heads（TP=8 → **每卡 8 head**）· DSA indexer(`index_n_heads=32, index_head_dim=128,
+index_topk=2048, index_topk_freq=4`) · MoE(256 routed + 1 shared, topk 8,
+`moe_intermediate_size=2048` → 每卡 256) · `first_k_dense_replace=3`。
+
+```
+每一层 (× 78)
+ x [T, 6144] bf16
+  │
+  ├─ RMSNorm
+  ├─ MLA attention ─────────────────────────────────────────────────
+  │    ├─ QKV-A 融合投影      6144 → 2624   (q_lora 2048 + kv_lora 512 + rope 64)
+  │    ├─ q_b_proj            2048 → 2048   (8 head × qk_head_dim 256)
+  │    ├─ fused_qk_rmsnorm  /  RoPE + 写 KV cache
+  │    │
+  │    ├─ DSA indexer  ── 只在 21 层跑（indexer_types 里的 "full"：第 0,1,2,6,10,…,74 层）
+  │    │     indexer q 2048→4096 · k 6144→128 · weights 6144→32
+  │    │     → Hadamard → fp8 量化 → paged MQA 打分 → top-2048
+  │    │     产出 Indices [T, 2048] int32                    ← 选出每个 query 要看的 2048 个 KV
+  │    │     （其余 57 层复用上一个 full 层的 Indices）
+  │    │
+  │    ├─ bmm  q_nope(192) × kv_b  → 512 latent
+  │    ├─ ★★★ TASK 1：DSA 稀疏 MLA（sparse_mla_fwd_decode_partial + combine）★★★
+  │    ├─ bmm  attn_out(512) × v_b → 256
+  │    └─ o_proj              2048 → 6144
+  ├─ TP all-reduce                                            （不在 task 范围，用户要求排除）
+  ├─ add_rmsnorm_quant
+  ├─ FFN ────────────────────────────────────────────────────────────
+  │    ├─ 第 0–2 层  (dense)：普通 MLP，intermediate 12288（每卡 1536）
+  │    └─ 第 3–77 层 (sparse, 共 75 层)：
+  │          router gate 6144 → 256  →  top-8 + 拼上 shared expert  →  topk=9
+  │          ★★★ TASK 2：aiter fused_moe（两段 grouped GEMM + 排序/量化/归约）★★★
+  └─ TP all-reduce
+```
+
+---
+
+## Task 1 — `mi355x_sglang_tilelang_dsa_sparse_mla_glm5`
+
+> **任务类型：单算子。** 2 个 device kernel 是同一个 attention 的 split-K 分解
+> （局部 softmax + LSE 合并），不是两个算子；可以合并成一个。
+
+### 这是什么算子
+
+**DeepSeek Sparse Attention (DSA) 的稀疏 MLA 注意力核。** GLM-5.2 的注意力是
+MLA（吸收式，query 被投影进 512 维 latent 空间）叠加 DSA 稀疏化：indexer 先给每个
+query 挑出 2048 个最相关的 KV 位置，这个 kernel 只对这 2048 个位置做 attention，
+而不是对整个上下文。
+
+它由**两个 kernel** 组成，一层跑一对：
+
+| | 作用 | decode 内 | 单次耗时 |
+|---|---|---|---|
+| `sparse_mla_fwd_decode_partial` | 把 2048 个 key 切成 N_GROUPS 组，每组算一个局部 attention（online softmax），输出 partial output + LSE | **20.18%** | 66.43 µs |
+| `sparse_mla_fwd_decode_combine` | 按 LSE 把各组的 partial output 加权合并成最终输出 | 1.28% | 4.21 µs |
+
+> 两个 TileLang prim_func 都叫 `main`，编出来的 HIP kernel 都叫 `main_kernel`，
+> 所以 trace 里它们是同一个名字、严格交替出现（66.9 / 4.4 / 65.8 / 4.2 …）。
+> session 自带的所有报告都把两者之和当成一个 21.5% 的 kernel 报了。
+
+### E2E 占比：**~40%**（区间 36–52%）
+
+| | 占该阶段 GPU 时间 | 阶段占 E2E | 贡献 |
+|---|---|---|---|
+| decode | **21.46%**（实测：8 rank trace，128 个 `step[DECODE bs=64]`） | 43.9% | 9.4% |
+| prefill | **~58%**（同卡按 session 的 prefill shape 回放实测：7.317 ms/层 × 78 层 = 570.7 ms，对 982.0 ms 的 prefill forward） | 52.9% | 30.7% |
+| **合计** | | | **~40%**（区间 36–52%） |
+
+两个阶段都走同一个入口 —— 这条 server.log 是硬证据：
+
+```
+[2026-08-14 19:00:23] Set DSA backends for bfloat16 KV Cache: prefill=tilelang, decode=tilelang
+```
+
+这是整个 session 里 E2E 占比最高的算子，比第二名高一倍多。
+
+### 对应模型结构的哪个部分
+
+**全部 78 层的 attention 主体。** 在上面的结构图里，它夹在
+「q_nope × kv_b 的 absorb bmm」和「attn_out × v_b 的输出 bmm」之间 ——
+也就是真正做 QK^T / softmax / PV 的那一步。
+
+它**不包含**：QKV 投影、o_proj、RoPE、KV cache 写入、以及 DSA indexer
+（indexer 是给它准备 `Indices` 的上游，21 层跑一次，另有 12 个小 kernel，
+decode 内合计 7.6%，不在本 task 里）。
+
+### shape（每卡，heads=8，latent 512+64=576，topk 2048）
+
+| case | Q | Indices | KV pool | inner_iter / N_GROUPS |
+|---|---|---|---|---|
+| `decode-bs64` | `[1, 64, 8, 576]` bf16 | `[1, 64, 1, 2048]` int32 | `[1, 1810496, 1, 576]` bf16 | 4 / 8 |
+| `prefill-16384` | `[1, 16384, 8, 576]` | `[1, 16384, 1, 2048]` | 同上 | 32 / 1 |
+| `prefill-8192` | `[1, 8192, 8, 576]` | `[1, 8192, 1, 2048]` | 同上 | 32 / 1 |
+
+K 是完整的 576 维 latent，V 是同一个张量的前 512 维；索引为负表示 padding，
+必须从 softmax 里 mask 掉。
+
+**索引的 locality 是 workload 的一部分。** 这个 kernel 是 gather-bound
+（decode 下 34.4 TFLOP/s = 峰值的 1.4%，KV gather 2.27 TB/s），耗时取决于 top-k
+索引集的局部性，不只是 shape。harness 让每个 query 从**自己序列的连续 slot 区间**里
+因果地取（也就是 `topk_transform` 真正吐出来的东西）：decode = 64 条独立序列各 1 个新
+token（无跨 query 复用）；prefill = 一个 16384 chunk 覆盖 2 条完整的 ISL-8192 序列
+（大量 L2 复用）。改成在 181 万 slot 的池子里均匀随机取，prefill 会**慢 52%**
+（11.13 ms vs 7.32 ms），测的是模型根本不会进入的 regime。
+
+### 语言与源码
+
+TileLang（Python DSL → TVM/TIR → HIP，JIT，改源码自动重编译），
+`sglang/kernels/ops/attention/dsa/tilelang_kernel.py`
+—— partial 在 `:811`，combine 在 `:989`，入口 `tilelang_sparse_fwd` 在 `:1317`。
+**两个 kernel 在同一个文件里**，可以合并重构。
+
+### headroom 与前车之鉴
+
+decode 下 34.4 TFLOP/s（峰值 1.4%）、2.27 TB/s —— gather/延迟受限，不是算力受限。
+prefill 下 `inner_iter=32` → `N_GROUPS=1`，combine 退化成 32768 个 block 去 reduce
+单个 split，是纯浪费。`_pick_inner_iter`（`tilelang_kernel.py:75`）是只有 2 的幂档位的
+粗启发式，`block_I=64 / threads=256 / block_per_cu=2` 三个常数没针对 gfx950 搜过。
+
+session 里 GEAK 花了约 10 小时在一个叫 `dsa_sparse_attn_prefill_main_kernel_task`
+的任务上，但 `opbench_result.json` 是 `isolated_speedup: 0.0` / `winner_ms: null` /
+`winner_editable: false` —— 它从没 benchmark 过这个 kernel，而是转去调 server flag。
+`reports/kernel_optimization_summary.json` 写的是 `kernel_opt_outcome: "skip"` /
+`by_kernel: []` / *"No kernels were attempted"*。那个 authored-Triton 替换
+（`final/overlay/dsa_authored_c0_triton.py`）挂在
+`HIP error: operation not permitted when stream is capturing`。
+**这里的 kernel 级 headroom 从来没被真正测过**；写出来的东西必须仍然能被 CUDA graph capture。
+
+---
+
+## Task 2 — `mi355x_sglang_flydsl_mxfp4_moe_2stage_glm5`
+
+> **任务类型：多算子连接。** 7 个 device kernel 覆盖 5 类不同算子
+> （量化 / 排序 / grouped GEMM / 激活 / 归约），是一条流水线；跨算子融合算收益。
+
+### 这是什么算子
+
+**MoE 专家前馈网络的完整一层**，即 `aiter.fused_moe`。被计时的是整条链，
+一次调用启动 **7 个 device kernel**（在目标卡上 profile 实测）：
+
+| kernel | 作用 | 语言 | 源码 | decode 内 |
+|---|---|---|---|---|
+| `mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32` | **stage-1 grouped GEMM**：`6144 → 512`（gate+up），带 SiLU·mul | FlyDSL | `ops/flydsl/kernels/mixed_moe_gemm_2stage.py:313` | 15.08% |
+| `mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_..._acc0` | **stage-2 grouped GEMM**：`256 → 6144`（down） | FlyDSL | 同文件 `:7432` | 7.86% |
+| `fused_mx_quant_moe_sort_kernel<bf16,fp4_t,256,32>` | stage-1 输入的 MXFP4 动态量化 + 按专家排序 | HIP C++ | `csrc/kernels/quant_kernels.cu` | 2.32% |
+| `fused_mx_quant_moe_sort_kernel<bf16,fp4_t,64,8>` | stage-2 输入（stage-1 输出）的量化 + 排序 | HIP C++ | 同文件 | 1.79% |
+| `opus_moe_sorting_entry<P23>` | moe sorting 第二阶段 | HIP C++ | `csrc/include/moe_sorting_opus.h` | 1.30% |
+| `moe_reduction_kernel_plain_bf16_topk9_md6144` | 按 topk 权重把 9 份专家输出归约回 hidden | FlyDSL | `ops/flydsl/kernels/moe_gemm_2stage.py:3591` | 1.29% |
+| `opus_moe_sorting_entry<P0_v2>` | moe sorting 第一阶段 | HIP C++ | 同文件 | 1.22% |
+| | | | | **30.86%** |
+
+整条链一起计时，所以跨 launch 融合（两次 sorting 合一、两次 mx-quant 合一）算收益。
+
+### E2E 占比：**~19%**
+
+| | 占该阶段 GPU 时间 | 阶段占 E2E | 贡献 |
+|---|---|---|---|
+| decode | **30.86%**（实测） | 43.9% | 13.5% |
+| prefill | **9.64%**（aiter 自带 GLM-5 调优表 TP=8 行 @token=16384：us1 367.41 + us2 894.91，× 75 层 = 94.7 ms / 982.0 ms；本机回放 1318 µs/层 = 98.9 ms，差 4.4%） | 52.9% | 5.1% |
+| **合计** | | | **~19%** |
+
+### 对应模型结构的哪个部分
+
+**第 3–77 层（共 75 层）的 FFN。** 前 3 层是 dense MLP（`first_k_dense_replace=3`），
+不走这条路。
+
+具体是 router 选完专家之后的那一段：
+
+```
+router gate 6144→256  →  top-8 routed + 拼上 shared expert  →  topk_ids [T, 9]
+                                                    ↓
+                              ★ 本 task：fused_moe(x, w1, w2, topk_weight, topk_ids) ★
+                                    量化+排序 → stage-1 GEMM → SiLU·mul
+                                              → 量化+排序 → stage-2 GEMM → 加权归约
+                                                    ↓
+                                              out [T, 6144]
+```
+
+**不包含**上游的 `grouped_topk`（1.41%）、`_fused_append_shared_experts`（1.22%）
+和 router gate GEMM（1.92%）—— 它们在 sglang 的 `select_experts` 里，
+在 `fused_moe` 之前跑。harness 直接合成 `topk_ids` / `topk_weight`，
+结构与它们的输出一致（8 个 routed + 第 9 列固定是 shared expert 256）。
+
+### shape（每卡 TP=8）
+
+`model_dim=6144` · `inter_dim=256` · `experts=257`（256 routed + 1 融合的 shared）
+· `topk=9` · MXFP4 `group_size=32` · SiLU · bf16 输出。
+
+这是 **afp4_wfp4**：权重和激活**都是** MXFP4（权重来自 quark checkpoint 预量化，
+激活在 `fused_moe` 内部动态量化）。跟 Kimi-K3 那个 task 的 a16w4 不是一条路 ——
+GLM-5.2 走 `shuffle_weight(w, (16,16))` + `e8m0_shuffle(scale)`，抄自 sglang
+`quark_w4a4_mxfp4_moe.py:562-597`。
+
+| case | x | M_routed |
+|---|---|---|
+| `decode-t64` | `[64, 6144]` bf16 | 576 |
+| `prefill-t16384` | `[16384, 6144]` bf16 | 147,456 |
+| `prefill-t8192` | `[8192, 6144]` bf16 | 73,728 |
+
+权重形状（用 aiter 自己的 `dynamic_mxfp4_quant` 构造，与 trace 记录逐位一致）：
+
+```
+w1       [257,  512, 3072]  float4_e2m1fn_x2     w1_scale [257,  512, 192]  float8_e8m0fnu
+w2       [257, 6144,  128]  float4_e2m1fn_x2     w2_scale [257, 6144,   8]  float8_e8m0fnu
+```
+
+### 语言与源码
+
+**两种语言**（见上表的源码列）：
+
+- **FlyDSL**（aiter 的 Python DSL → MFMA 汇编，JIT，改源码自动重编译）—— 3 个 kernel
+- **HIP C++**（aiter 带预编译 `.so`，编辑会被静默忽略）—— 4 个 kernel。
+  `src/jit_rebuild.py` 只在 `source_file_path` 含 C/C++ 扩展名时才 arm
+  `AITER_REBUILD=1` + 清理 stale `.so`，所以 `config.yaml` 里那两个 `csrc` 条目是
+  **功能性的、不是文档**。
+
+入口 `aiter/fused_moe.py:441`。`repository_language` 只能填一个值（框架用它选
+cheatsheet / forge fellow），填的是 `flydsl`，因为时间大头（22.94% / 30.86%）
+在两个 FlyDSL GEMM 上。
+
+> 注：`editable_sources` 这个 key 框架**根本不读**（`src/` 和 `main.py` 里零引用）。
+> 真正的编辑面是整个被拷贝的 repo；该 key 只用来记录作者意图。
+
+### headroom
+
+**stage-2 在大 M 上是坏的。** aiter 自己的 GLM-5 调优表
+（`configs/model_configs/glm5_fp4_tuned_fmoe.csv`，TP=8 行 `inter_dim=256`）：
+
+| token | stage-1 µs | stage-2 µs |
+|---|---|---|
+| 4096 | 149.08 | 239.42 |
+| 8192 | 222.97 | 452.37 |
+| 16384 | **367.41** | **894.91** |
+
+stage-2 的 FLOP 只有 stage-1 的一半却慢 2.4 倍，而且超线性。调优器在大 M 上挑的是
+`flydsl_moe2_afp4_wfp4_bf16_t64x256x256_reduce_bnt2_sbm12`。decode-only 的 trace
+看不见这个，所以之前没人发现。
+
+**decode 离峰值差 16 倍。** M = 64 × 9 = 576 行摊到 257 个专家上，平均每个 2 行：
+stage-1 是 70 TFLOP/s，prefill shape 下是 1102 TFLOP/s。
+
+---
+
+## 两个 task 的共同约定
+
+1. **shape 全部来自 session 实测。** 每个 case 都是 scored run 真正跑过的桶，
+   取自 8 rank torch trace、CUDA-graph capture trace 的 `record_shapes` 和
+   `server.log`。算子在两个阶段都跑的，两个阶段都覆盖。
+2. **精度和性能跑同一套 shape。** harness 里没有 correctness/performance 分支 ——
+   被计时的 shape 就是被校验的 shape。只有 `compile` 走
+   `_compile_smoke_case` 缩小。
+3. **性能用 CUDA graph 测。** 用框架的 `_benchmark_cuda_graph_or_events` +
+   `_TimedRun`，被计时的那次就是 graph replay，而且**测完之后会扰动输入、
+   把输出填 NaN、重放同一个 graph 再校验一次** —— 想在被计时的那条路上偷工减料会挂。
+   六个 case 全部报 `benchmark_method: cuda_graph`，没有回落到 event timing。
+4. **ref 用 torch 且向量化。** 全 shape correctness 几秒跑完。
+   * **DSA**：按 128 query 分块 gather + 每块两个 batched einsum，无 per-query 循环。
+     语义照着 `tilelang_kernel.py:900-968` 读出来的 —— K 是完整 576 维 latent，
+     V 是**同一个张量**的前 512 维，`sm_scale` 乘在原始 QK 点积上，
+     **整行被 mask 掉时输出 0 而不是 NaN**。容差 `atol = rtol = 0.05`
+     （bf16 在 2048 个 key 上累加）。
+   * **MoE**：直接用 aiter 自己验证 `fused_moe` 用的 `torch_moe_stage1` /
+     `torch_moe_stage2`，每段一个 grouped GEMM，不循环 token/expert。
+     门限 `max_relerr = 0.01`（实测 0.0016）。
+
+MoE 的容差有个坑：ref 里两次激活量化必须用
+`aiter.get_torch_quant(QuantType.per_1x32)`，**不能**换成
+`fp4_utils.dynamic_mxfp4_quant` —— 两者对 e8m0 block scale 的舍入不同，换了之后
+mean relative error 从 0.0016 涨到 0.15，看着像 kernel 有 bug 其实不是。门限 0.01。
+
+---
+
+## 没做的算子和取舍
+
+候选排序来自上面那份负载分析。跳过的：
+
+* **TP all-reduce（E2E ~8.8%）** —— 按要求排除。顺带记一笔：它其实是两套实现，
+  decode 走 aiter `cross_device_reduce_2stage`，prefill 的张量超过 16 MiB 的
+  `_MAX_CAR_SIZE` 会回落 RCCL。
+* **MoE 辅助族** —— 故意不单独建 task。8 个辅助 kernel 里有 5 个（decode 7.92%）
+  就在 `fused_moe` 内部，已经在 Task 2 的计时区里，单独建会重复计分。
+  另外 3 个（`grouped_topk` 1.41%、`_fused_append_shared_experts` 1.22%、
+  router gate GEMM 1.92%）在 sglang 的 `select_experts` 里，确实没覆盖 ——
+  合计 decode 4.55%、E2E ~2%，不值得单独长跑。
+* **`Cijk_*` / hipBLASLt（decode ~9.8%）** —— `/opt/rocm/lib/hipblaslt/library/`
+  下的预编译 Tensile 汇编，不在镜像 repo 里，构造不出 `image_kernel` 任务。
+  要做只能做成把 `aten::mm`/`bmm` 路由到 FlyDSL 的派发任务。
+* **`aten::mul` 权重缩放（decode 2.83%）** —— 这是框架 bug 不是 kernel 问题：
+  `[8,192,512]` 和 `[8,512,256]` 是 kv_b/v_b 的**权重**，每层每次 forward 都被重新
+  乘一遍标量。该在权重加载时折进去。
+* **DSA indexer paged-MQA-logits（decode 1.55%，E2E ~1.5–3%）** —— **没建**。
+  kernel 本身能跑（`aiter/ops/triton/gluon/pa_mqa_logits.py:351`，实测 29.3 µs
+  eager，shape 为 `q[64,32,128]` fp8 / `kv[28289,64,1,132]` fp8 /
+  `weights[64,32]` fp32 / `block_tables[64,177]`，max_seq_len 11328），但它跑在
+  `Preshuffle=True` 模式，block 内的 KV 布局由
+  `aiter::indexer_k_quant_and_cache_kernel` 写出，aiter 既没暴露对应 helper
+  也没有 torch 参考，手写的 ref 对不上。要做得驱动真正的 cache writer 来构造 KV。
+  在这个 E2E 份额下优先级低。
+
+---
+
+## 关于 `sync-perf-helpers`
+
+`src/perf_helper_materialization.py:image_kernel_targets` 只 glob
+`tasks/image_kernel/*/scripts/task_runner.py`，所以
+`python src/tools/sync_perf_helpers.py --check` 看不到本目录。运行时不受影响 ——
+`materialize_perf_helpers_in_workspace()` 是对拷贝出来的 workspace 操作、与路径无关，
+两个 task 就是这么验证的。要纳入 `--check`，要么把目录挪到 `tasks/image_kernel/` 下，
+要么把那条 glob 放宽成 `tasks/*/*/scripts/task_runner.py`。

--- a/tasks/image_kernel/mi355x_vllm_triton_paged_attention_2d/config.yaml
+++ b/tasks/image_kernel/mi355x_vllm_triton_paged_attention_2d/config.yaml
@@ -9,7 +9,7 @@ source_file_path:
 target_kernel_functions:
 - kernel_paged_attention_2d
 kernel_identity:
-  logical_operator: unified_attention_with_output
+  logical_operator: paged_attention_2d
   kernel_kind: triton
   source_owner: vllm
   workload:

--- a/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/config.yaml
+++ b/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/config.yaml
@@ -1,0 +1,104 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/aiter
+repo_subdir: aiter
+image_repo_exclude:
+  - __pycache__
+  - aiter/jit/build
+  - aiter/jit/flydsl_cache
+# The compute core is a FlyDSL MLIR builder; 'flydsl' must be one of the keys under
+# `knowledge` in src/prompts/cheatsheet/default_cheatsheet.yaml (flydsl/hip/triton),
+# which is also forge's fellow set.
+repository_language: flydsl
+source_file_path:
+  - aiter/ops/flydsl/kernels/splitk_hgemm.py
+  - aiter/ops/flydsl/kernels/small_m_hgemm.py
+  - aiter/ops/flydsl/kernels/hgemm_dispatch.py
+editable_sources:
+  - aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
+  - aiter/tuned_gemm.py
+  - aiter/ops/flydsl/gemm_kernels.py
+target_kernel_functions:
+  - flydsl_hgemm
+  - flydsl_gemm
+  - compile_flydsl_hgemm_kernel
+kernel_identity:
+  logical_operator: flydsl_hgemm_small_m
+  kernel_kind: flydsl
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: hgemm-decode-bs8-oproj-n7168k1536
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 3600
+correctness_timeout: 1800
+performance_timeout: 3600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the Kimi-K3 decode-side FlyDSL small-M split-K HGEMM on MI355X/gfx950.
+    Target kernel: hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0 -- 4.55% of
+    end-to-end GPU time in Hyperloom session 20260814T191522Z, decode-only, 162
+    launches per decode step at 12.3 us each (1.99 ms of the 25.557 ms step, 7.79%
+    of decode). It is the largest attackable non-attention, non-communication
+    kernel in the session: the bigger GEMM entries (Cijk_* MT256x256x64 and
+    friends, ~15% E2E) are hipBLASLt Tensile code objects with no source in the
+    image, and they already run at 62-65% of bf16 peak.
+
+    The kernel symbol decodes directly from the generator f-string at
+    ops/flydsl/kernels/splitk_hgemm.py:249: bf16, tile 16x64x64, stages 7,
+    split_k 2, warps 1x2x1, b_to_lds on, async_copy on, TN layout. tile_m=16 is the
+    bs=8 decode batch padded to the smallest FlyDSL M tile -- i.e. HALF the M tile
+    is wasted at the trace-recorded batch, and split_k=2 exists purely to find
+    parallelism a 16-row problem cannot supply on its own.
+
+    Which GEMMs these are. 162 launches/step = 69 + 93, exactly the per-step counts
+    the prefill GEMM census (trace-read aten::mm dims) shows for
+    [T,7168]x[7168,6144] (69 = the KDA layer count; N = 4 x 12 heads x 128 for
+    q/k/v/gate) and [T,1536]x[1536,7168] (93 = o_proj over KDA 69 + MLA 24, both
+    with local output dim 12 x 128 = 1536). Independently, the tuned table the
+    running stack consults -- aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
+    -- has gfx950/cu_num=256/M=8 rows for both (N=6144,K=7168) and (N=7168,K=1536),
+    each selecting libtype=flydsl with
+    flydsl_gemm7_..._t16x64x64_split_k2_block_m_warp1_block_n_warp2_..., which is
+    precisely the session's kernel (the gemm<N> suffix is the stage count).
+
+    Entry point is the REAL dispatcher, aiter.tuned_gemm.tgemm.mm, so the config
+    lookup in that CSV is live and inside your edit surface. Per-M dispatch is part
+    of the contract and must be preserved rather than collapsed to one config: at
+    M=8 the CSV picks t16x64x64/split_k2, at M=64 it picks a different FlyDSL
+    config (t32x64x128/split_k1/block_m_warp2 for N=7168,K=1536). The harness
+    records the resolved libtype and kernelName for every case, so silently falling
+    back to hipBLASLt or triton will be visible in the report -- do not do it, the
+    task is to make the FlyDSL path faster, not to route around it.
+
+    Scored shapes: M in {8, 64} x {(N=6144, K=7168), (N=7168, K=1536)} -- the
+    trace-recorded ramp batch and the steady-state batch (conc=64,
+    max_running_requests=64) against both projection families. All four have rows in
+    the tuned CSV. Activations are [M, K] bf16, weights [N, K] bf16 (TN), output
+    [M, N] bf16, fp32 accumulation, no bias. The correctness set and the performance
+    set are the same list.
+
+    Useful levers: the split-K reduction (partial buffer traffic and the final
+    combine dominate at M=8, where the whole GEMM is 12 us), tile_m/tile_n/tile_k and
+    the stage count for a 16-row problem, warp partitioning, b_to_lds unroll and
+    async-copy pipelining, persistent-CTA / n_tile_repeat variants, and retuning the
+    CSV rows for these four exact shapes. Note this GEMM is firmly
+    memory/latency-bound, not compute-bound: at M=8, N=6144, K=7168 the arithmetic is
+    0.7 GFLOP against ~88 MB of weight reads, so the weight stream and the split-K
+    epilogue are the budget.
+
+    Correctness is float64 parity against a torch reference (a @ b.T) in the harness:
+    cos > 0.9995 and normalized max error < 0.02. Keep the public signature of
+    flydsl_hgemm and the tgemm.mm contract unchanged, and keep the operator
+    graph-capturable -- performance is measured under HIP graph replay.
+  cheatsheet: null

--- a/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/forge_driver.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Kimi-K3 FlyDSL small-M HGEMM task.
+
+Targets (PROTECTED, optimized by forge-loop):
+    ``hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0``, built by
+    ``aiter/ops/flydsl/kernels/splitk_hgemm.py`` and dispatched through
+    ``aiter.tuned_gemm.tgemm.mm``.
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root. Without
+it the launcher generates a generic shim that delegates to ``arena_task_adapter``,
+which does NOT implement ``--profile-run``; forge-loop then burns an LLM agent
+authoring a profiling-capable driver before every run. Shipping this file makes the
+driver preflight pass on the first check, so task preparation is skipped entirely.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``SNR: <db> dB`` -- the worst case's signal-to-noise ratio against
+        the harness's independent, vectorized float64 golden.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` per case plus one ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's own evaluator).
+        Timing goes through ``task_runner._benchmark_cuda_graph_or_events``, i.e.
+        the call is captured once into a HIP graph and REPLAYED per timed
+        iteration, so forge-loop's graph-replay probe is satisfied for real.
+
+  * Profiling    ``--profile-run``
+        builds the largest case's inputs and launches ONLY the target entry point:
+        a few warmups to settle the Triton JIT, a couple of profiled launches, one
+        synchronize, exit 0. No timing is printed.
+
+All measurement logic is REUSED from ``scripts/task_runner.py`` (``_configure`` /
+``_prepare`` / ``_run`` / ``_golden`` / ``_benchmark_cuda_graph_or_events``), so the
+driver measures exactly the same op Arena scores. forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; run in place
+    from the task dir, both sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _case_cost(case: dict) -> int:
+    """GEMM work: M * N * K."""
+    p = case["params"]
+    return int(p["M"]) * int(p["N"]) * int(p["K"])
+
+
+def _run_correctness(tr) -> int:
+    """Per-case SNR against the float64 golden; report the worst case."""
+    import torch
+
+    worst_db = math.inf
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        out = tr._run(inp)
+        torch.cuda.synchronize()
+        ref = tr._golden(inp)
+        got = out.double().flatten()
+        gold = ref.flatten()
+        noise = (got - gold).norm().item()
+        signal = gold.norm().item()
+        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        worst_db = min(worst_db, db)
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+    print(f"SNR: {worst_db:.2f} dB")
+    return 0
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    """Graph-timed bench: one HIP-graph mean per case (reuses task_runner)."""
+    import torch
+
+    results = []
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        tr._run(inp)                   # settle the Triton JIT before capture
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda i=inp: tr._run(i),
+            warmup=max(1, warmup),
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        if not math.isfinite(ms) or ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {ms!r}", file=sys.stderr)
+            return 1
+        results.append((case["id"], ms, meta))
+        del inp
+        torch.cuda.empty_cache()
+    if len(results) != len(tr.CASES) or not results:
+        print("error: benchmark did not produce every task case", file=sys.stderr)
+        return 1
+    for case_id, ms, meta in results:
+        print(f"case_ms: {case_id} {ms:.6f}")
+        print(f"# bench {case_id}: {ms:.6f} ms method={meta.get('benchmark_method')}"
+              f" {meta.get('benchmark_fallback_reason', '')}".rstrip())
+    means = [ms for _, ms, _ in results]
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr) -> int:
+    """Kernel-only profiling for one case: warm, a few launches, sync, exit 0."""
+    import torch
+
+    case = max(tr.CASES, key=_case_cost)
+    inp = tr._prepare(case)
+    for _ in range(3):                 # settle Triton JIT / autotune selection
+        tr._run(inp)
+    torch.cuda.synchronize()
+    for _ in range(3):                 # profiled launches
+        tr._run(inp)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kimi-K3 FlyDSL small-M HGEMM forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=50)
+    args = parser.parse_args()
+
+    tr = _import_task_runner()
+    tr._configure()   # gfx950 env + workspace-seeded aiter first on sys.path
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/forge_driver.py
@@ -72,11 +72,19 @@ def _case_cost(case: dict) -> int:
     return int(p["M"]) * int(p["N"]) * int(p["K"])
 
 
+def _snr_db(signal: float, noise: float, *, finite: bool) -> float:
+    """Return a finite failing sentinel when an output cannot be scored safely."""
+    if not finite or not math.isfinite(signal) or not math.isfinite(noise):
+        return -1.0e9
+    return 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+
+
 def _run_correctness(tr) -> int:
     """Per-case SNR against the float64 golden; report the worst case."""
     import torch
 
     worst_db = math.inf
+    all_finite = True
     for case in tr.CASES:
         inp = tr._prepare(case)
         out = tr._run(inp)
@@ -86,13 +94,15 @@ def _run_correctness(tr) -> int:
         gold = ref.flatten()
         noise = (got - gold).norm().item()
         signal = gold.norm().item()
-        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        finite = bool(torch.isfinite(out).all())
+        all_finite = all_finite and finite
+        db = _snr_db(signal, noise, finite=finite)
         worst_db = min(worst_db, db)
-        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={finite}")
         del inp, out, ref, got, gold
         torch.cuda.empty_cache()
     print(f"SNR: {worst_db:.2f} dB")
-    return 0
+    return 0 if all_finite else 1
 
 
 def _run_bench(tr, warmup: int, iters: int) -> int:

--- a/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/task_runner.py
+++ b/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/task_runner.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the Kimi-K3 decode-side FlyDSL small-M split-K HGEMM.
+
+Kernel covered (Hyperloom session 20260814T191522Z, rank0 of TP=8):
+  ``hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0`` -- 4.55% of end-to-end GPU
+  time, decode-only, 162 launches per decode step at 12.3 us each (1.99 ms of the
+  25.557 ms step). It is the largest attackable non-attention, non-communication
+  kernel in the session: the bigger GEMM entries (``Cijk_*``, ~15% E2E) are
+  hipBLASLt Tensile code objects with no source in the image.
+
+Where the shapes come from
+--------------------------
+Decode kernels run inside the CUDA graph, so the trace carries no ``Input Dims``
+for them. Two independent artifacts pin M/N/K anyway:
+
+  1. 162 launches/step = 69 + 93, exactly the per-step counts the *prefill* GEMM
+     census (trace-read ``aten::mm`` dims) shows for ``[T,7168]x[7168,6144]``
+     (69 = KDA layers; N = 4 x 12 heads x 128 for q/k/v/gate) and
+     ``[T,1536]x[1536,7168]`` (93 = o_proj over KDA 69 + MLA 24).
+  2. ``aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv`` -- the tuned table
+     the running stack actually consults -- has ``gfx950 / cu_num=256 / M=8`` rows
+     for both (N=6144,K=7168) and (N=7168,K=1536), each selecting ``libtype=flydsl``
+     with ``flydsl_gemm7_..._t16x64x64_split_k2_block_m_warp1_block_n_warp2_...``,
+     which decodes to precisely the session's kernel name (the ``gemm<N>`` suffix is
+     the stage count).
+
+Entry point
+-----------
+``aiter.tuned_gemm.tgemm.mm(a[M,K], b[N,K])`` -- the *real* dispatcher. The backend
+and config are resolved live through ``get_GEMM_A16W16_config``, so the tuned CSV is
+part of the edit surface and the per-M dispatch (M=8 -> t16x64x64/split_k2,
+M=64 -> t32x64x128/split_k1) is exercised rather than hardcoded. Every case records
+the resolved ``libtype``/``kernelName`` in the performance report so a run is
+self-documenting.
+
+Golden
+------
+``a.double() @ b.double().T``. At these sizes (max 64 x 7168 x 7168) it is a single
+vectorized matmul -- no chunking, no loop.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MODEL_CONFIG = SPEC["model_config"]
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    seeded = WORKSPACE / "aiter"
+    if (seeded / "__init__.py").is_file():
+        sys.path.insert(0, str(WORKSPACE))
+    else:
+        sys.path.insert(0, os.environ.get("AITER_ROOT", "/sgl-workspace/aiter"))
+    os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "aiter_jit"))
+    # aiter's get_module() only rebuilds on an ARCH mismatch and never hashes the
+    # sources, so any csrc the FlyDSL path pulls in would otherwise be served from a
+    # stale prebuilt .so. =2 keeps the ninja build dir (unlike =1) and never touches
+    # module_aiter_core, so this cannot trigger a full aiter build.
+    os.environ.setdefault("AITER_REBUILD", "2")
+    # FlyDSL keys its compilation cache on a fingerprint that, by default, covers
+    # only flydsl's own sources -- aiter does NOT register its kernel builders via
+    # extra_source_dirs, so a shared cache would serve a stale binary after the agent
+    # edits splitk_hgemm.py. Pinning the cache inside the workspace makes every
+    # workspace start from an empty cache; combined with the per-run staleness probe
+    # in _run(), an edit can never be silently ignored.
+    os.environ.setdefault("FLYDSL_RUNTIME_CACHE_DIR",
+                          str(WORKSPACE / "build" / "flydsl_cache"))
+    # Never let a tuning sweep write into the workspace CSV mid-run.
+    os.environ.setdefault("AITER_TUNE_GEMM", "0")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _gemm_entry():
+    from aiter.tuned_gemm import tgemm
+
+    return tgemm
+
+
+def _resolve_config(M: int, N: int, K: int, dtype) -> dict:
+    """Ask the live dispatcher which backend/kernel it will pick, for the report.
+
+    Best-effort: a signature change in aiter must not fail the run, only lose the
+    annotation.
+    """
+    try:
+        from aiter.tuned_gemm import get_GEMM_A16W16_config
+
+        cfg = get_GEMM_A16W16_config(M, N, K, False, str(dtype), str(dtype))
+        if isinstance(cfg, dict):
+            return {"libtype": cfg.get("libtype"), "kernelName": cfg.get("kernelName"),
+                    "splitK": cfg.get("splitK"), "solidx": cfg.get("solidx")}
+        return {"resolved": str(cfg)}
+    except Exception as exc:  # pragma: no cover - annotation only
+        return {"resolve_error": f"{type(exc).__name__}: {exc}"[:200]}
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    """Build one case at its scored shape (same shape for correctness and perf)."""
+    torch = _torch()
+    p = case["params"]
+    M, N, K = int(p["M"]), int(p["N"]), int(p["K"])
+    dtype = getattr(torch, p.get("dtype", "bfloat16"))
+
+    gen = torch.Generator(device="cuda").manual_seed(int(case.get("seed", 6141)))
+
+    def rnd(*shape, scale=1.0):
+        return (torch.randn(*shape, device="cuda", dtype=torch.float32, generator=gen)
+                * scale).to(dtype)
+
+    # TN layout: activations [M, K], weights [N, K] (the aten::linear convention the
+    # dispatcher expects -- out is [M, N] = a @ b.T).
+    a = rnd(M, K, scale=0.5).contiguous()
+    b = rnd(N, K, scale=0.05).contiguous()
+
+    resolved = _resolve_config(M, N, K, dtype)
+    # HARD GUARD: this task only scores the FlyDSL path. The tuned CSV is inside the
+    # edit surface, so without this an agent could raise its score by routing these
+    # shapes to hipBLASLt / triton / opus instead of making the FlyDSL kernel faster,
+    # and a mis-specified case could silently benchmark another backend. (That is not
+    # hypothetical: (M=64, N=6144, K=7168) selects libtype=opus in the shipped CSV,
+    # which is why that combination is deliberately NOT a case here.)
+    want = case["params"].get("require_libtype", "flydsl")
+    got = resolved.get("libtype")
+    if got is None:
+        print(f"  WARNING {case['id']}: could not resolve the dispatch "
+              f"({resolved}); the libtype guard is inactive for this case")
+    else:
+        assert got == want, (
+            case["id"],
+            f"dispatch resolved to libtype={got!r}, expected {want!r}. This task "
+            f"scores the FlyDSL kernel; do not route around it.",
+        )
+    return {"cfg": case, "M": M, "N": N, "K": K, "dtype": dtype, "a": a, "b": b,
+            "resolved": resolved}
+
+
+def _run(inp: dict):
+    tgemm = _gemm_entry()
+    return tgemm.mm(inp["a"], inp["b"])
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+# --------------------------------------------------------------------------- #
+def _golden(inp: dict):
+    """out = a @ b.T in float64. Single vectorized matmul, no chunking needed."""
+    return inp["a"].double() @ inp["b"].double().T
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inp = _prepare(CASES[0])
+    out = _run(inp)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} "
+          f"resolved={inp['resolved']}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inp = _prepare(case)
+        out = _run(inp)
+        torch.cuda.synchronize()
+        ref = _golden(inp)
+
+        assert torch.isfinite(out).all(), (case["id"], "non-finite output")
+        assert tuple(out.shape) == (inp["M"], inp["N"]), (case["id"], tuple(out.shape))
+        got = out.double().flatten()
+        gold = ref.flatten()
+        cos = torch.nn.functional.cosine_similarity(got, gold, dim=0).item()
+        denom = gold.abs().max().clamp_min(1e-8)
+        rel_max = ((got - gold).abs().max() / denom).item()
+        p = case["params"]
+        assert cos > p.get("min_cosine", 0.9995), (
+            case["id"], f"cosine {cos:.7f} vs float64 golden too low"
+        )
+        assert rel_max < p.get("max_rel_err", 0.02), (
+            case["id"], f"normalized max err {rel_max:.5f} too high"
+        )
+        print("correctness PASS", case["id"],
+              f"[{case['phase']}] cos={cos:.7f} rel_max_err={rel_max:.5f} "
+              f"lib={inp['resolved'].get('libtype')}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inp = _prepare(case)
+        _run(inp)                       # settle the FlyDSL JIT / config lookup
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda i=inp: _run(i),
+            warmup=bench.get("warmup", 5),
+            repetition=bench.get("repetition", 50),
+            target_ms=bench.get("target_ms", 1.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 300),
+        )
+        tflops = 2.0 * inp["M"] * inp["N"] * inp["K"] / (exec_ms * 1e-3) / 1e12
+        metadata = {
+            **case["params"],
+            "phase": case.get("phase"),
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "exact_shape_source": case.get("exact_shape_source"),
+            "expected_kernel_name": case.get("expected_kernel_name"),
+            "resolved_dispatch": inp["resolved"],
+            "tflops": tflops,
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": [inp["M"], inp["N"], inp["K"]],
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms  {tflops:.2f} TFLOP/s",
+              meta.get("benchmark_method"), inp["resolved"].get("libtype"),
+              meta.get("benchmark_fallback_reason", ""))
+        del inp
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness,
+     "performance": run_performance}[mode]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/session_cases.json
+++ b/tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/session_cases.json
@@ -1,0 +1,173 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.15.post1.dev20260723+g6c9fd0adc5 (ROCm 7.2.0, aiter 0.1.17.dev352+gdcd204ea5)",
+  "model": "Kimi-K3",
+  "session_id": "20260814T191522Z",
+  "operator": "flydsl_hgemm_small_m",
+  "task_name": "mi355x-kimi-k3-flydsl-hgemm-small-m-20260814",
+  "language": "flydsl (aiter FlyDSL MLIR builder -> MFMA assembly)",
+  "selection": "hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0 -- 4.55% of end-to-end GPU time, decode-only, 162 launches per decode step at 12.3 us each (1.99 ms of the 25.557 ms step, 7.79% of decode). It is the largest attackable non-attention, non-communication kernel in the session: the bigger GEMM entries (Cijk_* MT256x256x64 etc., ~15% E2E) are hipBLASLt Tensile code objects with no source in the image.",
+  "phase_scope": "DECODE ONLY, and that is a dispatch property rather than a gap. In prefill the very same two projections run at M = 16384 and the aiter A16W16 dispatcher sends them to hipBLASLt (trace: Cijk_Alik_Bljk_BBS_..._MT256x256x64, 69 + 93 calls/step). At decode M they fall to the FlyDSL small-M split-K path. So the FlyDSL kernel this task targets has zero prefill launches; the prefill counterpart is not editable source and is already at 64-66% of bf16 peak. Only shapes whose tuned-CSV row selects libtype=flydsl are scored; see provenance.excluded_shape_note for the one combination that was dropped.",
+  "provenance": {
+    "session_root": "/shared_nfs/hyperloom-claw/Kimi-K3/20260814T191522Z",
+    "trace": "geak/e2e_cycle0/profile/round_0/profile/1786763352.027878-TP-{0..7}.trace.json.gz",
+    "analysis": "/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/kimi-k3-hot-kernels.md",
+    "e2e_weights": {
+      "prefill": 0.416,
+      "decode": 0.584
+    },
+    "measured_decode_tp0": {
+      "step_total_ms": 25.557,
+      "hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0": {
+        "calls_per_step": 162,
+        "total_ms": 1.99,
+        "avg_us": 12.3,
+        "pct_of_step": 7.79,
+        "e2e_pct": 4.55
+      },
+      "hgemm_bf16_16x64x64x7_SPK7_W1x2x1_BLDS1_TN_AS1_0": {
+        "calls_per_step": 24,
+        "e2e_pct": 0.51
+      },
+      "hgemm_bf16_16x64x64x8_SPK7_W1x1x2_BLDS1_TN_AS1_0": {
+        "calls_per_step": 24,
+        "e2e_pct": 0.46
+      },
+      "cross_rank_check": "1.96-2.00 ms across all 8 ranks -- pure compute, no skew."
+    },
+    "kernel_name_decode": {
+      "generator": "aiter/aiter/ops/flydsl/kernels/splitk_hgemm.py:249 -- KERNEL_NAME = f\"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}x{STAGES}_SPK{SPLIT_K}_W{BLOCK_M_WARPS}x{BLOCK_N_WARPS}x{BLOCK_K_WARPS}_BLDS{int(B_TO_LDS)}_TN\" (the _SPK suffix also appears at small_m_hgemm.py:155)",
+      "dtype": "bf16",
+      "tile_m": 16,
+      "tile_n": 64,
+      "tile_k": 64,
+      "stages": 7,
+      "split_k": 2,
+      "block_m_warps": 1,
+      "block_n_warps": 2,
+      "block_k_warps": 1,
+      "b_to_lds": true,
+      "async_copy": true,
+      "layout": "TN",
+      "note": "tile_m=16 is the bs=8 decode batch padded to the smallest FlyDSL M tile."
+    },
+    "shape_evidence": "Two independent artifacts agree. (1) Trace arithmetic: the kernel fires 162x per decode step, and 162 = 69 + 93 -- exactly the per-step call counts the prefill GEMM census (trace-read aten::mm Input Dims) shows for [T,7168]x[7168,6144] (69 = the KDA layer count, q/k/v/gate = 4 x 12 heads x 128) and [T,1536]x[1536,7168] (93 = o_proj over KDA 69 + MLA 24, both with local output dim 12 x 128 = 1536). (2) The tuned config the running stack actually consults, aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv, contains rows gfx950/cu_num=256/M=8 for BOTH (N=6144,K=7168) and (N=7168,K=1536), each selecting libtype=flydsl with kernelName flydsl_gemm7_abf16_wbf16_bf16_t16x64x64_split_k2_block_m_warp1_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950 -- which decodes to exactly hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0 (the gemm<N> suffix is the stage count). The CSV's full distinct (N,K) set also reproduces the trace's projection census: 6144/7168 (KDA qkv), 7168/1536 (o_proj), 7168/3584 (routed_expert_up_proj), 3072/512 (MLA kv_b_proj), 7168/768 (shared-expert down_proj), 2304/1536 (MLA q_b_proj = 12 x (128 nope + 64 rope)), 2112/7168 (fused q_a + kv_a + rope = 1536 + 512 + 64).",
+    "dispatch_note": "The harness calls the real dispatcher aiter.tuned_gemm.tgemm.mm, which resolves the backend and config through get_GEMM_A16W16_config(M,N,K,...) against kimik3_bf16_tuned_gemm.csv. The lookup is therefore live and inside the edit surface, and per-M dispatch is real session behaviour that must be preserved: at M=8 both shape families select the session's exact kernel (flydsl_gemm7_..._t16x64x64_split_k2_block_m_warp1_block_n_warp2_...), while at M=64 the o_proj family moves to flydsl_gemm4_..._t32x64x128_split_k1_block_m_warp2_.... Every case records the resolved libtype/kernelName in the performance report AND asserts it equals params.require_libtype ('flydsl') in _prepare, so routing around FlyDSL fails the run instead of inflating the score.",
+    "batch_derivation": "The trace's decode annotation is step[DECODE bs=8] -- profiling started at warmup 0s and captured the ramp. The run's steady-state decode batch is bs=64 (conc=64, max_running_requests=64; median_itl_ms 46.73 vs 25.56 ms at bs=8; 192 requests / 1024 OSL = 3 waves of 64). Both are scored, and both have tuned CSV rows.",
+    "excluded_shape_note": "(M=64, N=6144, K=7168) -- the KDA input projection at the steady-state decode batch -- is DELIBERATELY NOT a case. Verified on gfx950/cu_num=256: that row of kimik3_bf16_tuned_gemm.csv selects libtype=opus (opus_gemm_flatmm_splitk_256x64x96x64_2x1_16x16x32_0x0x0_wgpc, splitK=4), not FlyDSL, so scoring it here would benchmark module_deepgemm_opus -- outside this task's edit surface -- and would also drag a large opus instance build into every run. Reading the full CSV column for this shape: M=1..32 and M=128..256 are flydsl, M=64 is opus, M=512..1024 fall back to torch. The trace-recorded batch (bs=8) is flydsl, which is what this task targets."
+  },
+  "model_config": {
+    "source": "/shared_nfs/hyperloom/models/Kimi-K3/config.json (text_config) + kimik3_bf16_tuned_gemm.csv",
+    "hidden_size": 7168,
+    "num_attention_heads": 96,
+    "tensor_parallel_size": 8,
+    "local_heads": 12,
+    "kda_head_dim": 128,
+    "kda_layers": 69,
+    "mla_layers": 24,
+    "q_lora_rank": 1536,
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "cu_num": 256,
+    "notes": "KDA input projection N = 4 x (12 heads x 128) = 6144 (q, k, v and the full-rank gate). o_proj K = 12 x 128 = 1536 for both KDA and MLA, which is why its call count is 69 + 24 = 93."
+  },
+  "cases": [
+    {
+      "id": "hgemm-decode-bs8-kdaqkv-n6144k7168",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": [
+        "hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0"
+      ],
+      "gpu_pct_e2e": 4.55,
+      "exact_shape_source": "TRACE-MEASURED batch (step[DECODE bs=8]) x the KDA input projection; the (M=8, N=6144, K=7168) row exists in kimik3_bf16_tuned_gemm.csv and selects the session's exact kernel",
+      "trace_input_shapes": [
+        "a (8, 7168) bf16",
+        "b (6144, 7168) bf16   [N, K], TN layout",
+        "out (8, 6144) bf16"
+      ],
+      "expected_kernel_name": "flydsl_gemm7_abf16_wbf16_bf16_t16x64x64_split_k2_block_m_warp1_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950",
+      "calls_per_decode_step": 69,
+      "params": {
+        "M": 8,
+        "N": 6144,
+        "K": 7168,
+        "dtype": "bfloat16",
+        "bias": false,
+        "min_cosine": 0.9995,
+        "max_rel_err": 0.02,
+        "require_libtype": "flydsl"
+      },
+      "benchmark": {
+        "warmup": 5,
+        "repetition": 50,
+        "target_ms": 1.0,
+        "max_graph_repeats": 400
+      },
+      "seed": 6141
+    },
+    {
+      "id": "hgemm-decode-bs8-oproj-n7168k1536",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": [
+        "hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0"
+      ],
+      "exact_shape_source": "TRACE-MEASURED batch (bs=8) x o_proj (KDA 69 + MLA 24 = 93 calls/step); the (M=8, N=7168, K=1536) row exists in the tuned CSV and selects the same kernel",
+      "trace_input_shapes": [
+        "a (8, 1536) bf16",
+        "b (7168, 1536) bf16   [N, K], TN layout",
+        "out (8, 7168) bf16"
+      ],
+      "expected_kernel_name": "flydsl_gemm7_abf16_wbf16_bf16_t16x64x64_split_k2_block_m_warp1_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950",
+      "calls_per_decode_step": 93,
+      "params": {
+        "M": 8,
+        "N": 7168,
+        "K": 1536,
+        "dtype": "bfloat16",
+        "bias": false,
+        "min_cosine": 0.9995,
+        "max_rel_err": 0.02,
+        "require_libtype": "flydsl"
+      },
+      "benchmark": {
+        "warmup": 5,
+        "repetition": 50,
+        "target_ms": 1.0,
+        "max_graph_repeats": 400
+      },
+      "seed": 6142
+    },
+    {
+      "id": "hgemm-decode-bs64-oproj-n7168k1536",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": [
+        "flydsl small-M hgemm (M=64 bucket)"
+      ],
+      "exact_shape_source": "SESSION STEADY STATE -- bs=64 x o_proj; the (M=64, N=7168, K=1536) row exists in the tuned CSV and selects a DIFFERENT config (t32x64x128 split_k1 block_m_warp2), which is real per-M dispatch behaviour",
+      "expected_kernel_name": "flydsl_gemm4_abf16_wbf16_bf16_t32x64x128_split_k1_block_m_warp2_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950",
+      "params": {
+        "M": 64,
+        "N": 7168,
+        "K": 1536,
+        "dtype": "bfloat16",
+        "bias": false,
+        "min_cosine": 0.9995,
+        "max_rel_err": 0.02,
+        "require_libtype": "flydsl"
+      },
+      "benchmark": {
+        "warmup": 5,
+        "repetition": 50,
+        "target_ms": 1.0,
+        "max_graph_repeats": 300
+      },
+      "seed": 6144
+    }
+  ]
+}

--- a/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/config.yaml
+++ b/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/config.yaml
@@ -1,0 +1,105 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/aiter
+repo_subdir: aiter
+image_repo_exclude:
+  - __pycache__
+  - aiter/jit/build
+  - aiter/jit/flydsl_cache
+repository_language: hip
+source_file_path:
+  - csrc/kernels/topk_softmax_kernels_group.cu
+  - csrc/include/moe_sorting_opus.h
+  - csrc/kernels/quant_kernels.cu
+editable_sources:
+  - aiter/ops/topk.py
+  - aiter/ops/moe_sorting_opus.py
+  - aiter/ops/quant.py
+target_kernel_functions:
+  - biased_grouped_topk_hip
+  - moe_sorting_opus_fwd
+  - fused_dynamic_mx_quant_moe_sort_hip
+kernel_identity:
+  logical_operator: moe_routing_sort_quant
+  kernel_kind: hip
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: moe-route-prefill-t16384
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 3600
+correctness_timeout: 3600
+performance_timeout: 3600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the Kimi-K3 MoE routing / sorting / MX-quant stages on MI355X/gfx950.
+    These are the MoE pipeline stages that sit AROUND the 2-stage expert GEMM and
+    are deliberately NOT covered by mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3.
+    From Hyperloom session 20260814T191522Z: grouped_topk 2.75% + opus_moe_sorting
+    P23 1.20% + P0_v2 0.90% + fused_mx_quant_moe_sort 1.50% = 6.35% of end-to-end
+    GPU time. That is MORE than any single MoE GEMM kernel in the session (the
+    largest is mfma_moe1 t64x128x256 at 2.92%), and none of them has ever been a
+    task -- they are invisible to a kernel ranking that sorts by individual kernel
+    name.
+
+    The chain, exactly as the model runs it per MoE layer (92 of 93 layers, so 92
+    calls per forward pass for every kernel here):
+      1. biased_grouped_topk_hip(gating[T,896] bf16, correction_bias[896] bf16)
+         -> topk_weights[T,16] f32, topk_ids[T,16] i32.
+         K3 has num_expert_group=1 and topk_group=1, so the group stage degenerates
+         and this is a plain biased top-16 over 896 experts with renormalization.
+         The launcher picks the HIP kernel (not moe_fused_gate) because
+         num_experts/num_expert_group = 896 > 32.
+      2. moe_sorting_opus_fwd(topk_ids, topk_weights) -> sorted_ids, sorted_weights,
+         sorted_expert_ids, num_valid_ids. Multi-phase: the trace shows P0_v2 and
+         P23 as separate kernels plus two more phases (grids 1408/256/512/896).
+         sorted_ids packs (slot_id << 24) | token_id.
+      3. fused_dynamic_mx_quant_moe_sort_hip(latent[T,3584] bf16) -> fp8_e4m3 out
+         + e8m0 scales[.,112], group_size 32. In the chain only for the small-M and
+         decode cases: at big M the session's MoE1 kernel is
+         mfma_moe1_..._fp8q_sort_async_..., which folds the quant into the GEMM
+         prologue, so the standalone kernel measures 0.02% in prefill.
+
+    Dims are the session's real per-rank TP=8 values: num_experts=896, topk=16,
+    num_expert_group=1, topk_group=1, renormalize=true, routed_scaling_factor=1.0,
+    latent (routed_expert_hidden_size) = 3584, local inter_dim = 384, MX group 32.
+    block_size is 64 for the T>=8192 buckets and 32 for the small-M bucket -- this
+    was solved out of the trace's own buffer lengths
+    (max_num_tokens_padded = T*topk + num_experts*block_size - topk gives 319472 /
+    188400 / 29680 for T = 16384 / 8192 / 64) and must be preserved as a dispatch
+    contract, not hardcoded away.
+
+    Both phases are scored: prefill T = 16384 (chunked-prefill block), 8192 (first
+    EXTEND step) and 64 (tail step), decode T = 8 (trace-recorded ramp batch) and
+    64 (steady-state batch). The correctness set and the performance set are the
+    same list, so a shape that is timed is always a shape that was validated.
+
+    Useful levers: the top-k selection algorithm at E=896/topk=16 (the current
+    kernel is one CTA of 64 threads per token), the multi-phase sort's phase count
+    and workspace traffic (moe_sorting_opus_get_workspace_size returns 14.7 MB at
+    T=16384), fusing phases, wave/LDS occupancy at tiny T where the whole chain is
+    launch-latency bound (12.0 us at T=64 vs 70.3 us at T=16384 for a 256x smaller
+    problem), and the quant kernel's group-scale write pattern.
+
+    Correctness: the harness validates each stage independently against vectorized
+    torch references. The sort check is deliberately ORDERING-AGNOSTIC -- it decodes
+    sorted_ids, asserts every valid slot sits in a block whose sorted_expert_ids
+    entry is the expert that (token, slot) actually routed to, asserts the valid
+    (token, slot) pairs form exactly the T*topk routing set with no drops or
+    duplicates, and asserts sorted_weights carries the matching weight. Intra-expert
+    order and padding fill are yours to change. Keep the public Python signatures of
+    biased_grouped_topk_hip, moe_sorting_opus_fwd and
+    fused_dynamic_mx_quant_moe_sort_hip unchanged, keep num_valid_ids block-aligned,
+    and keep the chain graph-capturable -- performance is measured under HIP graph
+    replay.
+  cheatsheet: null

--- a/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/scripts/forge_driver.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Kimi-K3 MoE routing / sorting / MX-quant task.
+
+Targets (PROTECTED, optimized by forge-loop):
+    ``aiter::grouped_topk_kernel``            (csrc/kernels/topk_softmax_kernels_group.cu)
+    ``aiter::opus_moe_sorting_entry``         (csrc/include/moe_sorting_opus.h)
+    ``aiter::fused_mx_quant_moe_sort_kernel`` (csrc/kernels/quant_kernels.cu)
+
+Why this file exists
+--------------------
+The Arena forge launcher prefers a task-shipped ``scripts/forge_driver.py`` and
+copies it VERBATIM to the workspace root. Without it the launcher generates a
+generic shim that delegates to ``arena_task_adapter``, which does NOT implement
+``--profile-run``; forge-loop then burns an LLM agent authoring a profiling-capable
+driver before every run. Shipping this file makes the driver preflight pass on the
+first check.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        Runs the harness's full per-stage validation (top-k set + weights, the
+        ordering-agnostic sort semantics, and MX dequant error) and additionally
+        prints ``SNR: <db> dB`` computed on the top-k weights against the
+        vectorized torch reference. A failed invariant raises and exits non-zero,
+        which forge reads as a correctness regression.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` per case plus one ``mean_ms: <ms>``.
+        Timing goes through ``task_runner._benchmark_cuda_graph_or_events``: the
+        chain is captured once into a HIP graph and REPLAYED per timed iteration.
+
+  * Profiling    ``--profile-run``
+        builds the largest case and launches only the target chain: warmups, a few
+        profiled launches, one synchronize, exit 0.
+
+All measurement logic is REUSED from ``scripts/task_runner.py``. forge-loop never
+edits this file.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _case_cost(case: dict) -> int:
+    p = case["params"]
+    return int(p["num_tokens"]) * int(p["num_experts"])
+
+
+def _run_correctness(tr) -> int:
+    """Full per-stage validation plus a top-k-weight SNR for forge's gate."""
+    import torch
+
+    worst_db = math.inf
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        tr._run(inp)
+        torch.cuda.synchronize()
+
+        notes = []
+        if "topk" in inp["stages"]:
+            notes.append(tr._check_topk(inp, case))
+        if "sorting" in inp["stages"]:
+            notes.append(tr._check_sorting(inp, case))
+        if "quant" in inp["stages"]:
+            notes.append(tr._check_quant(inp, case))
+
+        # SNR on the routing weights, computed against the kernel's OWN chosen ids.
+        # Aligning two independent top-k selections by expert id is not valid here:
+        # with 896 experts the 16th/17th biased scores tie within fp32 noise, so the
+        # two selections legitimately differ at the boundary and an id-aligned diff
+        # would compare unrelated experts. _check_topk() above already validated the
+        # selection itself (min(biased[chosen]) >= max(biased[rest]) - eps).
+        score = torch.sigmoid(inp["gating"].float())
+        ids = inp["topk_ids"].long()
+        w_ref = torch.gather(score, 1, ids)
+        if inp["need_renorm"]:
+            w_ref = w_ref / w_ref.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+        w_ref = w_ref * inp["routed_scaling_factor"]
+        got = inp["topk_weights"].double().flatten()
+        gold = w_ref.double().flatten()
+        noise = (got - gold).norm().item()
+        signal = gold.norm().item()
+        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        worst_db = min(worst_db, db)
+        print(f"# case {case['id']}: SNR={db:.2f} dB {' '.join(notes)}")
+        del inp
+        torch.cuda.empty_cache()
+    print(f"SNR: {worst_db:.2f} dB")
+    return 0
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    import torch
+
+    results = []
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        tr._run(inp)
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda i=inp: tr._run(i),
+            warmup=max(1, warmup),
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        if not math.isfinite(ms) or ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {ms!r}", file=sys.stderr)
+            return 1
+        results.append((case["id"], ms, meta))
+        del inp
+        torch.cuda.empty_cache()
+    if len(results) != len(tr.CASES) or not results:
+        print("error: benchmark did not produce every task case", file=sys.stderr)
+        return 1
+    for case_id, ms, meta in results:
+        print(f"case_ms: {case_id} {ms:.6f}")
+        print(f"# bench {case_id}: {ms:.6f} ms method={meta.get('benchmark_method')}"
+              f" {meta.get('benchmark_fallback_reason', '')}".rstrip())
+    means = [ms for _, ms, _ in results]
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr) -> int:
+    import torch
+
+    case = max(tr.CASES, key=_case_cost)
+    inp = tr._prepare(case)
+    for _ in range(3):
+        tr._run(inp)
+    torch.cuda.synchronize()
+    for _ in range(3):
+        tr._run(inp)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kimi-K3 MoE routing/sort/quant forge driver")
+    parser.add_argument("--mode", default="full")
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr = _import_task_runner()
+    tr._configure()   # gfx950 env + workspace-seeded aiter first on sys.path
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/scripts/task_runner.py
+++ b/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/scripts/task_runner.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the Kimi-K3 MoE routing / sorting / MX-quant stages.
+
+Scope
+-----
+The MoE pipeline stages that sit AROUND the 2-stage expert GEMM, i.e. everything
+`mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3` does NOT cover:
+
+  * ``aiter::grouped_topk_kernel``                        2.75% E2E  (csrc/kernels/topk_softmax_kernels_group.cu:320)
+  * ``aiter::opus_moe_sorting_entry<...P23...>``          1.20% E2E  (csrc/include/moe_sorting_opus.h:109)
+  * ``aiter::opus_moe_sorting_entry<...P0_v2...>``        0.90% E2E  (same file, multi-phase)
+  * ``aiter::fused_mx_quant_moe_sort_kernel<bf16,fp8,..>``1.50% E2E  (csrc/kernels/quant_kernels.cu:1731)
+
+6.35% of end-to-end GPU time together -- more than any single MoE GEMM kernel in
+the session (largest is 2.92%). Each fires 92 times per forward pass, matching the
+92 MoE layers (``first_k_dense_replace=1`` of 93).
+
+Chain under test
+----------------
+The three stages are timed as one chain because that is how the model runs them::
+
+    biased_grouped_topk_hip(gating[T,896], bias[896]) -> topk_weights[T,16] f32,
+                                                          topk_ids[T,16] i32
+    moe_sorting_opus_fwd(topk_ids, topk_weights)      -> sorted_ids, sorted_weights,
+                                                          sorted_expert_ids, num_valid_ids
+    fused_dynamic_mx_quant_moe_sort_hip(latent[T,3584] bf16, sorted_ids, ...)
+                                                      -> fp8_e4m3 out + e8m0 scales
+
+``quant`` is in the chain only for the small-M / decode cases: at big M the session's
+MoE1 kernel is ``mfma_moe1_..._fp8q_sort_async_...``, which folds the quant into the
+GEMM prologue, so the standalone quant kernel measures 0.02% in prefill.
+
+Goldens
+-------
+All references are vectorized torch (no per-token Python loops):
+
+  * **topk** -- full torch reference of the biased grouped top-k, compared on the
+    selected expert set and on the renormalized weights.
+  * **sorting** -- ordering-agnostic *semantic* check. ``sorted_ids`` encodes
+    ``(slot_id << 24) | token_id`` (confirmed by
+    ``op_tests/flydsl_tests/test_silu_and_mul_fq.py:42``); the harness decodes every
+    valid slot, asserts its expert matches the owning block's ``sorted_expert_ids``,
+    asserts the (token, slot) multiset is exactly the T*topk routing pairs, and
+    asserts ``sorted_weights`` carries the matching ``topk_weights``. Intra-expert
+    order and padding fill are deliberately NOT constrained -- the agent may change
+    them.
+  * **quant** -- dequantize ``out * 2^(e8m0 scale)`` per 32-element group and compare
+    against the bf16 input.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MOE_CONFIG = SPEC["moe_config"]
+
+_TOKEN_MASK = (1 << 24) - 1
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    # Prefer the workspace-seeded editable copy so the agent's csrc edits are the
+    # ones aiter's JIT compiles; fall back to the in-image install for dev runs.
+    seeded = WORKSPACE / "aiter"
+    if (seeded / "__init__.py").is_file():
+        sys.path.insert(0, str(WORKSPACE))
+    else:
+        sys.path.insert(0, os.environ.get("AITER_ROOT", "/sgl-workspace/aiter"))
+    # aiter compiles csrc through its own JIT; point the build dir inside the
+    # workspace so one workspace can never serve another workspace's .so.
+    os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "aiter_jit"))
+    # CRITICAL: aiter's get_module() only rebuilds on an ARCH mismatch -- it does
+    # NOT hash the csrc sources (jit/core.py:633-659). Without this the agent's
+    # edits to csrc/** are silently ignored and the prebuilt .so is served
+    # (measured: edit + no AITER_REBUILD = 0.1 s and an unchanged .so mtime).
+    # AITER_REBUILD=2 does rm_module() only (not clear_build()), so the ninja build
+    # dir persists inside the workspace: measured ~53 s for all three target modules
+    # cold (moe_asm 33 s + quant 13 s + moe_sorting_opus 7 s) and ~17 s per module
+    # on a rebuild. Do NOT use AITER_REBUILD=1 -- that also wipes the build dir.
+    # module_aiter_core is exempt (jit/core.py seeds it into rebuilded_list), so this
+    # never triggers a full aiter build.
+    os.environ.setdefault("AITER_REBUILD", "2")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _aiter():
+    import aiter
+
+    return aiter
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    """Build one case at its scored shape (same shape for correctness and perf)."""
+    torch = _torch()
+    p = case["params"]
+    T = int(p["num_tokens"])
+    E = int(p["num_experts"])
+    topk = int(p["topk"])
+    bs = int(p["block_size"])
+    md = int(p["latent_dim"])
+    stages = list(p["stages"])
+
+    gen = torch.Generator(device="cuda").manual_seed(int(case.get("seed", 9141)))
+
+    gating = (torch.randn(T, E, device="cuda", dtype=torch.float32, generator=gen)
+              * 0.5).to(torch.bfloat16).contiguous()
+    bias = (torch.randn(E, device="cuda", dtype=torch.float32, generator=gen)
+            * 0.1).to(torch.bfloat16).contiguous()
+    topk_weights = torch.empty(T, topk, device="cuda", dtype=torch.float32)
+    topk_ids = torch.empty(T, topk, device="cuda", dtype=torch.int32)
+
+    # Sorting buffers, sized exactly the way aiter/fused_moe.py:203-210 does.
+    max_padded = int(T * topk + E * bs - topk)
+    max_blocks = int((max_padded + bs - 1) // bs)
+    sorted_ids = torch.empty(max_padded, device="cuda", dtype=torch.int32)
+    sorted_weights = torch.empty(max_padded, device="cuda", dtype=torch.float32)
+    sorted_expert_ids = torch.empty(max_blocks, device="cuda", dtype=torch.int32)
+    num_valid_ids = torch.empty(2, device="cuda", dtype=torch.int32)
+    if p.get("moe_buf_mode") == "real":
+        moe_buf = torch.empty(T, md, device="cuda", dtype=torch.bfloat16)
+    else:
+        moe_buf = torch.empty((0, 0), device="cuda", dtype=torch.bfloat16)
+
+    inp = {
+        "cfg": case, "T": T, "E": E, "topk": topk, "block_size": bs, "md": md,
+        "stages": stages, "gating": gating, "bias": bias,
+        "topk_weights": topk_weights, "topk_ids": topk_ids,
+        "sorted_ids": sorted_ids, "sorted_weights": sorted_weights,
+        "sorted_expert_ids": sorted_expert_ids, "num_valid_ids": num_valid_ids,
+        "moe_buf": moe_buf, "max_padded": max_padded, "max_blocks": max_blocks,
+        "num_expert_group": int(p["num_expert_group"]),
+        "topk_group": int(p["topk_group"]),
+        "need_renorm": bool(p["need_renorm"]),
+        "routed_scaling_factor": float(p["routed_scaling_factor"]),
+    }
+
+    if "sorting" in stages:
+        aiter = _aiter()
+        ws_size = aiter.moe_sorting_opus_get_workspace_size(T, E, topk, 0)
+        inp["workspace"] = (torch.empty(ws_size, device="cuda", dtype=torch.uint8)
+                            if ws_size > 0 else None)
+
+    if "quant" in stages:
+        g = int(p.get("mx_group_size", MOE_CONFIG["mx_group_size"]))
+        assert md % g == 0, (case["id"], "latent_dim must be a multiple of the MX group")
+        inp["mx_group_size"] = g
+        inp["quant_in"] = (torch.randn(T, md, device="cuda", dtype=torch.float32,
+                                       generator=gen) * 0.5).to(torch.bfloat16).contiguous()
+        inp["quant_out"] = torch.empty(T, md, device="cuda",
+                                       dtype=torch.float8_e4m3fn)
+        # Scale rows are the padded sorted-slot count rounded up to a block,
+        # columns are md / group_size. Trace: (29696, 112) for T=64, md=3584, bs=32.
+        inp["quant_scales"] = torch.empty(inp["max_blocks"] * bs, md // g,
+                                          device="cuda", dtype=torch.float8_e8m0fnu)
+    return inp
+
+
+def _run(inp: dict):
+    """Execute the session's routing chain in order. Returns nothing; the harness
+    reads the output buffers, which is also what the model does."""
+    aiter = _aiter()
+    stages = inp["stages"]
+
+    if "topk" in stages:
+        aiter.biased_grouped_topk_hip(
+            inp["gating"], inp["bias"], inp["topk_weights"], inp["topk_ids"],
+            inp["num_expert_group"], inp["topk_group"], inp["need_renorm"],
+            inp["routed_scaling_factor"],
+        )
+    if "sorting" in stages:
+        aiter.moe_sorting_opus_fwd(
+            inp["topk_ids"], inp["topk_weights"],
+            inp["sorted_ids"], inp["sorted_weights"], inp["sorted_expert_ids"],
+            inp["num_valid_ids"], inp["moe_buf"],
+            inp["E"], int(inp["block_size"]),
+            None, None, inp.get("workspace"), 0, None, None, None,
+        )
+    if "quant" in stages:
+        aiter.fused_dynamic_mx_quant_moe_sort_hip(
+            inp["quant_out"], inp["quant_scales"], inp["quant_in"],
+            inp["sorted_ids"], inp["num_valid_ids"],
+            inp["T"], int(inp["block_size"]), inp["mx_group_size"],
+            inp["sorted_weights"],
+        )
+    return inp
+
+
+# --------------------------------------------------------------------------- #
+# References (vectorized torch)
+# --------------------------------------------------------------------------- #
+def _golden_topk(inp: dict):
+    """Biased grouped top-k, exactly as the kernel defines it, fully vectorized.
+
+    K3 has num_expert_group=1 / topk_group=1, so the group stage is a no-op and the
+    reference reduces to: score = sigmoid(gating) (moe_router_activation_func), add
+    the correction bias, take top-k on the biased score, but return the UNBIASED
+    score as the weight, then renormalize and scale.
+    """
+    torch = _torch()
+    g = inp["gating"].float()
+    score = torch.sigmoid(g)
+    biased = score + inp["bias"].float().unsqueeze(0)
+    _, ids = torch.topk(biased, inp["topk"], dim=-1)
+    w = torch.gather(score, 1, ids)
+    if inp["need_renorm"]:
+        w = w / w.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+    w = w * inp["routed_scaling_factor"]
+    return w, ids.to(torch.int32)
+
+
+def _check_topk(inp: dict, case: dict) -> str:
+    """Tie-safe validation of the biased grouped top-k.
+
+    Comparing against a torch top-k *element by element* is not a valid test here:
+    with 896 experts the 16th and 17th biased scores are routinely within fp32 noise
+    of each other, so the kernel and torch legitimately pick different experts at the
+    boundary, and any id-aligned weight diff then compares two unrelated experts.
+    (Measured: that formulation reports 8.7e-3 max weight error on pure ties.)
+
+    So the contract is checked in the two ways that are actually well defined:
+
+      A. SELECTION -- the chosen set must be a valid top-k of the biased score:
+         min(biased[chosen]) >= max(biased[not chosen]) - eps. Exact, tie-tolerant.
+      B. WEIGHTS -- the returned weights must be the renormalized *unbiased* scores of
+         the kernel's OWN chosen experts. Immune to which side of a tie was taken.
+    """
+    torch = _torch()
+    got_ids = inp["topk_ids"].long()
+    got_w = inp["topk_weights"]
+    T, E, topk = inp["T"], inp["E"], inp["topk"]
+
+    assert torch.isfinite(got_w).all(), (case["id"], "non-finite topk weights")
+    assert int(got_ids.min()) >= 0 and int(got_ids.max()) < E, (
+        case["id"], "topk id out of range"
+    )
+    assert (got_ids.sort(dim=-1).values.diff(dim=-1) > 0).all(), (
+        case["id"], "duplicate expert inside one token's top-k list"
+    )
+
+    score = torch.sigmoid(inp["gating"].float())
+    biased = score + inp["bias"].float().unsqueeze(0)
+
+    # A. selection validity
+    chosen_min = torch.gather(biased, 1, got_ids).min(dim=-1).values
+    rest = biased.scatter(1, got_ids, float("-inf"))
+    rest_max = rest.max(dim=-1).values
+    sel_gap = (rest_max - chosen_min).max().item()          # <= 0 when strictly correct
+    eps = case["params"].get("max_select_gap", 2e-3)
+    assert sel_gap < eps, (
+        case["id"],
+        f"a non-selected expert outscores a selected one by {sel_gap:.2e} (> {eps})",
+    )
+
+    # B. weight consistency against the kernel's own ids
+    w_ref = torch.gather(score, 1, got_ids)
+    if inp["need_renorm"]:
+        w_ref = w_ref / w_ref.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+    w_ref = w_ref * inp["routed_scaling_factor"]
+    w_err = (got_w - w_ref).abs().max().item()
+    tol = case["params"].get("max_weight_err", 1e-3)
+    assert w_err < tol, (case["id"], f"topk weight max err {w_err:.2e} > {tol}")
+
+    # Informational: how far the selection drifted from a plain torch top-k.
+    _, ref_ids = _golden_topk(inp)
+    same = (got_ids.sort(dim=-1).values == ref_ids.long().sort(dim=-1).values)
+    return (f"topk(w_err={w_err:.2e} sel_gap={sel_gap:.1e} "
+            f"tie_drift={1.0 - same.float().mean().item():.2e})")
+
+
+def _check_sorting(inp: dict, case: dict) -> str:
+    """Ordering-agnostic semantic validation of the opus sort.
+
+    sorted_ids packs (slot_id << 24) | token_id. Padding slots decode to a token id
+    >= T. For every valid slot we require the owning block's expert to be the expert
+    that (token, slot) actually routed to, and we require the set of valid
+    (token, slot) pairs to be exactly the T*topk routing pairs -- nothing dropped,
+    nothing duplicated. Intra-expert order and the padding fill are NOT constrained.
+    """
+    torch = _torch()
+    T, topk, bs = inp["T"], inp["topk"], inp["block_size"]
+    nvalid = int(inp["num_valid_ids"][0].item())
+    assert 0 < nvalid <= inp["max_padded"], (case["id"], f"num_valid_ids={nvalid}")
+    assert nvalid % bs == 0, (case["id"], f"num_valid_ids {nvalid} not block-aligned")
+
+    ids = inp["sorted_ids"][:nvalid].long()
+    tok = ids & _TOKEN_MASK
+    slot = ids >> 24
+    valid = tok < T
+    assert int(valid.sum()) == T * topk, (
+        case["id"], f"valid slot count {int(valid.sum())} != T*topk {T * topk}"
+    )
+    assert int(slot[valid].max()) < topk, (case["id"], "slot id out of range")
+
+    # Each valid slot must sit in a block whose expert is the routed expert.
+    blk_expert = inp["sorted_expert_ids"][: nvalid // bs].long()
+    per_slot_expert = blk_expert.repeat_interleave(bs)
+    routed = inp["topk_ids"].long()[tok[valid], slot[valid]]
+    assert torch.equal(routed, per_slot_expert[valid]), (
+        case["id"], "a sorted slot landed in a block for the wrong expert"
+    )
+
+    # Every (token, slot) pair appears exactly once.
+    flat = (tok[valid] * topk + slot[valid])
+    uniq = torch.unique(flat)
+    assert uniq.numel() == T * topk, (
+        case["id"], f"routing pairs not a permutation ({uniq.numel()} unique)"
+    )
+
+    # sorted_weights must carry the matching topk weight.
+    w_err = (inp["sorted_weights"][:nvalid][valid]
+             - inp["topk_weights"][tok[valid], slot[valid]]).abs().max().item()
+    tol = case["params"].get("max_weight_err", 1e-3)
+    assert w_err < tol, (case["id"], f"sorted_weights err {w_err:.2e} > {tol}")
+    return f"sort(nvalid={nvalid} w_err={w_err:.2e})"
+
+
+def _check_quant(inp: dict, case: dict) -> str:
+    """Validate the MX quantization WITHOUT assuming the scale tensor's layout.
+
+    ``out`` is token-row aligned ``[T, md]`` fp8_e4m3, but ``scales`` is written in
+    sorted-slot order AND hardware-swizzled -- an inspected row reads
+    ``[119, 0, 119, 0, ...]``, so a plain ``scales[t]`` lookup is meaningless (it
+    dequantizes to zero). That layout is an implementation detail the agent is
+    allowed to change, so pinning it here would be both wrong and over-constraining.
+
+    Instead the quantization MATH is validated from the payload alone:
+
+      * per 32-element group, the implied scale is ``amax(x) / amax(q)``; for a
+        correct MX quantization that ratio must be a power of two, so
+        ``e = round(log2(ratio))`` and ``|log2(ratio) - e|`` must be small;
+      * ``q * 2^e`` must reproduce the bf16 input to within e4m3 precision
+        (3 mantissa bits -> ~6% of the group max).
+
+    The scale tensor itself is checked structurally: the number of rows it actually
+    wrote must equal ``num_valid_ids[0]`` -- layout-independent, but still catches a
+    sort/scale-placement regression.
+    """
+    torch = _torch()
+    g = inp["mx_group_size"]
+    T, md = inp["T"], inp["md"]
+    ng = md // g
+    x = inp["quant_in"].float().view(T, ng, g)
+    q = inp["quant_out"].to(torch.float32).view(T, ng, g)
+    assert torch.isfinite(q).all(), (case["id"], "non-finite fp8 payload")
+
+    xa = x.abs().amax(dim=-1, keepdim=True)
+    qa = q.abs().amax(dim=-1, keepdim=True)
+    live = (xa > 0) & (qa > 0)                       # skip all-zero groups
+    ratio = torch.where(live, xa / qa.clamp_min(1e-30), torch.ones_like(xa))
+    log2r = torch.log2(ratio)
+    e = torch.round(log2r)
+    p2_err = (log2r - e).abs()[live].max().item() if live.any() else 0.0
+    assert p2_err < 0.35, (
+        case["id"],
+        f"implied per-group scale is not a power of two (max |log2 dev| {p2_err:.3f}); "
+        "the payload is not an MX quantization of the input",
+    )
+
+    deq = (q * torch.pow(2.0, e)).view(T, md)
+    ref = inp["quant_in"].float()
+    denom = ref.abs().amax().clamp_min(1e-8)
+    rel = ((deq - ref).abs().amax() / denom).item()
+    tol = case["params"].get("max_quant_rel_err", 0.08)
+    assert torch.isfinite(deq).all(), (case["id"], "non-finite dequant")
+    assert rel < tol, (case["id"], f"MX quant normalized max err {rel:.4f} > {tol}")
+
+    nvalid = int(inp["num_valid_ids"][0].item())
+    written = int((inp["quant_scales"].view(torch.uint8).sum(dim=-1) > 0).sum().item())
+    assert written == nvalid, (
+        case["id"],
+        f"scale rows written = {written} but num_valid_ids = {nvalid}",
+    )
+    return f"quant(rel_max_err={rel:.4f} p2_dev={p2_err:.3f} scale_rows={written})"
+
+
+def _golden(inp: dict):
+    """Kept for the forge driver's SNR path: returns the reference topk weights."""
+    ref_w, _ = _golden_topk(inp)
+    return ref_w
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inp = _prepare(CASES[0])
+    _run(inp)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  stages={inp['stages']} "
+          f"nvalid={int(inp['num_valid_ids'][0].item())}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inp = _prepare(case)
+        _run(inp)
+        torch.cuda.synchronize()
+        notes = []
+        if "topk" in inp["stages"]:
+            notes.append(_check_topk(inp, case))
+        if "sorting" in inp["stages"]:
+            notes.append(_check_sorting(inp, case))
+        if "quant" in inp["stages"]:
+            notes.append(_check_quant(inp, case))
+        print("correctness PASS", case["id"], f"[{case['phase']}]", " ".join(notes))
+        del inp
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inp = _prepare(case)
+        _run(inp)                       # settle aiter's JIT / kernel selection
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda i=inp: _run(i),
+            warmup=bench.get("warmup", 3),
+            repetition=bench.get("repetition", 30),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        metadata = {
+            **case["params"],
+            "phase": case.get("phase"),
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "exact_shape_source": case.get("exact_shape_source"),
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms", meta.get("benchmark_method"),
+              meta.get("benchmark_fallback_reason", ""))
+        del inp
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness,
+     "performance": run_performance}[mode]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/session_cases.json
+++ b/tasks/kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3/session_cases.json
@@ -1,0 +1,184 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.15.post1.dev20260723+g6c9fd0adc5 (ROCm 7.2.0, aiter 0.1.17.dev352+gdcd204ea5)",
+  "model": "Kimi-K3",
+  "session_id": "20260814T191522Z",
+  "operator": "moe_routing_sort_quant",
+  "task_name": "mi355x-kimi-k3-moe-routing-sort-quant-20260814",
+  "language": "hip (aiter csrc, JIT-compiled through aiter.jit / compile_ops)",
+  "selection": "The MoE pipeline stages that sit AROUND the 2-stage expert GEMM and are not covered by mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3. grouped_topk 2.75% + opus_moe_sorting P0_v2 0.90% + P23 1.20% + fused_mx_quant_moe_sort 1.50% = 6.35% of end-to-end GPU time -- larger than any single MoE GEMM kernel in the session (the biggest is mfma_moe1 t64x128x256 at 2.92%). None of these have ever been a task.",
+  "shape_policy": "Every case is a shape the session actually executed, read from the trace's cpu_op Input Dims (record_shapes=True). Both phases are covered: prefill (T = 16384 / 8192 / 64) and decode (T = bs). The quant stage is included only where the session actually ran it standalone -- see stage_note. The correctness set and the performance set are the same CASES list.",
+  "provenance": {
+    "session_root": "/shared_nfs/hyperloom-claw/Kimi-K3/20260814T191522Z",
+    "trace": "geak/e2e_cycle0/profile/round_0/profile/1786763352.027878-TP-{0..7}.trace.json.gz",
+    "analysis": "/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/kimi-k3-hot-kernels.md",
+    "e2e_weights": {"prefill": 0.416, "decode": 0.584},
+    "kernels_covered": [
+      {"kernel": "void aiter::grouped_topk_kernel<c10::BFloat16, float __vector(4), 1, true, true, false>", "e2e_pct": 2.75, "prefill_pct": 0.61, "decode_pct": 4.28, "calls_per_forward": 92, "src": "csrc/kernels/topk_softmax_kernels_group.cu:320"},
+      {"kernel": "void aiter::opus_moe_sorting_entry<...MoeSortingMultiPhaseKernel_P23...>", "e2e_pct": 1.20, "prefill_pct": 0.01, "decode_pct": 2.05, "calls_per_forward": 92, "src": "csrc/include/moe_sorting_opus.h:109"},
+      {"kernel": "void aiter::opus_moe_sorting_entry<...MoeSortingMultiPhaseKernel_P0_v2...>", "e2e_pct": 0.90, "prefill_pct": 0.01, "decode_pct": 1.54, "calls_per_forward": 92, "src": "csrc/include/moe_sorting_opus.h:109"},
+      {"kernel": "void aiter::fused_mx_quant_moe_sort_kernel<bf16, fp8, 256, 16>", "e2e_pct": 1.50, "prefill_pct": 0.02, "decode_pct": 2.55, "calls_per_forward": 92, "src": "csrc/kernels/quant_kernels.cu:1731"}
+    ],
+    "measured_prefill_tp0": {
+      "grouped_topk_kernel": [
+        {"grid": [16384, 1, 1], "block": [64, 1, 1], "calls": 276, "total_ms": 19.40, "avg_us": 70.3},
+        {"grid": [8192, 1, 1], "block": [64, 1, 1], "calls": 92, "total_ms": 3.69, "avg_us": 40.1},
+        {"grid": [64, 1, 1], "block": [64, 1, 1], "calls": 92, "total_ms": 1.11, "avg_us": 12.0}
+      ],
+      "opus_moe_sorting_entry": [
+        {"grid": [1408, 1, 1], "block": [256, 1, 1], "calls": 460, "total_ms": 11.76, "avg_us": 25.6},
+        {"grid": [256, 1, 1], "block": [1024, 1, 1], "calls": 368, "total_ms": 2.03, "avg_us": 5.5},
+        {"grid": [512, 1, 1], "block": [256, 1, 1], "calls": 368, "total_ms": 1.77, "avg_us": 4.8},
+        {"grid": [896, 1, 1], "block": [256, 1, 1], "calls": 368, "total_ms": 1.80, "avg_us": 4.9}
+      ],
+      "fused_mx_quant_moe_sort_kernel": [
+        {"grid": [7420, 1, 1], "block": [256, 1, 1], "calls": 92, "total_ms": 0.96, "avg_us": 10.5}
+      ]
+    },
+    "trace_recorded_signatures": {
+      "biased_grouped_topk_hip@T16384": "dims [[16384,896],[896],[16384,16],[16384,16],...] types [bf16, bf16, float, int, ...]",
+      "biased_grouped_topk_hip@T8192": "dims [[8192,896],[896],[8192,16],[8192,16],...]",
+      "biased_grouped_topk_hip@T64": "dims [[64,896],[896],[64,16],[64,16],...]",
+      "moe_sorting_opus_fwd@T16384": "dims [[16384,16] int,[16384,16] float,[319472] int,[319472] float,[4992] int,[2] int,[0,0] bf16, ... ,[14683904] u8]",
+      "moe_sorting_opus_fwd@T8192": "dims [[8192,16],[8192,16],[188400],[188400],[2944],[2],[0,0], ... ,[7343872]]",
+      "moe_sorting_opus_fwd@T64": "dims [[64,16],[64,16],[29680],[29680],[928],[2],[64,3584] bf16, ... ,[233216]]",
+      "fused_dynamic_mx_quant_moe_sort_hip@T64": "dims [[64,3584] fp8_e4m3,[29696,112] fp8_e8m0,[64,3584] bf16,[29680] int,[2] int, ... ,[29680] float]"
+    },
+    "block_size_evidence": "max_num_tokens_padded = topk_ids.numel() + num_experts*block_size - topk (fused_moe.py:203). Solving against the trace: T=16384 -> 262144 + 896*b - 16 = 319472 -> b = 64; T=8192 -> 131072 + 896*b - 16 = 188400 -> b = 64; T=64 -> 1024 + 896*b - 16 = 29680 -> b = 32. sorted_expert_ids length confirms it: ceil(319472/64)=4992, ceil(188400/64)=2944, ceil(29680/32)=928. So the session uses block_size 64 for the big-M buckets and 32 for the small-M bucket.",
+    "stage_note": "The standalone MX-quant kernel fires 92 times per forward in the T=64 tail step and 92 times per decode step, but essentially never in the T=16384/8192 steps (measured prefill share 0.02%). That is because the large-tile MoE1 kernel used at big M is mfma_moe1_silu_mul_afp8_wfp4_fp8_t64x128x256_pm1_FP8Q_SORT_ASYNC_gui_... -- it folds the fp8 quant and the scale sort into the GEMM prologue. So `stages` below includes \"quant\" only for the small-M / decode cases, which is exactly where the session ran it.",
+    "moe_buf_note": "The T=16384 / T=8192 calls pass moe_buf as an empty [0,0] placeholder (FlyDSL stage2 reduce mode, accumulate=False, expert_mask=None); the T=64 call passes a real [64, 3584] bf16 buffer. Both variants are reproduced.",
+    "sorted_ids_encoding": "(slot_id << 24) | token_id, int32 -- confirmed by op_tests/flydsl_tests/test_silu_and_mul_fq.py:42. The harness decodes this to validate the sort semantically (ordering-agnostic), because the intra-expert order and the padding fill are implementation details the agent is allowed to change.",
+    "decode_batch_caveat": "Profiling used warmup 0s, so the recorded decode steps are the bs=8 ramp. The session's steady-state decode batch is bs=64 (conc=64, max_running_requests=64; median_itl_ms 46.73 vs 25.56 ms at bs=8). Both are scored."
+  },
+  "moe_config": {
+    "source": "/shared_nfs/hyperloom/models/Kimi-K3/config.json (text_config) + trace",
+    "hidden_size": 7168,
+    "routed_expert_hidden_size": 3584,
+    "num_experts": 896,
+    "num_experts_per_token": 16,
+    "num_expert_group": 1,
+    "topk_group": 1,
+    "num_shared_experts": 2,
+    "moe_intermediate_size": 3072,
+    "tensor_parallel_size": 8,
+    "local_inter_dim": 384,
+    "moe_layers": 92,
+    "moe_renormalize": true,
+    "routed_scaling_factor": 1.0,
+    "mx_group_size": 32,
+    "notes": "first_k_dense_replace=1 so 92 of the 93 layers are MoE, which matches the 92 calls/forward the trace shows for every kernel in this task. K3 is latent-MoE: the experts run on routed_expert_hidden_size=3584, not on hidden_size=7168, which is why the quant input is [T, 3584]."
+  },
+  "cases": [
+    {
+      "id": "moe-route-prefill-t16384",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["grouped_topk_kernel", "opus_moe_sorting_entry"],
+      "gpu_pct_e2e": 6.35,
+      "exact_shape_source": "TRACE-MEASURED -- chunked-prefill block, 92 calls/forward",
+      "trace_input_shapes": [
+        "gating_output (16384, 896) bf16",
+        "correction_bias (896) bf16",
+        "topk_weights (16384, 16) f32",
+        "topk_ids (16384, 16) i32",
+        "sorted_ids (319472) i32",
+        "sorted_expert_ids (4992) i32",
+        "workspace (14683904) u8"
+      ],
+      "params": {
+        "num_tokens": 16384, "num_experts": 896, "topk": 16,
+        "num_expert_group": 1, "topk_group": 1, "need_renorm": true,
+        "routed_scaling_factor": 1.0, "block_size": 64,
+        "latent_dim": 3584, "moe_buf_mode": "empty",
+        "stages": ["topk", "sorting"],
+        "max_weight_err": 1e-3
+      },
+      "benchmark": {"warmup": 3, "repetition": 30, "target_ms": 2.0, "max_graph_repeats": 50},
+      "seed": 9141
+    },
+    {
+      "id": "moe-route-prefill-t8192",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["grouped_topk_kernel", "opus_moe_sorting_entry"],
+      "exact_shape_source": "TRACE-MEASURED -- the session's first EXTEND step (bs=1, 8192 tokens)",
+      "trace_input_shapes": [
+        "gating_output (8192, 896) bf16",
+        "topk_ids (8192, 16) i32",
+        "sorted_ids (188400) i32",
+        "sorted_expert_ids (2944) i32"
+      ],
+      "params": {
+        "num_tokens": 8192, "num_experts": 896, "topk": 16,
+        "num_expert_group": 1, "topk_group": 1, "need_renorm": true,
+        "routed_scaling_factor": 1.0, "block_size": 64,
+        "latent_dim": 3584, "moe_buf_mode": "empty",
+        "stages": ["topk", "sorting"],
+        "max_weight_err": 1e-3
+      },
+      "benchmark": {"warmup": 3, "repetition": 30, "target_ms": 2.0, "max_graph_repeats": 60},
+      "seed": 9142
+    },
+    {
+      "id": "moe-route-prefill-t64",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["grouped_topk_kernel", "opus_moe_sorting_entry", "fused_mx_quant_moe_sort_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- the tail EXTEND step; the only prefill step where the standalone MX-quant kernel runs",
+      "trace_input_shapes": [
+        "gating_output (64, 896) bf16",
+        "topk_ids (64, 16) i32",
+        "sorted_ids (29680) i32",
+        "sorted_expert_ids (928) i32",
+        "quant_in (64, 3584) bf16 -> quant_out (64, 3584) fp8_e4m3 + scales (29696, 112) fp8_e8m0",
+        "moe_buf (64, 3584) bf16"
+      ],
+      "params": {
+        "num_tokens": 64, "num_experts": 896, "topk": 16,
+        "num_expert_group": 1, "topk_group": 1, "need_renorm": true,
+        "routed_scaling_factor": 1.0, "block_size": 32,
+        "latent_dim": 3584, "moe_buf_mode": "real",
+        "stages": ["topk", "sorting", "quant"],
+        "mx_group_size": 32, "max_weight_err": 1e-3, "max_quant_rel_err": 0.08
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 200},
+      "seed": 9143
+    },
+    {
+      "id": "moe-route-decode-bs8",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["grouped_topk_kernel", "opus_moe_sorting_entry", "fused_mx_quant_moe_sort_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- step[DECODE bs=8], the single fully-recorded CUDA-graph replay (ramp batch)",
+      "params": {
+        "num_tokens": 8, "num_experts": 896, "topk": 16,
+        "num_expert_group": 1, "topk_group": 1, "need_renorm": true,
+        "routed_scaling_factor": 1.0, "block_size": 32,
+        "latent_dim": 3584, "moe_buf_mode": "real",
+        "stages": ["topk", "sorting", "quant"],
+        "mx_group_size": 32, "max_weight_err": 1e-3, "max_quant_rel_err": 0.08
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 400},
+      "seed": 9144
+    },
+    {
+      "id": "moe-route-decode-bs64",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["grouped_topk_kernel", "opus_moe_sorting_entry", "fused_mx_quant_moe_sort_kernel"],
+      "exact_shape_source": "SESSION STEADY STATE -- bs=64 is the run's real decode batch (conc=64, max_running_requests=64, 3072 of 3077 decode steps). Absent from the trace only because profiling started at warmup 0s.",
+      "params": {
+        "num_tokens": 64, "num_experts": 896, "topk": 16,
+        "num_expert_group": 1, "topk_group": 1, "need_renorm": true,
+        "routed_scaling_factor": 1.0, "block_size": 32,
+        "latent_dim": 3584, "moe_buf_mode": "real",
+        "stages": ["topk", "sorting", "quant"],
+        "mx_group_size": 32, "max_weight_err": 1e-3, "max_quant_rel_err": 0.08
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 400},
+      "seed": 9145
+    }
+  ]
+}

--- a/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/config.yaml
+++ b/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/config.yaml
@@ -1,0 +1,88 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/sglang/python/sglang
+repo_subdir: sglang
+image_repo_exclude:
+  - __pycache__
+repository_language: triton
+source_file_path:
+  - srt/layers/attn_residual.py
+editable_sources:
+  - kernels/ops/kimi_k3/attn_res.py
+target_kernel_functions:
+  - aggregate_stream
+  - _mix_fused
+  - _score_kernel
+  - _combine_kernel
+kernel_identity:
+  logical_operator: attn_residual
+  kernel_kind: triton
+  source_owner: sglang
+  workload:
+    source: session_cases.json
+    primary_case: attn-res-prefill-t16384-nvb8
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 1800
+correctness_timeout: 3600
+performance_timeout: 3600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the Kimi-K3 attention-residual aggregation on MI355X/gfx950. This is
+    the single largest attackable kernel in Hyperloom session 20260814T191522Z:
+    _score_kernel (8.20% of end-to-end GPU time) plus _combine_kernel (4.04%),
+    12.24% together, both in sglang/srt/layers/attn_residual.py.
+
+    What the operator does: K3 does not carry one residual stream. Every
+    attn_res_block_size (=12) layers it snapshots the running pre-attention prefix
+    into a bank [T, NB, H]; at each of the 186 aggregation points per forward pass
+    the model scores every banked snapshot plus the current prefix, softmaxes, and
+    emits the weighted mixture. _score_kernel is grid (T, nvb+1) block (512,1,1),
+    one CTA per (token, row), scanning H=7168 to emit one scalar
+    score = (v . cw) * rsqrt(mean(v^2) + eps), where cw = norm.weight *
+    proj.weight is precomputed by get_cw(). _combine_kernel is grid (T, H/1024)
+    block (256,1,1): softmax over the <=16 scores (redundantly per H-chunk, which
+    is cheap and intentional) then the weighted sum, one 1024-wide H chunk per CTA.
+
+    Where the headroom is. _score_kernel is memory-bound and lands at 1.74-1.82
+    TB/s at every measured prefill grid -- about 22-23% of the MI355X HBM3E peak
+    (8 TB/s). Each CTA reads only 7168*2 = 14 KB and then does two reductions
+    (sumsq and dotv) to emit a single scalar, so with up to ~147k CTAs the
+    reduction tail dominates. On top of that the two-kernel split round-trips
+    scores[T,16] fp32 through HBM and reads the whole bank TWICE per aggregation
+    point. Note that _use_fast() (attn_residual.py:32) gates a warp-specialized
+    fused kernel behind torch.cuda.get_device_capability().major >= 10, i.e.
+    NVIDIA SM100+ only -- gfx950 has no fused path at all. Writing the gfx950
+    equivalent (score + online softmax + combine, and ideally the output RMSNorm,
+    in ONE kernel with the bank read once and no fp32 scores round-trip) is the
+    obvious and largest win. Other levers: BLOCK_H and num_warps retuning per nvb,
+    persistent CTAs, packed bf16 loads, splitting the H scan across more CTAs with
+    a cheap cross-CTA reduction, and specializing the tiny-T decode grid
+    (T*(nvb+1) is only ~40-580 CTAs, which is deeply under-occupied on 256 CUs).
+
+    Dims are the session's real ones: hidden_size H=7168 (= 7 x BLOCK_H, so the
+    H % _BLOCK_H eager fallback in aggregate_stream never triggers), bank depth
+    NB=8 with nvb sweeping 1..8 inside one forward pass, _MAX_ROWS=16,
+    rms_norm_eps=1e-5, dtype bf16 with fp32 accumulation and an fp32 cw. Both
+    phases are scored from session_cases.json: prefill T=16384 (chunked prefill
+    block size) at nvb 1/4/8, T=8192, T=64, and decode T=8 (the trace-recorded
+    ramp batch) and T=64 (the steady-state batch that dominates the 249 s run).
+
+    Correctness is numerical parity against an independent, vectorized float64
+    golden in the harness (cos > 0.9995 and normalized max error < 0.02). Do NOT
+    try to satisfy it by editing aggregate_stream_torch: the harness never calls
+    it. Keep the public signature of aggregate_stream(prefix_sum, bank, nvb,
+    score_proj, score_norm) unchanged, keep get_cw()'s contract (it may be called
+    with dtype=torch.float32 or torch.bfloat16 and caches on the proj object), and
+    keep the operator graph-capturable -- performance is measured under HIP graph
+    replay.
+  cheatsheet: null

--- a/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/forge_driver.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Kimi-K3 attention-residual task.
+
+Targets (PROTECTED, optimized by forge-loop):
+    ``_score_kernel`` and ``_combine_kernel`` in
+    ``sglang/srt/layers/attn_residual.py``, reached through ``aggregate_stream``.
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root. Without
+it the launcher generates a generic shim that delegates to ``arena_task_adapter``,
+which does NOT implement ``--profile-run``; forge-loop then burns an LLM agent
+authoring a profiling-capable driver before every run. Shipping this file makes the
+driver preflight pass on the first check, so task preparation is skipped entirely.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``SNR: <db> dB`` -- the worst case's signal-to-noise ratio against
+        the harness's independent, vectorized float64 golden.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` per case plus one ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's own evaluator).
+        Timing goes through ``task_runner._benchmark_cuda_graph_or_events``, i.e.
+        the call is captured once into a HIP graph and REPLAYED per timed
+        iteration, so forge-loop's graph-replay probe is satisfied for real.
+
+  * Profiling    ``--profile-run``
+        builds the largest case's inputs and launches ONLY the target entry point:
+        a few warmups to settle the Triton JIT, a couple of profiled launches, one
+        synchronize, exit 0. No timing is printed.
+
+All measurement logic is REUSED from ``scripts/task_runner.py`` (``_configure`` /
+``_prepare`` / ``_run`` / ``_golden`` / ``_benchmark_cuda_graph_or_events``), so the
+driver measures exactly the same op Arena scores. forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; run in place
+    from the task dir, both sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _case_cost(case: dict) -> int:
+    """Bytes the aggregation must stream: T * (nvb+1) * H."""
+    p = case["params"]
+    return int(p["num_tokens"]) * (int(p["num_valid_blocks"]) + 1) * int(p["hidden_size"])
+
+
+def _run_correctness(tr) -> int:
+    """Per-case SNR against the float64 golden; report the worst case."""
+    import torch
+
+    worst_db = math.inf
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        out = tr._run(inp)
+        torch.cuda.synchronize()
+        ref = tr._golden(inp)
+        got = out.double().flatten()
+        gold = ref.flatten()
+        noise = (got - gold).norm().item()
+        signal = gold.norm().item()
+        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        worst_db = min(worst_db, db)
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+    print(f"SNR: {worst_db:.2f} dB")
+    return 0
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    """Graph-timed bench: one HIP-graph mean per case (reuses task_runner)."""
+    import torch
+
+    results = []
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        tr._run(inp)                   # settle the Triton JIT before capture
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda i=inp: tr._run(i),
+            warmup=max(1, warmup),
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        if not math.isfinite(ms) or ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {ms!r}", file=sys.stderr)
+            return 1
+        results.append((case["id"], ms, meta))
+        del inp
+        torch.cuda.empty_cache()
+    if len(results) != len(tr.CASES) or not results:
+        print("error: benchmark did not produce every task case", file=sys.stderr)
+        return 1
+    for case_id, ms, meta in results:
+        print(f"case_ms: {case_id} {ms:.6f}")
+        print(f"# bench {case_id}: {ms:.6f} ms method={meta.get('benchmark_method')}"
+              f" {meta.get('benchmark_fallback_reason', '')}".rstrip())
+    means = [ms for _, ms, _ in results]
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr) -> int:
+    """Kernel-only profiling for one case: warm, a few launches, sync, exit 0."""
+    import torch
+
+    case = max(tr.CASES, key=_case_cost)
+    inp = tr._prepare(case)
+    for _ in range(3):                 # settle Triton JIT / autotune selection
+        tr._run(inp)
+    torch.cuda.synchronize()
+    for _ in range(3):                 # profiled launches
+        tr._run(inp)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kimi-K3 attention-residual forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    tr = _import_task_runner()
+    tr._configure()   # gfx950 env + workspace-seeded sglang first on sys.path
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/forge_driver.py
@@ -71,11 +71,19 @@ def _case_cost(case: dict) -> int:
     return int(p["num_tokens"]) * (int(p["num_valid_blocks"]) + 1) * int(p["hidden_size"])
 
 
+def _snr_db(signal: float, noise: float, *, finite: bool) -> float:
+    """Return a finite failing sentinel when an output cannot be scored safely."""
+    if not finite or not math.isfinite(signal) or not math.isfinite(noise):
+        return -1.0e9
+    return 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+
+
 def _run_correctness(tr) -> int:
     """Per-case SNR against the float64 golden; report the worst case."""
     import torch
 
     worst_db = math.inf
+    all_finite = True
     for case in tr.CASES:
         inp = tr._prepare(case)
         out = tr._run(inp)
@@ -85,13 +93,15 @@ def _run_correctness(tr) -> int:
         gold = ref.flatten()
         noise = (got - gold).norm().item()
         signal = gold.norm().item()
-        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        finite = bool(torch.isfinite(out).all())
+        all_finite = all_finite and finite
+        db = _snr_db(signal, noise, finite=finite)
         worst_db = min(worst_db, db)
-        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={finite}")
         del inp, out, ref, got, gold
         torch.cuda.empty_cache()
     print(f"SNR: {worst_db:.2f} dB")
-    return 0
+    return 0 if all_finite else 1
 
 
 def _run_bench(tr, warmup: int, iters: int) -> int:

--- a/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/task_runner.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/task_runner.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for Kimi-K3 attention residual (`_score_kernel` + `_combine_kernel`).
+
+What this operator is
+---------------------
+Kimi-K3 does not carry a single residual stream. Every ``attn_res_block_size`` (=12)
+layers it snapshots the running pre-attention prefix into a bank ``[T, NB, H]``; at
+each aggregation point the model scores *all* banked snapshots plus the current
+prefix, softmaxes the scores and emits the weighted mixture. That lets each layer
+choose which historical residual state to read.
+
+Two Triton kernels implement it (``sglang/srt/layers/attn_residual.py``):
+
+  * ``_score_kernel``   grid ``(T, nvb+1)``, block ``(512,1,1)`` -- one CTA per
+    (token, row); scans H and emits one scalar
+    ``score = (v . cw) / sqrt(mean(v^2) + eps)`` where ``cw = norm.weight *
+    proj.weight`` is precomputed by ``get_cw()``.
+  * ``_combine_kernel`` grid ``(T, H/1024)``, block ``(256,1,1)`` -- softmax over
+    the (<=16) scores, then the weighted sum of the same rows, one H-chunk per CTA.
+
+Both fire **186 times per forward pass**, in prefill and in decode alike, and
+together they are 12.24% of end-to-end GPU time in session 20260814T191522Z --
+the largest attackable kernel in the whole session.
+
+Why there is headroom
+---------------------
+``_use_fast()`` (attn_residual.py:32) gates the warp-specialized TMA kernel behind
+``torch.cuda.get_device_capability().major >= 10`` -- that is NVIDIA SM100+. On
+gfx950 the model is permanently on this 2-kernel fallback, which round-trips
+``scores[T,16]`` fp32 through HBM and reads the whole bank twice (once to score,
+once to combine). Measured: 1.74-1.82 TB/s at every prefill grid, i.e. ~22-23% of
+the MI355X HBM3E peak.
+
+Entry point under test
+----------------------
+``aggregate_stream(prefix_sum, bank, nvb, score_proj, score_norm)`` -- the public
+pre-norm aggregation API (attn_residual.py:285). It is used rather than
+``_mix_fused`` directly because it is the stable public signature, and rather than
+``AttnResidual.forward`` because the latter also needs an ``out_norm`` RMSNorm
+module and a distributed-initialized ``ReplicatedLinear``.
+
+``score_proj`` / ``score_norm`` are duck-typed stand-ins: ``get_cw()`` only reads
+``proj.weight`` (``[1, H]``), ``norm.weight`` (``[H]``) and caches on
+``proj._attn_res_cw_cache``; ``_mix_fused`` additionally reads
+``norm.variance_epsilon``. Constructing the real ``ReplicatedLinear`` would require
+``torch.distributed`` to be initialized, which the harness deliberately avoids.
+
+Golden
+------
+An independent, fully vectorized float64 transcription of the two kernels, chunked
+over the token axis so peak memory stays bounded (no per-token Python loop). It does
+NOT call ``aggregate_stream_torch`` from the model source: that function lives in
+the agent's edit surface, so reusing it would let a broken edit validate itself.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MODEL_CONFIG = SPEC["model_config"]
+
+# Token-chunk for the float64 golden. 1024 tokens x 9 rows x 7168 x 8 B = 528 MB
+# per temporary; four live temporaries stay comfortably inside a 288 GB card while
+# keeping the reference fully vectorized.
+_GOLDEN_CHUNK = 1024
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    # Prefer the workspace-seeded editable copy so the agent's edits take effect;
+    # fall back to the in-image install for standalone/dev runs.
+    seeded = WORKSPACE / "sglang"
+    if (seeded / "__init__.py").is_file():
+        sys.path.insert(0, str(WORKSPACE))
+    else:
+        sys.path.insert(0, os.environ.get("SGLANG_PYTHON", "/sgl-workspace/sglang/python"))
+    # Triton keys its JIT cache on kernel source, so an edit already forces a
+    # recompile; pinning the cache inside the workspace additionally guarantees a
+    # run can never serve a binary built from another workspace's source.
+    os.environ.setdefault("TRITON_CACHE_DIR", str(WORKSPACE / "build" / "triton_cache"))
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _attn_res_ops():
+    """Public aggregation entry from the (possibly agent-edited) sglang copy."""
+    from sglang.srt.layers.attn_residual import aggregate_stream
+
+    return aggregate_stream
+
+
+class _WeightHolder:
+    """Duck-typed stand-in for ReplicatedLinear / RMSNorm.
+
+    get_cw() reads ``.weight`` and stores its cache on the proj object;
+    _mix_fused() reads ``.variance_epsilon`` off the norm object. Nothing else in
+    the aggregation path touches these modules, so constructing the real sglang
+    layers (which would need torch.distributed) is unnecessary.
+    """
+
+    def __init__(self, weight, variance_epsilon: float | None = None):
+        self.weight = weight
+        if variance_epsilon is not None:
+            self.variance_epsilon = variance_epsilon
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    """Build one case at its scored shape.
+
+    There is deliberately no correctness/performance switch: the shape that is
+    timed is the shape that is validated, so the scored code path can never differ
+    from the checked one.
+    """
+    torch = _torch()
+    p = case["params"]
+    T = int(p["num_tokens"])
+    H = int(p["hidden_size"])
+    nvb = int(p["num_valid_blocks"])
+    nb = int(p["bank_blocks"])
+    dtype = getattr(torch, p.get("dtype", "bfloat16"))
+    assert nb >= nvb, (case["id"], "bank_blocks must cover num_valid_blocks")
+
+    gen = torch.Generator(device="cuda").manual_seed(int(case.get("seed", 8141)))
+
+    def rnd(*shape, dt=dtype, scale=1.0):
+        return (torch.randn(*shape, device="cuda", dtype=torch.float32, generator=gen)
+                * scale).to(dt)
+
+    # The residual stream and the frozen snapshot bank, exactly as AttnResidual
+    # holds them: bank is [T, NB, H] contiguous, prefix is [T, H].
+    prefix_sum = rnd(T, H, scale=0.5).contiguous()
+    bank = rnd(T, nb, H, scale=0.5).contiguous()
+
+    # score_proj: ReplicatedLinear(H -> 1), weight [1, H].  score_norm: RMSNorm(H).
+    proj_w = rnd(1, H, scale=0.05).contiguous()
+    norm_w = (torch.ones(H, device="cuda", dtype=torch.float32)
+              + 0.1 * torch.randn(H, device="cuda", dtype=torch.float32, generator=gen)).to(dtype)
+
+    return {
+        "cfg": case, "T": T, "H": H, "nvb": nvb, "nb": nb, "dtype": dtype,
+        "eps": float(p.get("eps", MODEL_CONFIG["rms_norm_eps"])),
+        "prefix_sum": prefix_sum, "bank": bank,
+        "score_proj": _WeightHolder(proj_w),
+        "score_norm": _WeightHolder(norm_w, float(p.get("eps", MODEL_CONFIG["rms_norm_eps"]))),
+    }
+
+
+def _run(inp: dict):
+    aggregate_stream = _attn_res_ops()
+    return aggregate_stream(
+        inp["prefix_sum"], inp["bank"], inp["nvb"], inp["score_proj"], inp["score_norm"]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+# --------------------------------------------------------------------------- #
+def _golden(inp: dict):
+    """Vectorized float64 transcription of _score_kernel + _combine_kernel.
+
+    Per token t, with rows = [bank[t,0..nvb-1,:], prefix[t,:]] (nvb+1 rows of H):
+
+        score_j = (rows_j . cw) * rsqrt(mean(rows_j^2) + eps)   # _score_kernel
+        p       = softmax(score)                                # _combine_kernel
+        out_t   = sum_j p_j * rows_j                            # _combine_kernel
+
+    with ``cw = score_norm.weight * score_proj.weight.squeeze()`` in fp32 (this is
+    what get_cw() precomputes, and it is algebraically the RMSNorm-then-project the
+    eager path performs).
+
+    Chunked over the token axis only -- every arithmetic step below is a whole-tensor
+    op, there is no per-token loop.
+    """
+    torch = _torch()
+    T, H, nvb, eps = inp["T"], inp["H"], inp["nvb"], inp["eps"]
+    cw = (inp["score_norm"].weight.double() * inp["score_proj"].weight.squeeze(0).double())
+    out = torch.empty(T, H, device="cuda", dtype=torch.float64)
+
+    for s in range(0, T, _GOLDEN_CHUNK):
+        e = min(s + _GOLDEN_CHUNK, T)
+        rows = torch.cat(
+            [inp["bank"][s:e, :nvb, :].double(),
+             inp["prefix_sum"][s:e, :].double().unsqueeze(1)],
+            dim=1,
+        )                                              # [c, nvb+1, H]
+        dotv = rows @ cw                               # [c, nvb+1] -- matmul, no [c,R,H] temp
+        sumsq = rows.pow(2).sum(-1)                    # [c, nvb+1]
+        score = dotv * torch.rsqrt(sumsq / H + eps)    # [c, nvb+1]
+        prob = torch.softmax(score, dim=-1)            # [c, nvb+1]
+        out[s:e] = (prob.unsqueeze(-1) * rows).sum(dim=1)
+        del rows, dotv, sumsq, score, prob
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inp = _prepare(CASES[0])
+    out = _run(inp)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} dtype={out.dtype}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inp = _prepare(case)
+        out = _run(inp)
+        torch.cuda.synchronize()
+        ref = _golden(inp)
+
+        assert torch.isfinite(out).all(), (case["id"], "non-finite output")
+        assert tuple(out.shape) == (inp["T"], inp["H"]), (
+            case["id"], tuple(out.shape), (inp["T"], inp["H"])
+        )
+        assert out.dtype == inp["dtype"], (case["id"], out.dtype, inp["dtype"])
+
+        got = out.double().flatten()
+        gold = ref.flatten()
+        cos = torch.nn.functional.cosine_similarity(got, gold, dim=0).item()
+        denom = gold.abs().max().clamp_min(1e-8)
+        rel_max = ((got - gold).abs().max() / denom).item()
+        p = case["params"]
+        assert cos > p.get("min_cosine", 0.9995), (
+            case["id"], f"cosine {cos:.7f} vs float64 golden too low"
+        )
+        assert rel_max < p.get("max_rel_err", 0.02), (
+            case["id"], f"normalized max err {rel_max:.5f} too high"
+        )
+        print("correctness PASS", case["id"],
+              f"[{case['phase']}] cos={cos:.7f} rel_max_err={rel_max:.5f} "
+              f"|o|={got.norm().item():.3f}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inp = _prepare(case)
+        _run(inp)                       # settle the Triton JIT and warm the cw cache
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda i=inp: _run(i),
+            warmup=bench.get("warmup", 3),
+            repetition=bench.get("repetition", 20),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        metadata = {
+            **case["params"],
+            "phase": case.get("phase"),
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "exact_shape_source": case.get("exact_shape_source"),
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            # Flat, not nested: src/testcases.py reads benchmark_method from the
+            # top level of each row when building TestCaseResult.metadata.
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms", meta.get("benchmark_method"),
+              meta.get("benchmark_fallback_reason", ""))
+        del inp
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness,
+     "performance": run_performance}[mode]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/session_cases.json
+++ b/tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/session_cases.json
@@ -1,0 +1,185 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.15.post1.dev20260723+g6c9fd0adc5 (ROCm 7.2.0, aiter dcd204ea, triton 3.6.0+git42270451)",
+  "model": "Kimi-K3",
+  "session_id": "20260814T191522Z",
+  "operator": "attn_residual",
+  "task_name": "mi355x-kimi-k3-attn-residual-20260814",
+  "language": "triton (@triton.jit, runtime-compiled; sglang/srt/layers/attn_residual.py)",
+  "selection": "Highest single-kernel E2E share in the session: _score_kernel 8.20% + _combine_kernel 4.04% = 12.24% of end-to-end GPU time. Both fire 186 times per forward pass, in prefill AND in decode, and are reached through aggregate_stream(). Chosen because (a) largest attackable single kernel, (b) measured at only 22-23% of HBM bandwidth so headroom is real, (c) gfx950 has no fused fast path -- _use_fast() gates the warp-specialized TMA kernel behind torch.cuda.get_device_capability().major >= 10 (NVIDIA SM100+), so MI355X is permanently on the 2-kernel Triton fallback.",
+  "shape_policy": "Every case below is a shape the session actually executed, read off the trace kernel events. Both phases are covered: prefill (T = 16384 chunked / 8192 first step / 64 tail step) and decode (T = bs). All correctness cases are also performance cases and vice versa -- task_runner iterates the same CASES list for both.",
+  "provenance": {
+    "session_root": "/shared_nfs/hyperloom-claw/Kimi-K3/20260814T191522Z",
+    "trace": "geak/e2e_cycle0/profile/round_0/profile/1786763352.027878-TP-{0..7}.trace.json.gz",
+    "analysis": "/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/kimi-k3-hot-kernels.md",
+    "method": "Every GPU event attributed to a scheduler step via kernel.correlation -> cuda_runtime -> step[...] user_annotation. prefill = the 5 EXTEND steps (24133 kernels, 3974.64 ms on TP0); decode = the single fully-recorded CUDA-graph replay (25.49 ms) plus out-of-graph kernels amortized over 59 steps (25.557 ms/step). E2E% = prefill% * 0.416 + decode% * 0.584.",
+    "e2e_weights": {
+      "prefill": 0.416,
+      "decode": 0.584,
+      "derivation": "Two independent methods, averaged. (A) trace prefill rate 16384 tok / 1060.9 ms -> 15443 tok/s; 1572864 input tokens -> 101.85 s of 249.116 s -> 40.9% prefill. (B) bench median_itl_ms 46.73 (p90 47.43) x 3072 decode steps -> 143.56 s -> 57.6% decode. They differ by 1.5 pt; either endpoint moves every E2E% by < 0.25 pt."
+    },
+    "call_stack": [
+      "sglang/srt/models/kimi_k3.py  (AttnResidual.forward at every aggregation point)",
+      "sglang/srt/layers/attn_residual.py(403): AttnResidual.forward",
+      "sglang/srt/layers/attn_residual.py(336): _aggregate   -- _use_fast() is False on gfx950",
+      "sglang/srt/layers/attn_residual.py(247): _aggregate_fused",
+      "sglang/srt/layers/attn_residual.py(197): _mix_fused   -- _score_kernel[(T, nvb+1)] then _combine_kernel[(T, H//1024)]"
+    ],
+    "shape_evidence": "grid/block read directly from trace kernel events. _score_kernel grid is exactly (T, nvb+1), block (512,1,1); grid.y sweeps 2..9 within one forward pass, i.e. nvb = 1..8, matching _MAX_ROWS = next_pow2(8+1) = 16 and attn_res_block_size=12 over 93 layers. _combine_kernel grid is (T, 7), block (256,1,1), 7 = H/BLOCK_H = 7168/1024. Both fire exactly 186 times per forward in every phase.",
+    "measured_prefill_tp0": {
+      "_score_kernel_total_ms": 462.52,
+      "_combine_kernel_total_ms": 207.93,
+      "_score_kernel_by_grid": [
+        {"grid": [16384, 2, 1], "nvb": 1, "calls": 72, "total_ms": 19.41, "avg_us": 269.5, "bytes_read": 469762048, "achieved_tb_s": 1.74},
+        {"grid": [16384, 3, 1], "nvb": 2, "calls": 72, "total_ms": 28.46, "avg_us": 395.2},
+        {"grid": [16384, 4, 1], "nvb": 3, "calls": 72, "total_ms": 37.85, "avg_us": 525.8},
+        {"grid": [16384, 5, 1], "nvb": 4, "calls": 72, "total_ms": 47.04, "avg_us": 653.3, "bytes_read": 1174405120, "achieved_tb_s": 1.80},
+        {"grid": [16384, 6, 1], "nvb": 5, "calls": 72, "total_ms": 56.43, "avg_us": 783.8},
+        {"grid": [16384, 7, 1], "nvb": 6, "calls": 72, "total_ms": 65.82, "avg_us": 914.2},
+        {"grid": [16384, 8, 1], "nvb": 7, "calls": 72, "total_ms": 74.80, "avg_us": 1038.9},
+        {"grid": [16384, 9, 1], "nvb": 8, "calls": 54, "total_ms": 62.88, "avg_us": 1164.5, "bytes_read": 2113929216, "achieved_tb_s": 1.82},
+        {"grid": [8192, 9, 1], "nvb": 8, "calls": 24, "total_ms": 12.58, "avg_us": 524.4}
+      ],
+      "_combine_kernel_by_grid": [
+        {"grid": [16384, 7, 1], "calls": 558, "total_ms": 177.78, "avg_us": 318.6},
+        {"grid": [8192, 7, 1], "calls": 186, "total_ms": 28.50, "avg_us": 153.2},
+        {"grid": [64, 7, 1], "calls": 186, "total_ms": 0.84, "avg_us": 4.5}
+      ]
+    },
+    "measured_decode_tp0": {
+      "step_total_ms": 25.557,
+      "_score_kernel": {"calls_per_step": 186, "total_ms": 1.48, "avg_us": 7.9, "pct_of_step": 5.78},
+      "_combine_kernel": {"calls_per_step": 186, "total_ms": 0.82, "avg_us": 4.4, "pct_of_step": 3.21},
+      "note": "Decode kernels run inside a CUDA graph, so the trace carries no grid/block for them; T = batch size = 8 is read from the step[DECODE bs=8] annotation and nvb sweeps the same 1..8 as prefill (same 186 aggregation points, same bank depth)."
+    },
+    "cross_rank_check": "Pure compute, no TP skew: _score_kernel prefill total is 457.32-462.98 ms across all 8 ranks (spread < 1.3%); _combine_kernel 207.27-208.16 ms (spread < 0.5%).",
+    "efficiency_note": "_score_kernel is strictly linear in nvb and lands at 1.74-1.82 TB/s at every grid -- about 22-23% of the MI355X HBM3E peak (8 TB/s). Each CTA reads only 7168*2 = 14 KB then does two reductions (sumsq, dotv) to emit one scalar; with up to ~147k CTAs the reduction tail dominates. In decode the grid is only 8*(nvb+1) ~ 40 CTAs, so 7.9 us per launch is pure latency, not bandwidth.",
+    "decode_batch_caveat": "The session profiled with warmup 0s, so all 64 recorded scheduler steps sit in the ramp and decode was captured at bs=8. The session's steady-state decode batch is bs=64 (conc=64, max_running_requests=64; confirmed independently by median_itl_ms 46.73 vs 25.56 ms at bs=8). Both are shapes this session really ran; the bs=8 case is the trace-recorded one and the bs=64 case is the one that dominates the 249 s benchmark. Both are scored."
+  },
+  "model_config": {
+    "source": "/shared_nfs/hyperloom/models/Kimi-K3/config.json (text_config)",
+    "hidden_size": 7168,
+    "num_hidden_layers": 93,
+    "attn_res_block_size": 12,
+    "max_bank_rows": 8,
+    "rms_norm_eps": 1e-05,
+    "tensor_parallel_size": 8,
+    "block_h": 1024,
+    "max_rows_padded": 16,
+    "aggregation_points_per_forward": 186,
+    "notes": "attn_res_block_size=12 over 93 layers gives at most 8 banked snapshots, which is why _MAX_ROWS = next_pow2(8+1) = 16. H = 7168 = 7 x BLOCK_H(1024), so the H % _BLOCK_H eager fallback in aggregate_stream() is never taken in this model. score_proj is a ReplicatedLinear with out_features=1 (weight [1, 7168]); score_norm is an RMSNorm with weight [7168]; get_cw() caches their elementwise product as fp32. The attention residual is NOT replicated across TP ranks in a way that changes shape -- H is the full 7168 on every rank."
+  },
+  "cases": [
+    {
+      "id": "attn-res-prefill-t16384-nvb8",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "gpu_pct_e2e": 12.24,
+      "exact_shape_source": "TRACE-MEASURED -- grid (16384, 9), the deepest bank state of a chunked-prefill step",
+      "trace_input_shapes": [
+        "prefix_sum (16384, 7168) bf16",
+        "bank (16384, 8, 7168) bf16",
+        "cw (7168) f32",
+        "scores (16384, 16) f32"
+      ],
+      "params": {
+        "num_tokens": 16384, "hidden_size": 7168,
+        "num_valid_blocks": 8, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 4.0, "max_graph_repeats": 20},
+      "seed": 8141
+    },
+    {
+      "id": "attn-res-prefill-t16384-nvb4",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- grid (16384, 5), the mid-depth bank state (72 calls/forward)",
+      "params": {
+        "num_tokens": 16384, "hidden_size": 7168,
+        "num_valid_blocks": 4, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 3.0, "max_graph_repeats": 30},
+      "seed": 8142
+    },
+    {
+      "id": "attn-res-prefill-t16384-nvb1",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- grid (16384, 2), the first aggregation point (after layer 12)",
+      "params": {
+        "num_tokens": 16384, "hidden_size": 7168,
+        "num_valid_blocks": 1, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 2.0, "max_graph_repeats": 50},
+      "seed": 8143
+    },
+    {
+      "id": "attn-res-prefill-t8192-nvb8",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- grid (8192, 9), the session's first EXTEND step (bs=1, 8192 tokens)",
+      "params": {
+        "num_tokens": 8192, "hidden_size": 7168,
+        "num_valid_blocks": 8, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 3.0, "max_graph_repeats": 30},
+      "seed": 8144
+    },
+    {
+      "id": "attn-res-prefill-t64-nvb8",
+      "phase": "prefill",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- grid (64, 9) / combine grid (64, 7), the tail EXTEND step; the launch-bound regime",
+      "params": {
+        "num_tokens": 64, "hidden_size": 7168,
+        "num_valid_blocks": 8, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 400},
+      "seed": 8145
+    },
+    {
+      "id": "attn-res-decode-bs8-nvb8",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "TRACE-MEASURED -- step[DECODE bs=8], the single fully-recorded CUDA-graph replay (ramp-up batch)",
+      "trace_input_shapes": [
+        "prefix_sum (8, 7168) bf16",
+        "bank (8, 8, 7168) bf16"
+      ],
+      "params": {
+        "num_tokens": 8, "hidden_size": 7168,
+        "num_valid_blocks": 8, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 400},
+      "seed": 8146
+    },
+    {
+      "id": "attn-res-decode-bs64-nvb8",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_score_kernel", "_combine_kernel"],
+      "exact_shape_source": "SESSION STEADY STATE -- bs=64 is the session's real decode batch (conc=64, max_running_requests=64, 3072 of the run's 3077 decode steps). Not in the trace only because profiling started at warmup 0s and captured the ramp.",
+      "params": {
+        "num_tokens": 64, "hidden_size": 7168,
+        "num_valid_blocks": 8, "bank_blocks": 8, "eps": 1e-05,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 5, "repetition": 50, "target_ms": 1.0, "max_graph_repeats": 400},
+      "seed": 8147
+    }
+  ]
+}

--- a/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/config.yaml
+++ b/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/config.yaml
@@ -1,0 +1,94 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/sglang/python/sglang
+repo_subdir: sglang
+image_repo_exclude:
+  - __pycache__
+repository_language: triton
+source_file_path:
+  - kernels/ops/attention/decode_attention.py
+target_kernel_functions:
+  - decode_attention_fwd_grouped
+  - _fwd_grouped_kernel_stage1
+  - _fwd_kernel_stage2
+kernel_identity:
+  logical_operator: mla_decode_grouped
+  kernel_kind: triton
+  source_owner: sglang
+  workload:
+    source: session_cases.json
+    primary_case: mla-decode-bs64-kv8192
+compile_command:
+  - python3 scripts/task_runner.py compile
+correctness_command:
+  - python3 scripts/task_runner.py correctness
+performance_command:
+  - python3 scripts/task_runner.py performance
+compile_timeout: 1800
+correctness_timeout: 3600
+performance_timeout: 3600
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize Kimi-K3 MLA grouped decode attention (flash-decoding split-KV) on
+    MI355X/gfx950. From Hyperloom session 20260814T191522Z:
+    _fwd_grouped_kernel_stage1 is 3.96% of end-to-end GPU time and
+    _fwd_kernel_stage2 is 0.69%, 4.65% together, both reached through
+    decode_attention_fwd_grouped in
+    sglang/kernels/ops/attention/decode_attention.py. The session ran
+    --attention-backend triton, so this is the path that actually executed.
+
+    K3 is a hybrid model: only 24 of its 93 layers are MLA full attention (the
+    other 69 are KDA linear attention), and the trace shows exactly 24 stage1 +
+    24 stage2 launches per decode step, which pins the attribution.
+
+    This operator is DECODE ONLY, and that is a property of the operator rather
+    than a gap in the case set: K3's MLA prefill goes through a structurally
+    different kernel (_fwd_kernel in extend_attention.py) which has zero launches
+    in decode, and decode_attention_fwd_grouped has zero launches in prefill.
+
+    Layout (absorbed MLA decode, per-rank TP=8; every number pinned by the call
+    site at srt/layers/attention/triton_backend.py:1823 plus the model config):
+      q            [bs, 12, 576]            bf16   12 = 96 heads / TP8;
+                                                   576 = kv_lora 512 + rope 64
+      k_buffer     [num_kv_tokens, 1, 576]  bf16   one compressed entry per token
+      v_buffer     [num_kv_tokens, 1, 512]  bf16   NON-CONTIGUOUS view of
+                                                   k_buffer[..., :512]
+      o            [bs, 12, 512]            bf16
+      attn_logits  [bs, 12, 256, 512]       f32
+      attn_lse     [bs, 12, 256]            f32
+    kv_head_num = 1 so kv_group_num = 12 -- that is what routes the call to the
+    grouped kernel. max_kv_splits = 256 is exact for this run: the server default
+    is 8, then _mla_decode_kv_splits_cap(8, sm_count=256, max_context_len=13312)
+    = max(8, min(next_pow2(256), next_pow2(ceil(13312/32)))) = 256. sm_scale =
+    192**-0.5 = 0.0721687836 (qk_nope 128 + qk_rope 64). num_kv_splits is filled by
+    the backend's own get_num_kv_splits_triton scheduler, which is outside the edit
+    surface, so you are timed against the session's real split schedule.
+
+    Scored shapes span the workload's real decode envelope: batch 8 (the
+    trace-recorded ramp batch, step[DECODE bs=8]) and 64 (the steady-state batch --
+    conc=64, max_running_requests=64), each at KV length 8192 (ISL, start of
+    generation) and 9216 (ISL + OSL, end of generation). The correctness set and
+    the performance set are the same list.
+
+    Useful levers: the stage1 KV-block tile and the BLOCK_H grouping over the 12
+    query heads, exploiting that q and k share the same 576-wide buffer while v is
+    just its first 512 columns (one load can serve both), the fp32 attn_logits
+    traffic (bs * 12 * 256 * 512 * 4 B = 402 MB at bs=64 -- the split count is
+    capped at 256 by CU count, not by need, so a smarter per-sequence split
+    schedule or a smaller logits footprint is on the table), stage1/stage2 fusion
+    when the split count is small, LDS reuse across the 12-head group, and the
+    non-contiguous v_buffer stride pattern.
+
+    Correctness is numerical parity against an independent, vectorized float64
+    reference attention in the harness (cos > 0.9995 and normalized max error <
+    0.02). The reference is split-agnostic -- split-KV must reproduce plain softmax
+    attention, so you may change num_kv_splits handling freely as long as the
+    result is unchanged. Keep the public signature of decode_attention_fwd_grouped
+    unchanged, keep honouring has_mla=True and page_size, and keep the operator
+    graph-capturable -- performance is measured under HIP graph replay.
+  cheatsheet: null

--- a/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/forge_driver.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Kimi-K3 MLA grouped-decode task.
+
+Targets (PROTECTED, optimized by forge-loop):
+    ``_fwd_grouped_kernel_stage1`` and ``_fwd_kernel_stage2`` in
+    ``sglang/kernels/ops/attention/decode_attention.py``, reached through
+    ``decode_attention_fwd_grouped``.
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root. Without
+it the launcher generates a generic shim that delegates to ``arena_task_adapter``,
+which does NOT implement ``--profile-run``; forge-loop then burns an LLM agent
+authoring a profiling-capable driver before every run. Shipping this file makes the
+driver preflight pass on the first check, so task preparation is skipped entirely.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``SNR: <db> dB`` -- the worst case's signal-to-noise ratio against
+        the harness's independent, vectorized float64 golden.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` per case plus one ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's own evaluator).
+        Timing goes through ``task_runner._benchmark_cuda_graph_or_events``, i.e.
+        the call is captured once into a HIP graph and REPLAYED per timed
+        iteration, so forge-loop's graph-replay probe is satisfied for real.
+
+  * Profiling    ``--profile-run``
+        builds the largest case's inputs and launches ONLY the target entry point:
+        a few warmups to settle the Triton JIT, a couple of profiled launches, one
+        synchronize, exit 0. No timing is printed.
+
+All measurement logic is REUSED from ``scripts/task_runner.py`` (``_configure`` /
+``_prepare`` / ``_run`` / ``_golden`` / ``_benchmark_cuda_graph_or_events``), so the
+driver measures exactly the same op Arena scores. forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; run in place
+    from the task dir, both sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _case_cost(case: dict) -> int:
+    """KV bytes the decode must stream: bs * seq_len * qk_head_dim."""
+    p = case["params"]
+    return int(p["batch_size"]) * int(p["seq_len"]) * int(p["qk_head_dim"])
+
+
+def _run_correctness(tr) -> int:
+    """Per-case SNR against the float64 golden; report the worst case."""
+    import torch
+
+    worst_db = math.inf
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        out = tr._run(inp)
+        torch.cuda.synchronize()
+        ref = tr._golden(inp)
+        got = out.double().flatten()
+        gold = ref.flatten()
+        noise = (got - gold).norm().item()
+        signal = gold.norm().item()
+        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        worst_db = min(worst_db, db)
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+    print(f"SNR: {worst_db:.2f} dB")
+    return 0
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    """Graph-timed bench: one HIP-graph mean per case (reuses task_runner)."""
+    import torch
+
+    results = []
+    for case in tr.CASES:
+        inp = tr._prepare(case)
+        tr._run(inp)                   # settle the Triton JIT before capture
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda i=inp: tr._run(i),
+            warmup=max(1, warmup),
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        if not math.isfinite(ms) or ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {ms!r}", file=sys.stderr)
+            return 1
+        results.append((case["id"], ms, meta))
+        del inp
+        torch.cuda.empty_cache()
+    if len(results) != len(tr.CASES) or not results:
+        print("error: benchmark did not produce every task case", file=sys.stderr)
+        return 1
+    for case_id, ms, meta in results:
+        print(f"case_ms: {case_id} {ms:.6f}")
+        print(f"# bench {case_id}: {ms:.6f} ms method={meta.get('benchmark_method')}"
+              f" {meta.get('benchmark_fallback_reason', '')}".rstrip())
+    means = [ms for _, ms, _ in results]
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr) -> int:
+    """Kernel-only profiling for one case: warm, a few launches, sync, exit 0."""
+    import torch
+
+    case = max(tr.CASES, key=_case_cost)
+    inp = tr._prepare(case)
+    for _ in range(3):                 # settle Triton JIT / autotune selection
+        tr._run(inp)
+    torch.cuda.synchronize()
+    for _ in range(3):                 # profiled launches
+        tr._run(inp)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kimi-K3 MLA grouped-decode forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    tr = _import_task_runner()
+    tr._configure()   # gfx950 env + workspace-seeded sglang first on sys.path
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/forge_driver.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/forge_driver.py
@@ -72,11 +72,19 @@ def _case_cost(case: dict) -> int:
     return int(p["batch_size"]) * int(p["seq_len"]) * int(p["qk_head_dim"])
 
 
+def _snr_db(signal: float, noise: float, *, finite: bool) -> float:
+    """Return a finite failing sentinel when an output cannot be scored safely."""
+    if not finite or not math.isfinite(signal) or not math.isfinite(noise):
+        return -1.0e9
+    return 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+
+
 def _run_correctness(tr) -> int:
     """Per-case SNR against the float64 golden; report the worst case."""
     import torch
 
     worst_db = math.inf
+    all_finite = True
     for case in tr.CASES:
         inp = tr._prepare(case)
         out = tr._run(inp)
@@ -86,13 +94,15 @@ def _run_correctness(tr) -> int:
         gold = ref.flatten()
         noise = (got - gold).norm().item()
         signal = gold.norm().item()
-        db = 200.0 if noise <= 0 else 20.0 * math.log10(signal / noise)
+        finite = bool(torch.isfinite(out).all())
+        all_finite = all_finite and finite
+        db = _snr_db(signal, noise, finite=finite)
         worst_db = min(worst_db, db)
-        print(f"# case {case['id']}: SNR={db:.2f} dB finite={bool(torch.isfinite(out).all())}")
+        print(f"# case {case['id']}: SNR={db:.2f} dB finite={finite}")
         del inp, out, ref, got, gold
         torch.cuda.empty_cache()
     print(f"SNR: {worst_db:.2f} dB")
-    return 0
+    return 0 if all_finite else 1
 
 
 def _run_bench(tr, warmup: int, iters: int) -> int:

--- a/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/task_runner.py
+++ b/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/task_runner.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for Kimi-K3 MLA grouped decode attention (flash-decoding).
+
+Kernels covered (Hyperloom session 20260814T191522Z, rank0 of TP=8):
+  * ``_fwd_grouped_kernel_stage1`` -- 3.96% E2E, 24 launches/decode step,
+    ``sglang/kernels/ops/attention/decode_attention.py:384``
+  * ``_fwd_kernel_stage2``         -- 0.69% E2E, 24 launches/decode step,
+    ``sglang/kernels/ops/attention/decode_attention.py:732``
+
+4.65% of end-to-end GPU time. 24 launches/step is exactly K3's 24 MLA
+full-attention layers (the other 69 layers are KDA linear attention). The session
+launched sglang with ``--attention-backend triton``, so this is the path that ran.
+
+Decode-only by construction
+---------------------------
+K3's MLA prefill goes through a structurally different kernel (``_fwd_kernel`` in
+``extend_attention.py``); ``decode_attention_fwd_grouped`` has zero launches in
+prefill and ``_fwd_kernel`` has zero in decode. Every case here is therefore a
+decode shape -- that is a property of the operator, not a gap in coverage.
+
+Layout
+------
+Absorbed MLA decode, per-rank TP=8::
+
+    q            [bs, 12, 576]                 bf16   576 = kv_lora 512 + rope 64
+    k_buffer     [num_kv_tokens, 1, 576]       bf16   one compressed entry per token
+    v_buffer     [num_kv_tokens, 1, 512]       bf16   NON-CONTIGUOUS view k_buffer[..., :512]
+    o            [bs, 12, 512]                 bf16
+    attn_logits  [bs, 12, 256, 512]            f32    max_kv_splits = 256
+    attn_lse     [bs, 12, 256]                 f32
+
+``kv_head_num = 1`` so ``kv_group_num = 12`` -- that is what routes
+``decode_attention_fwd`` to the *grouped* kernel. ``max_kv_splits = 256`` is exact
+for this run: the server default is 8, then ``_mla_decode_kv_splits_cap(8,
+sm_count=256, max_context_len=13312)`` = ``max(8, min(next_pow2(256),
+next_pow2(ceil(13312/32))))`` = 256.
+
+``num_kv_splits`` is filled by the *same* scheduler the backend uses
+(``get_num_kv_splits_triton``, ``kernels/ops/attention/metadata.py``), which is
+outside the edit surface, so the split schedule the agent is timed against is the
+session's own.
+
+Golden
+------
+A vectorized float64 reference attention over the gathered KV, chunked over the
+batch axis so peak memory stays bounded. No per-token or per-head Python loop. The
+reference is split-agnostic: flash-decoding's split-KV reduction must reproduce
+plain softmax attention exactly, so the number of splits affects speed only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MODEL_CONFIG = SPEC["model_config"]
+
+# Sequences per golden chunk. 8 x 9216 x 576 x 8 B = 340 MB per fp64 temporary.
+_GOLDEN_BATCH_CHUNK = 8
+# MI355X compute-unit count; feeds the same split scheduler the backend uses.
+_DEVICE_CORE_COUNT = 256
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    seeded = WORKSPACE / "sglang"
+    if (seeded / "__init__.py").is_file():
+        sys.path.insert(0, str(WORKSPACE))
+    else:
+        sys.path.insert(0, os.environ.get("SGLANG_PYTHON", "/sgl-workspace/sglang/python"))
+    os.environ.setdefault("TRITON_CACHE_DIR", str(WORKSPACE / "build" / "triton_cache"))
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _decode_op():
+    from sglang.kernels.ops.attention.decode_attention import decode_attention_fwd_grouped
+
+    return decode_attention_fwd_grouped
+
+
+def _fill_num_kv_splits(num_kv_splits, seq_lens, num_head, num_kv_head, max_kv_splits):
+    """Reproduce the backend's split schedule (triton_backend.py:328).
+
+    get_num_kv_splits_triton lives in kernels/ops/attention/metadata.py, outside the
+    edit surface, so the agent is timed against the session's own schedule. If the
+    helper is unavailable the harness falls back to the backend's static branch
+    (num_kv_splits.fill_(max_kv_splits), triton_backend.py:309).
+    """
+    try:
+        import triton
+        from sglang.kernels.ops.attention.metadata import get_num_kv_splits_triton
+    except Exception:
+        num_kv_splits.fill_(max_kv_splits)
+        return "static"
+    num_seq = seq_lens.shape[0]
+    schedule_seq = 256 if num_seq < 256 else triton.next_power_of_2(num_seq)
+    get_num_kv_splits_triton[(1,)](
+        num_kv_splits, seq_lens, num_seq, 1, num_head, num_kv_head,
+        max_kv_splits, _DEVICE_CORE_COUNT, MAX_NUM_SEQ=schedule_seq,
+    )
+    return "scheduler"
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    """Build one case at its scored shape (same shape for correctness and perf)."""
+    torch = _torch()
+    p = case["params"]
+    B = int(p["batch_size"])
+    H = int(p["num_heads"])
+    KVH = int(p["kv_head_num"])
+    Dqk = int(p["qk_head_dim"])
+    Dv = int(p["v_head_dim"])
+    S = int(p["seq_len"])
+    splits = int(p["max_kv_splits"])
+    dtype = getattr(torch, p.get("dtype", "bfloat16"))
+
+    gen = torch.Generator(device="cuda").manual_seed(int(case.get("seed", 7141)))
+
+    def rnd(*shape, dt=dtype, scale=1.0):
+        return (torch.randn(*shape, device="cuda", dtype=torch.float32, generator=gen)
+                * scale).to(dt)
+
+    q = rnd(B, H, Dqk, scale=0.5).contiguous()
+
+    # One compressed latent+rope entry per KV token. v_buffer is the leading
+    # kv_lora_rank columns of the SAME tensor -- a non-contiguous view, exactly as
+    # MLATokenToKVPool.get_value_buffer() returns it.
+    kv_pool = rnd(B * S, KVH, Dqk, scale=0.5).contiguous()
+    k_buffer = kv_pool
+    v_buffer = kv_pool[..., :Dv]
+
+    # Contiguous per-request page ranges, page_size = 1.
+    kv_indptr = torch.arange(0, (B + 1) * S, S, device="cuda", dtype=torch.int32)
+    kv_indices = torch.arange(0, B * S, device="cuda", dtype=torch.int32)
+    seq_lens = torch.full((B,), S, device="cuda", dtype=torch.int32)
+
+    o = torch.empty(B, H, Dv, device="cuda", dtype=dtype)
+    attn_logits = torch.empty(B, H, splits, Dv, device="cuda", dtype=torch.float32)
+    attn_lse = torch.empty(B, H, splits, device="cuda", dtype=torch.float32)
+    num_kv_splits = torch.empty(B, device="cuda", dtype=torch.int32)
+    split_mode = _fill_num_kv_splits(num_kv_splits, seq_lens, H, KVH, splits)
+
+    return {
+        "cfg": case, "B": B, "H": H, "KVH": KVH, "Dqk": Dqk, "Dv": Dv, "S": S,
+        "dtype": dtype, "max_kv_splits": splits, "split_mode": split_mode,
+        "q": q, "kv_pool": kv_pool, "k_buffer": k_buffer, "v_buffer": v_buffer,
+        "kv_indptr": kv_indptr, "kv_indices": kv_indices, "seq_lens": seq_lens,
+        "o": o, "attn_logits": attn_logits, "attn_lse": attn_lse,
+        "num_kv_splits": num_kv_splits,
+        "sm_scale": float(p["sm_scale"]), "logit_cap": float(p.get("logit_cap", 0.0)),
+        "page_size": int(p.get("page_size", 1)),
+        # The backend passes k_descale/v_descale = 1.0 whenever the KV cache is not
+        # fp8 (triton_backend.py:1352-1353), and this session's MLA cache is bf16.
+        # It must NOT be None: _fwd_kernel_stage2 multiplies the accumulator by
+        # v_scale (decode_attention.py:803), so a None makes Triton fail at compile
+        # time with "'NoneType' object has no attribute 'type'".
+        "v_scale": float(p.get("v_scale", 1.0)),
+    }
+
+
+def _run(inp: dict):
+    decode_attention_fwd_grouped = _decode_op()
+    # attn_lse must start at -inf for the split reduction, exactly as the backend
+    # does before every call (triton_backend.py:1795).
+    inp["attn_lse"].fill_(float("-inf"))
+    decode_attention_fwd_grouped(
+        inp["q"], inp["k_buffer"], inp["v_buffer"], inp["o"],
+        inp["kv_indptr"], inp["kv_indices"],
+        inp["attn_logits"], inp["attn_lse"],
+        inp["num_kv_splits"], inp["max_kv_splits"],
+        inp["sm_scale"], inp["v_scale"],
+        logit_cap=inp["logit_cap"],
+        has_mla=True,
+        page_size=inp["page_size"],
+    )
+    return inp["o"]
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+# --------------------------------------------------------------------------- #
+def _golden(inp: dict):
+    """Vectorized float64 attention over the gathered KV, chunked over the batch.
+
+        scores = (q . kv) * sm_scale        [b, H, S]
+        p      = softmax(scores, -1)
+        o      = p @ kv[..., :Dv]           [b, H, Dv]
+
+    Split-agnostic on purpose: flash-decoding's split-KV reduction must reproduce
+    plain softmax attention, so num_kv_splits affects speed only, never the result.
+    Every step is a whole-tensor op -- no per-token or per-head loop.
+    """
+    torch = _torch()
+    B, H, S, Dv = inp["B"], inp["H"], inp["S"], inp["Dv"]
+    scale = inp["sm_scale"]
+    kv = inp["kv_pool"].view(B, S, -1)      # [B, S, Dqk], KVH == 1
+    out = torch.empty(B, H, Dv, device="cuda", dtype=torch.float64)
+
+    for s in range(0, B, _GOLDEN_BATCH_CHUNK):
+        e = min(s + _GOLDEN_BATCH_CHUNK, B)
+        kvc = kv[s:e].double()                              # [c, S, Dqk]
+        qc = inp["q"][s:e].double()                         # [c, H, Dqk]
+        scores = torch.bmm(qc, kvc.transpose(1, 2)) * scale  # [c, H, S]
+        if inp["logit_cap"] > 0:
+            scores = inp["logit_cap"] * torch.tanh(scores / inp["logit_cap"])
+        probs = torch.softmax(scores, dim=-1)
+        out[s:e] = torch.bmm(probs, kvc[..., :Dv])          # [c, H, Dv]
+        del kvc, qc, scores, probs
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inp = _prepare(CASES[0])
+    out = _run(inp)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} "
+          f"splits={inp['split_mode']}/{int(inp['num_kv_splits'][0].item())}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inp = _prepare(case)
+        out = _run(inp)
+        torch.cuda.synchronize()
+        ref = _golden(inp)
+
+        assert torch.isfinite(out).all(), (case["id"], "non-finite output")
+        assert tuple(out.shape) == (inp["B"], inp["H"], inp["Dv"]), (
+            case["id"], tuple(out.shape)
+        )
+        got = out.double().flatten()
+        gold = ref.flatten()
+        cos = torch.nn.functional.cosine_similarity(got, gold, dim=0).item()
+        denom = gold.abs().max().clamp_min(1e-8)
+        rel_max = ((got - gold).abs().max() / denom).item()
+        p = case["params"]
+        assert cos > p.get("min_cosine", 0.9995), (
+            case["id"], f"cosine {cos:.7f} vs float64 golden too low"
+        )
+        assert rel_max < p.get("max_rel_err", 0.02), (
+            case["id"], f"normalized max err {rel_max:.5f} too high"
+        )
+        print("correctness PASS", case["id"],
+              f"[{case['phase']}] cos={cos:.7f} rel_max_err={rel_max:.5f} "
+              f"splits={int(inp['num_kv_splits'][0].item())}")
+        del inp, out, ref, got, gold
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inp = _prepare(case)
+        _run(inp)                       # settle the Triton JIT
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda i=inp: _run(i),
+            warmup=bench.get("warmup", 3),
+            repetition=bench.get("repetition", 20),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        metadata = {
+            **case["params"],
+            "phase": case.get("phase"),
+            "model": case.get("model"),
+            "kernel_ids": case.get("kernel_ids"),
+            "exact_shape_source": case.get("exact_shape_source"),
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms", meta.get("benchmark_method"),
+              meta.get("benchmark_fallback_reason", ""))
+        del inp
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    {"compile": run_compile, "correctness": run_correctness,
+     "performance": run_performance}[mode]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/session_cases.json
+++ b/tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/session_cases.json
@@ -1,0 +1,137 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "sglang 0.5.15.post1.dev20260723+g6c9fd0adc5 (ROCm 7.2.0, triton 3.6.0+git42270451)",
+  "model": "Kimi-K3",
+  "session_id": "20260814T191522Z",
+  "operator": "mla_decode_grouped",
+  "task_name": "mi355x-kimi-k3-mla-decode-grouped-20260814",
+  "language": "triton (@triton.jit, runtime-compiled; sglang/kernels/ops/attention/decode_attention.py)",
+  "selection": "_fwd_grouped_kernel_stage1 (3.96% E2E) + _fwd_kernel_stage2 (0.69% E2E) = 4.65%, the flash-decoding split-KV pair behind decode_attention_fwd_grouped. K3 runs 24 MLA full-attention layers (the other 69 are KDA linear attention), and the trace shows exactly 24 stage1 + 24 stage2 launches per decode step. The session launched sglang with --attention-backend triton, so this is the path that actually ran.",
+  "phase_scope": "DECODE ONLY -- and that is a property of the operator, not a gap in the case set. K3's MLA prefill goes through a structurally different kernel (_fwd_kernel in kernels/ops/attention/extend_attention.py, 1.50% E2E, 0 launches in decode); decode_attention_fwd_grouped has 0 launches in prefill. Every shape below is therefore a decode shape. The correctness set and the performance set are the same CASES list.",
+  "provenance": {
+    "session_root": "/shared_nfs/hyperloom-claw/Kimi-K3/20260814T191522Z",
+    "trace": "geak/e2e_cycle0/profile/round_0/profile/1786763352.027878-TP-{0..7}.trace.json.gz",
+    "analysis": "/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/kimi-k3-hot-kernels.md",
+    "e2e_weights": {"prefill": 0.416, "decode": 0.584},
+    "measured_decode_tp0": {
+      "step_total_ms": 25.557,
+      "_fwd_grouped_kernel_stage1": {"calls_per_step": 24, "total_ms": 1.72, "avg_us": 71.7, "pct_of_step": 6.79, "e2e_pct": 3.96},
+      "_fwd_kernel_stage2": {"calls_per_step": 24, "total_ms": 0.30, "avg_us": 12.5, "pct_of_step": 1.18, "e2e_pct": 0.69},
+      "note": "Both run inside the CUDA graph, so the trace carries no grid/block and no CPU-side Input Dims for them. The tensor layout below is therefore reconstructed from the call site (srt/layers/attention/triton_backend.py:1823) plus the model config -- every number is pinned by code, not guessed; see layout_derivation."
+    },
+    "call_stack": [
+      "sglang/srt/layers/attention/triton_backend.py(1823): TritonAttnBackend.forward_decode -> self.decode_attention_fwd(...)",
+      "sglang/kernels/ops/attention/decode_attention.py(967): decode_attention_fwd  -- kv_group_num = 12/1 = 12 != 1 -> grouped path",
+      "sglang/kernels/ops/attention/decode_attention.py(912): decode_attention_fwd_grouped",
+      "sglang/kernels/ops/attention/decode_attention.py(384): _fwd_grouped_kernel_stage1  (via _decode_grouped_att_m_fwd)",
+      "sglang/kernels/ops/attention/decode_attention.py(732): _fwd_kernel_stage2          (via _decode_softmax_reducev_fwd)"
+    ],
+    "layout_derivation": {
+      "q": "[bs, tp_q_head_num, qk_head_dim] = [bs, 12, 576].  tp_q_head_num = num_attention_heads 96 / TP 8 = 12.  qk_head_dim for the absorbed MLA decode = kv_lora_rank 512 + qk_rope_head_dim 64 = 576.  Call site: triton_backend.py:1824 q.view(-1, layer.tp_q_head_num, layer.qk_head_dim).",
+      "k_buffer": "[num_kv_tokens, 1, 576] bf16 -- the MLA pool stores one compressed latent+rope entry per token, so kv_head_num = 1 and kv_group_num = 12/1 = 12 (this is what routes the call to the *grouped* kernel).",
+      "v_buffer": "[num_kv_tokens, 1, 512] bf16 -- get_value_buffer() returns a NON-CONTIGUOUS view of the first kv_lora_rank=512 columns of the same 576-wide buffer. The harness reproduces the view rather than allocating a separate tensor, because the stride pattern is part of what the kernel sees.",
+      "o": "[bs, 12, 512] -- triton_backend.py:1827 o.view(-1, layer.tp_q_head_num, layer.v_head_dim); v_head_dim is kv_lora_rank in the absorbed decode.",
+      "attn_logits": "[bs, 12, max_kv_splits, 512] f32 -- triton_backend.py:761. decode_attention_fwd asserts max_kv_splits == attn_logits.shape[2] and the kernel's '// Lv' stride trick requires shape[-1] == v_head_dim.",
+      "attn_lse": "[bs, 12, max_kv_splits] f32 -- triton_backend.py:774.",
+      "max_kv_splits": "256. server default triton_attention_num_kv_splits = 8, then _mla_decode_kv_splits_cap(8, sm_count=256, max_context_len=13312) = max(8, min(next_pow2(256)=256, next_pow2(ceil(13312/32))=512)) = 256. _MLA_DECODE_MIN_BLOCK_KV = 32 (triton_backend.py:64,67-74). MI355X has 256 CUs and the session's max_model_len is 13312, so 256 is exact for this run.",
+      "num_kv_splits": "[bs] i32, filled by the same get_num_kv_splits_triton scheduler the backend uses (kernels/ops/attention/metadata.py, called from triton_backend.py:328 with num_head=12, num_kv_head=1, max_kv_splits=256, device_core_count=256). The harness calls it directly; it is outside the edit surface.",
+      "sm_scale": "(qk_nope_head_dim 128 + qk_rope_head_dim 64) ** -0.5 = 192 ** -0.5 = 0.0721687836. This is layer.scaling for a DeepSeek-style MLA layer.",
+      "k_descale/v_descale": "None -- the KV cache is bf16 in this session (the reference launch recipe's kv-cache-dtype fp8_e4m3 applies to the non-MLA path; the trace's MLA decode kernels are the bf16 template)."
+    },
+    "seq_len_derivation": "Workload is ISL 8192 / OSL 1024 / max_model_len 13312. A request enters decode with 8192 KV tokens and leaves with 8192+1024 = 9216, so the decode KV length sweeps [8192, 9216] across the run. Both endpoints are scored. During the profiled window the requests had just finished prefill, i.e. the 8192 end.",
+    "batch_derivation": "The trace's decode annotation is step[DECODE bs=8] -- profiling started at warmup 0s so it captured the ramp. The run's steady-state decode batch is bs=64 (conc=64, max_running_requests=64; median_itl_ms 46.73 vs 25.56 ms at bs=8, and 196608 output tokens / 1024 OSL = 192 requests = 3 waves of 64). Both are scored."
+  },
+  "model_config": {
+    "source": "/shared_nfs/hyperloom/models/Kimi-K3/config.json (text_config)",
+    "num_attention_heads": 96,
+    "tensor_parallel_size": 8,
+    "tp_q_head_num": 12,
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "v_head_dim": 128,
+    "qk_head_dim_decode": 576,
+    "v_head_dim_decode": 512,
+    "mla_layers": 24,
+    "kda_layers": 69,
+    "max_model_len": 13312,
+    "notes": "K3 is a hybrid: linear_attn_config.full_attn_layers lists 24 MLA layers, the remaining 69 are KDA linear attention. Only the 24 MLA layers reach this kernel, which is exactly the 24 launches/step the trace shows."
+  },
+  "cases": [
+    {
+      "id": "mla-decode-bs8-kv8192",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_fwd_grouped_kernel_stage1", "_fwd_kernel_stage2"],
+      "gpu_pct_e2e": 4.65,
+      "exact_shape_source": "TRACE-MEASURED batch (step[DECODE bs=8]) x session ISL (8192 KV tokens at the start of generation)",
+      "trace_input_shapes": [
+        "q (8, 12, 576) bf16",
+        "k_buffer (65536, 1, 576) bf16",
+        "v_buffer (65536, 1, 512) bf16 [view of k_buffer[..., :512]]",
+        "o (8, 12, 512) bf16",
+        "attn_logits (8, 12, 256, 512) f32",
+        "attn_lse (8, 12, 256) f32"
+      ],
+      "params": {
+        "batch_size": 8, "num_heads": 12, "kv_head_num": 1,
+        "qk_head_dim": 576, "v_head_dim": 512,
+        "seq_len": 8192, "max_kv_splits": 256, "page_size": 1,
+        "sm_scale": 0.0721687836, "logit_cap": 0.0,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 5, "repetition": 30, "target_ms": 1.0, "max_graph_repeats": 200},
+      "seed": 7141
+    },
+    {
+      "id": "mla-decode-bs64-kv8192",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_fwd_grouped_kernel_stage1", "_fwd_kernel_stage2"],
+      "exact_shape_source": "SESSION STEADY STATE -- bs=64 (conc=64, max_running_requests=64, 3072 of the run's decode steps) x 8192 KV tokens at the start of generation",
+      "params": {
+        "batch_size": 64, "num_heads": 12, "kv_head_num": 1,
+        "qk_head_dim": 576, "v_head_dim": 512,
+        "seq_len": 8192, "max_kv_splits": 256, "page_size": 1,
+        "sm_scale": 0.0721687836, "logit_cap": 0.0,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 2.0, "max_graph_repeats": 50},
+      "seed": 7142
+    },
+    {
+      "id": "mla-decode-bs64-kv9216",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_fwd_grouped_kernel_stage1", "_fwd_kernel_stage2"],
+      "exact_shape_source": "SESSION STEADY STATE -- bs=64 x 9216 KV tokens (ISL 8192 + OSL 1024), the end of generation and the longest KV this workload reaches",
+      "params": {
+        "batch_size": 64, "num_heads": 12, "kv_head_num": 1,
+        "qk_head_dim": 576, "v_head_dim": 512,
+        "seq_len": 9216, "max_kv_splits": 256, "page_size": 1,
+        "sm_scale": 0.0721687836, "logit_cap": 0.0,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 3, "repetition": 20, "target_ms": 2.0, "max_graph_repeats": 50},
+      "seed": 7143
+    },
+    {
+      "id": "mla-decode-bs8-kv9216",
+      "phase": "decode",
+      "model": "Kimi-K3",
+      "kernel_ids": ["_fwd_grouped_kernel_stage1", "_fwd_kernel_stage2"],
+      "exact_shape_source": "TRACE-MEASURED batch (bs=8) x 9216 KV tokens (ISL + OSL), the tail of the ramp-phase requests",
+      "params": {
+        "batch_size": 8, "num_heads": 12, "kv_head_num": 1,
+        "qk_head_dim": 576, "v_head_dim": 512,
+        "seq_len": 9216, "max_kv_splits": 256, "page_size": 1,
+        "sm_scale": 0.0721687836, "logit_cap": 0.0,
+        "dtype": "bfloat16", "min_cosine": 0.9995, "max_rel_err": 0.02
+      },
+      "benchmark": {"warmup": 5, "repetition": 30, "target_ms": 1.0, "max_graph_repeats": 200},
+      "seed": 7144
+    }
+  ]
+}

--- a/tasks/kimi-k3/task-overview.md
+++ b/tasks/kimi-k3/task-overview.md
@@ -1,0 +1,514 @@
+# Kimi-K3 kernel task 总览 —— session `20260814T191522Z`
+
+从 Hyperloom session **`100132` Kimi-K3**（`/shared_nfs/hyperloom-claw/Kimi-K3/20260814T191522Z/`）
+中抽取的 4 个 `image_kernel` task。
+
+- **软件栈**：sglang `0.5.15.post1.dev20260723+g6c9fd0adc5`、aiter `dcd204ea`、
+  ROCm 7.2.0、triton `3.6.0+git42270451`，8×MI355X（gfx950），TP=8
+- **压测配置**：ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312，mxfp4，192 条请求
+- **数据来源**：8 个 rank 的原始 torch trace，全部重新解析
+  （`geak/e2e_cycle0/profile/round_0/profile/1786763352.027878-TP-{0..7}.trace.json.gz`）。
+  **不采用 session 自带 report 的任何现成结论。**
+- **完整分析**：`/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/kimi-k3-hot-kernels.md`
+
+| task | 算子 | **任务形态** | 后端 | **E2E 占比** | 覆盖阶段 |
+|---|---|---|---|---|---|
+| [`mi355x_sglang_triton_attn_residual_kimi_k3`](#一attention-residual注意力残差聚合) | K3 注意力残差聚合 | **单入口 · 2 kernel 流水** | triton (sglang) | **12.24%** | prefill + decode |
+| [`mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3`](#二moe-路由--排序--mx-量化) | MoE 路由/排序/MX 量化 | **多算子连续调用（3 入口 / 6 kernel）** | hip (aiter) | **6.35%** | prefill + decode |
+| [`mi355x_sglang_triton_mla_decode_grouped_kimi_k3`](#三mla-grouped-decode-注意力) | MLA grouped decode 注意力 | **单入口 · 2 kernel 流水** | triton (sglang) | **4.65%** | decode |
+| [`mi355x_sglang_flydsl_hgemm_small_m_kimi_k3`](#四flydsl-小-m-split-k-hgemm) | 小 M split-K bf16 GEMM | **单算子 · 单 kernel** | flydsl (aiter) | **4.55%** | decode |
+| | | | | **合计 27.79%** | |
+
+## 任务形态：单算子 vs. 多算子连续调用
+
+这一列决定了 agent **能改到哪一层**，以及计时到底盖住了什么，值得先看清楚。
+
+| 形态 | 含义 | 本目录里的 task |
+|---|---|---|
+| **单算子 · 单 kernel** | 一个 Python 入口 → 一次 kernel 启动。计时 = 该 kernel。 | 四 |
+| **单入口 · N kernel 流水** | 一个 Python 入口，内部固定启动 N 个 kernel。中间结果是**私有**的，不对外暴露。计时 = 整个入口。 | 一、三 |
+| **多算子连续调用** | N 个各自独立的公开 Python 入口，被模型按固定顺序串起来调用，前一个的输出张量是后一个的输入。计时 = 整条链。 | 二 |
+
+**为什么这个区分重要：**
+
+- **单入口多 kernel（task 一、三）—— kernel 边界是可以动的。** 中间张量
+  （task 一的 `scores[T,16]` fp32、task 三的 `attn_logits`/`attn_lse`）只在入口内部存在，
+  外界看不到，所以 agent 可以合并 kernel、改中间布局、甚至把两段完全融成一个 kernel。
+  对 task 一来说**这恰恰就是主要优化方向**（NVIDIA SM100+ 上官方实现就是融合的，
+  gfx950 缺这条路径）。约束只有一条：入口函数的公开签名不变。
+- **多算子连续调用（task 二）—— kernel 边界不能动。** `biased_grouped_topk_hip` /
+  `moe_sorting_opus_fwd` / `fused_dynamic_mx_quant_moe_sort_hip` 是三个独立的公开 API，
+  模型别处也会调用它们，中间张量（`topk_ids`、`sorted_ids`、`num_valid_ids` 等）是
+  **契约的一部分**。agent 只能优化各个 kernel 的内部，不能把三者融成一个。
+  harness 因此逐段做正确性校验，而不是只看链尾输出。
+  （链内的排序本身是多 phase 的：trace 里 `P0_v2` 和 `P23` 是两个独立 kernel，
+  另有两个 phase，所以 3 个入口一共对应 6 个 kernel。）
+- **单算子（task 四）** 没有这些问题，但要注意它的 4 个 case 是**互相独立的 shape**
+  （M ∈ {8,64} × 两个投影族），不构成链；它们之所以在同一个 task 里，
+  是因为 session 里这四种 shape 都由同一个 FlyDSL 派发路径服务。
+
+## E2E 占比的口径
+
+`E2E% = prefill 内占比 × 0.416 + decode 内占比 × 0.584`
+
+权重由两条互相独立的路径推出后取中值：
+
+- **A：trace 实测 prefill 速率外推** —— 16384 tok / 1060.9 ms → 15443 tok/s；
+  1,572,864 个输入 token 需要 101.85 s，占总时长 249.116 s 的 **40.9%**。
+- **B：实测稳态 ITL 反推** —— bench 原始结果 `median_itl_ms = 46.73` × 3072 个 decode 步
+  = 143.56 s，反推 prefill **42.4%**。
+
+两者相差 1.5 个百分点；用任一端点重算，下文所有数字变动 < 0.25 pt。
+
+prefill 占比在 5 个 EXTEND 步上实测（24133 个 kernel，TP0 共 3974.64 ms）；
+decode 占比在唯一一次被完整记录的 CUDA graph replay 上实测，
+再加上图外 kernel 按 59 步均摊（单步基准 25.557 ms）。
+
+## 先了解模型结构
+
+Kimi-K3：93 层，hidden 7168。有三处不常规，下面每个 task 的定位都依赖它们。
+
+- **混合注意力** —— 24 层 MLA 全注意力（q_lora 1536、kv_lora 512、qk_nope 128、
+  qk_rope 64，96 头 → TP8 后每卡 12 头）+ **69 层 KDA 线性注意力**。
+- **Latent MoE** —— 专家不在 hidden 7168 上算，而是在
+  `routed_expert_hidden_size = 3584` 上算；896 个专家、top-16、2 个 shared expert、
+  `moe_intermediate_size` 3072 → 每卡 384。93 层里有 92 层是 MoE
+  （`first_k_dense_replace = 1`）。
+- **Attention residual** —— `attn_res_block_size = 12`：模型不维护单一残差流，
+  而是每 12 层把当时的 prefix 快照进一个 bank，每个聚合点对所有历史快照学一个
+  softmax 混合权重。一次前向有 186 个聚合点。
+
+## 哪些被刻意排除了
+
+约 27% 的端到端 GPU 时间在 kernel 源码层面**不可攻击**。在提更多 task 之前值得知道原因：
+
+- **hipBLASLt Tensile GEMM 全家**（`Cijk_…MT256x256x64` 7.98% + `MT256x16x64` 3.66%
+  + `MT32x16x256` 1.44% + `PostGSU16` 1.37% + 其他 ≈ **15.4%**）——
+  以预编译 code object 形式放在 `/opt/rocm/lib/hipblaslt/library/`，**镜像内没有源码**。
+  而且它们已经跑到 **bf16 峰值的 62.5%**（大 shape 64–66%）；本 session 的 KERNEL 阶段
+  为 `MT256x256x64` 重写了两轮，实测 0.33× / 0.57×，全部更慢。
+- **两个 allreduce**（quickreduce 7.96% + aiter `cross_device_reduce_2stage` 5.57%）——
+  按要求排除。顺带一提：aiter 那个在 prefill 里约 **98% 是自旋等 rank 3**，不是真通信。
+- **ATen elementwise / memcpy / 采样**（≈12%）—— PyTorch 运行时算子，
+  真正的收益在模型层融合，不属于 kernel task。
+
+---
+
+## 一、Attention residual（注意力残差聚合）
+
+`mi355x_sglang_triton_attn_residual_kimi_k3` —— **E2E 12.24%**
+（`_score_kernel` 8.20% + `_combine_kernel` 4.04%），triton，
+`sglang/srt/layers/attn_residual.py`。
+
+> **任务形态：单入口 · 2 kernel 流水。** 一个公开入口
+> `aggregate_stream(prefix_sum, bank, nvb, score_proj, score_norm)`，
+> 内部固定启动 `_score_kernel` → `_combine_kernel`。中间张量 `scores[T,16]` fp32
+> 是**私有的**，不属于对外契约 —— **kernel 边界可以随便动，融成一个核正是本 task 的
+> 主要优化方向。** 计时覆盖整个入口。
+
+### 这是什么算子
+
+**全 session 最大的可攻击 kernel，且是 K3 独有结构。** K3 不维护单一残差流：
+每 `attn_res_block_size`（=12）层把当时的 pre-attention prefix 快照进一个 bank
+`[T, NB, H]`；每个聚合点对 bank 里所有历史快照 + 当前 prefix 逐行打分、softmax、
+加权求和 —— 于是每一层可以自己决定读哪个历史时刻的残差状态。
+
+```
+_score_kernel    grid (T, nvb+1)  block (512,1,1)   score = (v·cw) · rsqrt(mean(v²)+eps)
+_combine_kernel  grid (T, H/1024) block (256,1,1)   softmax → 加权求和
+```
+
+`cw = score_norm.weight ⊙ score_proj.weight` 由 `get_cw()` 预乘缓存，
+把"逐行 RMSNorm 再投影成标量"压成一次点积。
+
+### 对应模型结构的哪个部分
+
+**既不在 attention 里，也不在 MoE 里** —— 它是**层间的残差路由**，
+取代了普通 Transformer 的 `x = x + f(x)` 跳连。一次前向触发 **186 次**，
+prefill 和 decode 都跑，横跨全部 93 层。`nvb`（bank 深度）在一次前向内从 1 涨到 8，
+所以最后几个聚合点的开销是第一个的 8 倍。
+
+### 为什么值得让 agent 长跑
+
+- 实测 **1.74–1.82 TB/s ≈ HBM3E 峰值（8 TB/s）的 22–23%**，各档 grid 一致，
+  且严格线性于 `nvb`。
+- `_use_fast()`（`attn_residual.py:32`）把一个 warp-specialized 融合 TMA kernel
+  锁在 `torch.cuda.get_device_capability().major >= 10` 之后 —— 即**只给 NVIDIA SM100+**。
+  gfx950 根本没有融合路径，永久走这条两段式 Triton fallback：每个聚合点把 bank 读两遍，
+  中间还要把 `scores[T,16]` fp32 往显存里过一趟。
+- 优化目标很明确：给 gfx950 写等价融合核（score → online softmax → combine，
+  最好把 output RMSNorm 也融进去）。
+
+**7 个 case**：prefill T=16384 的 nvb 1/4/8、T=8192、T=64；decode T=8 和 64。
+
+---
+
+## 二、MoE 路由 / 排序 / MX 量化
+
+`mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3` —— **E2E 6.35%**，HIP C++，aiter csrc。
+
+> **任务形态：多算子连续调用（3 个入口 / 6 个 kernel）。** 本目录里唯一的一个。
+> `biased_grouped_topk_hip` → `moe_sorting_opus_fwd` → `fused_dynamic_mx_quant_moe_sort_hip`
+> 是三个**各自独立的公开 API**，模型别处也会调用；中间张量
+> （`topk_ids`、`topk_weights`、`sorted_ids`、`sorted_weights`、`num_valid_ids`）
+> 属于对外契约。**agent 只能优化每个 kernel 的内部，不能把三者融成一个。**
+> 排序本身还是多 phase 的（trace 里 `P0_v2` 和 `P23` 是两个独立 kernel，另有两个 phase），
+> 所以 3 个入口对应 6 个 kernel。计时覆盖整条链，但正确性是**逐段校验**的。
+
+### 这是什么算子
+
+MoE 流水线里**除 2-stage 专家 GEMM 之外**的全部环节。GEMM 部分已由
+`tasks/image_kernel/mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3` 覆盖（其 dims 与本
+session 完全一致），周边这一段从来没被覆盖过。四个 kernel 按模型的真实顺序串成一条链计时：
+
+| kernel | E2E% | 源码 |
+|---|---|---|
+| `aiter::grouped_topk_kernel` | 2.75 | `csrc/kernels/topk_softmax_kernels_group.cu:320` |
+| `aiter::opus_moe_sorting_entry<…P23…>` | 1.20 | `csrc/include/moe_sorting_opus.h:109` |
+| `aiter::opus_moe_sorting_entry<…P0_v2…>` | 0.90 | 同上 |
+| `aiter::fused_mx_quant_moe_sort_kernel<bf16,fp8,256,16>` | 1.50 | `csrc/kernels/quant_kernels.cu:1731` |
+
+```
+biased_grouped_topk_hip(gating[T,896], bias[896]) → topk_weights[T,16] f32, topk_ids[T,16] i32
+moe_sorting_opus_fwd(topk_ids, topk_weights)      → sorted_ids / sorted_weights / sorted_expert_ids / num_valid_ids
+fused_dynamic_mx_quant_moe_sort_hip(latent[T,3584] bf16, sorted_ids, …)
+                                                  → fp8_e4m3 输出 + e8m0 scale，group 32
+```
+
+### 对应模型结构的哪个部分
+
+**每个 MoE 层的进出管道** —— 92 次/前向，与 92 个 MoE 层一一对应。
+router → 专家分配 → 把 token 重排成专家连续的块 → 为 mxfp4 专家 GEMM 做激活量化。
+因为 K3 是 latent-MoE，量化输入是 `[T, 3584]` 而不是 `[T, 7168]`。
+
+### 为什么值得让 agent 长跑
+
+- **6.35% 比 session 里任何单个 MoE GEMM kernel 都大**
+  （最大的 `mfma_moe1 t64x128x256` 才 2.92%）。它在按 kernel 名排序的榜单里完全隐形，
+  这正是它一直没被做成 task 的原因。
+- 小 T 下整条链是 launch 延迟受限：T=64 时 12.0 µs，而规模大 256 倍的 T=16384 才 70.3 µs。
+- 排序的 workspace 在 T=16384 时是 14.7 MB，且分 4 个 phase 跑。
+
+**5 个 case**：prefill T=16384 / 8192 / 64，decode T=8 和 64。
+`block_size`（大 M 档 64、小 M 档 32）不是猜的 —— 用
+`max_num_tokens_padded = T×topk + num_experts×block_size − topk` 反解 trace 里的
+buffer 长度得到，`sorted_expert_ids` 长度逐项对得上。
+`quant` 只出现在小 M 和 decode 的 case 里，因为大 M 下 session 用的 MoE1 kernel
+（`…_fp8q_sort_async_…`）把量化融进了 GEMM 前导，独立量化核在 prefill 只有 0.02%。
+
+---
+
+## 三、MLA grouped decode 注意力
+
+`mi355x_sglang_triton_mla_decode_grouped_kimi_k3` —— **E2E 4.65%**
+（`_fwd_grouped_kernel_stage1` 3.96% + `_fwd_kernel_stage2` 0.69%），triton，
+`sglang/kernels/ops/attention/decode_attention.py`。
+
+> **任务形态：单入口 · 2 kernel 流水。** 一个公开入口
+> `decode_attention_fwd_grouped(...)`，内部固定启动
+> `_decode_grouped_att_m_fwd`（stage1）→ `_decode_softmax_reducev_fwd`（stage2）。
+> `attn_logits` / `attn_lse` 虽然由调用方分配，但只作为两段之间的中转，
+> 输出只有 `o` —— **两段可以融合**（split 数小时尤其值得），
+> 参考实现也是 split-agnostic 的，所以 `num_kv_splits` 的处理方式可以自由改。
+> 计时覆盖整个入口。
+
+### 这是什么算子
+
+**吸收式 MLA** 的 flash-decoding split-KV 注意力，入口 `decode_attention_fwd_grouped`。
+stage1 扫 KV 分块写出 per-split 部分结果，stage2 做归约。
+
+```
+q            [bs, 12, 576]            bf16   12 = 96 头 / TP8；576 = kv_lora 512 + rope 64
+k_buffer     [num_kv_tokens, 1, 576]  bf16
+v_buffer     [num_kv_tokens, 1, 512]  bf16   k_buffer[..., :512] 的非连续视图
+o            [bs, 12, 512]            bf16
+attn_logits  [bs, 12, 256, 512]       f32
+```
+
+`kv_head_num = 1` → `kv_group_num = 12`，这正是把调用路由到 *grouped* kernel 的原因。
+
+### 对应模型结构的哪个部分
+
+**24 层 MLA 全注意力** —— trace 里每个 decode 步正好 24 次 stage1 + 24 次 stage2，
+归属由此钉死。其余 69 层是 KDA 线性注意力，永远不会走到这个 kernel。
+session 用的是 `--attention-backend triton`，所以这就是实际执行的路径。
+
+**只覆盖 decode 是算子属性，不是漏覆盖**：K3 的 MLA prefill 走的是结构完全不同的
+`_fwd_kernel`（`extend_attention.py`，1.50% E2E），它在 decode 里 0 次调用；
+反过来本 kernel 在 prefill 里也 0 次调用。
+
+### 为什么值得让 agent 长跑
+
+- `attn_logits` 是 `bs × 12 × 256 × 512 × 4 B`，**bs=64 时 402 MB**，每层写一遍读一遍。
+  `max_kv_splits = 256` 是被 **CU 数量**卡出来的，不是调优选的 ——
+  来自 `_mla_decode_kv_splits_cap(8, 256 CU, 13312)`。
+- `q` 和 `k_buffer` 共用同一块 576 宽的存储，`v_buffer` 只是它前 512 列，
+  一次 load 可以同时服务 K 和 V。
+- 12 个 query head 对 1 个 KV head 是天然的 LDS 复用组；split 数少时 stage1/stage2 可以融合。
+
+**4 个 case**：bs ∈ {8, 64} × KV 长度 ∈ {8192（ISL，生成开始）、9216（ISL+OSL，生成结束）}
+—— 覆盖这个 workload 的完整 decode 区间。
+
+---
+
+## 四、FlyDSL 小 M split-K HGEMM
+
+`mi355x_sglang_flydsl_hgemm_small_m_kimi_k3` —— **E2E 4.55%**
+（`hgemm_bf16_16x64x64x7_SPK2_W1x2x1_BLDS1_TN_AS1_0`），FlyDSL，
+`aiter/ops/flydsl/kernels/splitk_hgemm.py`。
+
+> **任务形态：单算子 · 单 kernel。** 本目录里最干净的一个：一个入口
+> `aiter.tuned_gemm.tgemm.mm(a, b)` → 一次 kernel 启动，golden 就是
+> `a @ b.T`。注意 4 个 case 是**互相独立的 shape**（M ∈ {8,64} × 两个投影族），
+> **不构成链** —— 它们放在同一个 task 里，是因为 session 里这四种 shape 都由同一条
+> FlyDSL 派发路径服务。split-K 的两段（partial + 收尾归约）在 kernel 内部，
+> 不是两次启动。
+
+### 这是什么算子
+
+专为极小 M 特化的 bf16 GEMM：tile 16×64×64、stages 7、split-K 2、warps 1/2/1、
+`b_to_lds`、async copy、TN 布局。kernel 名可以从 `splitk_hgemm.py:249` 的生成 f-string
+逐字段反解出来。`tile_m = 16` 是 bs=8 的 decode batch 向上补齐到 FlyDSL 最小 M tile ——
+**一半的 M tile 是空转的**，而 `split_k=2` 的存在只是为了给一个 16 行的问题
+凑出并行度。
+
+### 对应模型结构的哪个部分
+
+**decode batch 下的注意力投影。** 每个 decode 步 162 次调用 = 69 + 93：
+
+| shape | 次/步 | 是什么 |
+|---|---|---|
+| `[M, 7168] × [7168, 6144]` | 69 | KDA 输入投影 —— N = 4 × (12 头 × 128)，即 q/k/v/gate；**69 = KDA 层数** |
+| `[M, 1536] × [1536, 7168]` | 93 | o_proj —— KDA 69 + MLA 24，两者本地输出维都是 12 × 128 = 1536 |
+
+在 **prefill** 里，这两个完全相同的投影以 M = 16384 运行，dispatcher 把它们送去
+hipBLASLt（`Cijk_…MT256x256x64`，调用次数同样是 69 + 93）；到 decode 的小 M 才落到
+这条 FlyDSL 路径。所以"只有 decode"是**派发行为**，而 prefill 那一侧既不可编辑也不慢。
+
+shape 有两重独立佐证：一是上面的调用次数算术；二是
+`aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv` —— 运行栈真正查的那张调优表 ——
+里对这两个 shape 都有 `gfx950 / cu_num=256 / M=8` 的行，选的是
+`flydsl_gemm7_…t16x64x64_split_k2_block_m_warp1_block_n_warp2_…`，
+正是 session 里那个 kernel（`gemm`**`7`** 后缀就是 stage 数）。
+这张 CSV 的全部 `(N,K)` 组合还完整复现了我从 trace 做的投影普查，
+包括 `2304,1536`（MLA `q_b_proj`）和 `2112,7168`（q_a + kv_a + rope 融合）。
+
+### 为什么值得让 agent 长跑
+
+- session 里最大的**非注意力、非通信**可攻击 kernel。
+- 明确是**访存/延迟受限而非算力受限**：M=8、N=6144、K=7168 时算术量只有 0.7 GFLOP，
+  却要读约 88 MB 权重。预算花在权重流和 split-K 收尾上，不在 MFMA 管线。
+- 入口用的是**真实 dispatcher**（`aiter.tuned_gemm.tgemm.mm`），所以调优 CSV 是正当的
+  优化杠杆 —— 但按 M 分档的派发必须保留（M=8 → `t16x64x64/split_k2`，
+  M=64 → `t32x64x128/split_k1`）。harness 每个 case 都记录解析出的
+  `libtype` / `kernelName`，偷偷 fallback 到 hipBLASLt 会在报告里露出来。
+
+**3 个 case**：`(M=8, N=6144, K=7168)`、`(M=8, N=7168, K=1536)`、`(M=64, N=7168, K=1536)`。第四种组合 `(M=64, N=6144, K=7168)` 被刻意排除 —— 调优 CSV 对它选的是 `libtype=opus` 而不是 FlyDSL，收进来就会去测 `module_deepgemm_opus`（编辑面之外）。harness 里有硬性守卫强制每个 case 必须解析到 `libtype=flydsl`。
+
+---
+
+## 四个 task 共同遵守的约定
+
+- **shape 一律来自 session。** prefill 的 shape 直接读 trace 的 `Input Dims`
+  （`record_shapes=True`）；decode 因为跑在 CUDA graph 里没有 CPU 栈，
+  由调用点源码 + 模型 config 反推。每个 case 都带 `exact_shape_source` 字段说明属于哪种。
+- **精度和性能用同一份 case list。** `run_correctness` 和 `run_performance` 迭代同一个
+  `CASES`，所以被计时的 shape 一定是被校验过的 shape；harness 里没有任何
+  correctness/performance 分支。
+- **性能一律基于 CUDA graph 测量** —— 走 `_benchmark_cuda_graph_or_events`
+  （capture 一次，每次计时迭代 replay）。四个 prompt 都写明改写后必须保持 graph-capturable。
+- **参考实现全部是向量化的 torch**（float64），没有逐 token / 逐 head 的 Python 循环
+  （显存吃紧处按 token 或 batch 轴分块）。**不复用任何位于 agent 编辑面之内的 eager 参考**
+  —— 否则一个坏改动可以自己验证自己。
+- **每个 task 只有 4 个文件**：`config.yaml`、`session_cases.json`、
+  `scripts/task_runner.py`、`scripts/forge_driver.py`。本目录下只保留这一份说明文档，
+  各 task 目录内不再放 README。细节按下表分布，需要查证时直接看对应文件：
+
+  | 想查什么 | 去哪里看 |
+  |---|---|
+  | 每个 case 的 shape、来源（trace 实测 / 推导）、trace 实测耗时与 grid | `session_cases.json` 的 `cases` 和 `provenance` |
+  | shape 是怎么定出来的（`block_size` 反解、`max_kv_splits` 计算、kernel 名反解、调用次数归属） | `session_cases.json` 的 `shape_evidence` / `block_size_evidence` / `layout_derivation` / `kernel_name_decode` |
+  | 优化方向、可动与不可动的契约、禁止事项 | `config.yaml` 的 `prompt.instructions` |
+  | 入口点选择理由、golden 的数学推导、精度校验口径 | `scripts/task_runner.py` 顶部 docstring |
+  | 算子是什么、对应模型哪个部分、E2E 占比 | 本文档对应章节 |
+
+## 实测验证结果（2026-08-17，MI355X gfx950 单卡）
+
+这些 harness 是**单 rank** 的 kernel 测试，不需要 TP=8，所以已经在本机全部实跑过。
+
+### 耗时（全部 < 5 分钟，实际都在 1 分钟内）
+
+| task | compile | correctness | performance |
+|---|---|---|---|
+| attn_residual | 11.4 s | **9.7 s** (7/7 PASS) | **8.9 s** |
+| moe_routing_sort_quant | 50.9 s | **59.8 s** (5/5 PASS) | **57.9 s** |
+| mla_decode_grouped | 5.5 s | **5.3 s** (4/4 PASS) | **4.5 s** |
+| flydsl_hgemm_small_m | 16.9 s | **6.8 s** (3/3 PASS) | **6.6 s** |
+
+MoE task 的 ~50 s 里绝大部分是 `AITER_REBUILD=2` 触发的三个模块 JIT 重编（冷编译实测
+moe_asm 33.2 s + quant 13.2 s + moe_sorting_opus 6.7 s）。**不会触发全量 aiter 编译**：
+这三个模块各只有 2–5 个源文件、不含 CK、不走 blob_gen，而 `module_aiter_core` 被
+`jit/core.py` 的 `rebuilded_list` 豁免。
+
+### 性能确实走 CUDA graph，且与 trace 对得上
+
+四个 task 的每一个 case 都报告 `benchmark_method=cuda_graph`，无一例回退到 event 计时。
+实测单次调用耗时与 session trace 的实测值高度一致：
+
+| case | harness 实测 | trace 实测 |
+|---|---|---|
+| attn-res prefill t16384 nvb4 | 0.928 ms | 0.653 + 0.319 = **0.972 ms** |
+| mla-decode bs8 kv8192 | 0.0874 ms | 71.7 + 12.5 µs = **0.0842 ms** |
+| moe-route prefill t16384 | 0.1019 ms | 70.3 + 40.8 µs = **0.111 ms** |
+| hgemm decode bs8 kdaqkv | 0.0154 ms | **0.0123 ms** |
+
+### 精度结果
+
+- **attn_residual** 7/7：cos 0.9999986–0.9999990，rel_max_err 0.0020–0.0034
+- **mla_decode_grouped** 4/4：cos 0.9999982–0.9999983，rel_max_err 0.0026–0.0029；
+  split 调度器给出 bs=8→222、bs=64→28，与后端行为一致
+- **flydsl_hgemm_small_m** 3/3：cos 0.9999970–0.9999986，全部 `lib=flydsl`
+- **moe_routing_sort_quant** 5/5：topk 权重误差 1.5e-8～3.0e-8、`sel_gap ≤ 0`；
+  sort 语义校验 `w_err = 0`；quant `rel_max_err` 0.032–0.055、`p2_dev` 0.087
+
+### agent 编辑能被 JIT 采用（逐后端实测，不是推断）
+
+| 后端 | 机制 | 实测结论 |
+|---|---|---|
+| **Triton**（task 一、三） | Triton 按 kernel 源码 hash 建缓存 | 把 workspace 副本里 `_score_kernel` 的 `dotv*rrms` 改成 `*1.5`，精度立刻从 0.9999987 掉到 0.9944341 而 FAIL ✓ |
+| **aiter csrc**（task 二） | `AITER_REBUILD=2` | 向 `topk_softmax_kernels_group.cu` 和 `moe_sorting_opus.h` 各注入 `#error`，编译均失败并回传 probe 文本 ✓ |
+| **FlyDSL**（task 四） | builder 每进程重新执行 | 向 `compile_hgemm_kernel` 注入 `raise`，热缓存下仍然抛出 ✓ |
+
+**其中 aiter 那条是一个必须修的真 bug，已修复。** `jit/core.py` 的 `get_module()`
+只在 **arch 不匹配**时重编，**从不校验源码 hash/mtime**（`core.py:633-659`）。实测对照：
+
+| 场景 | 耗时 | `.so` 是否重建 |
+|---|---|---|
+| 改了 csrc、**无** `AITER_REBUILD` | 0.1 s | **否 —— 编辑被静默忽略** |
+| 改了 csrc、`AITER_REBUILD=2` | 16.9 s | 是 |
+
+所以两个 aiter task 的 `_configure()` 都设了 `AITER_REBUILD=2`（不是 `=1`——那会连
+ninja 构建目录一起清掉，每次都变成全新冷编译）。
+
+### 本轮实跑中发现并修掉的 4 个问题
+
+1. **`mla_decode_grouped` 精度直接崩** —— 我给 `v_scale` 传了 `None`，但
+   `_fwd_kernel_stage2` 会解引用它（`decode_attention.py:803`），Triton 报
+   `'NoneType' object has no attribute 'type'`。后端在非 fp8 KV 时传的是 `1.0`
+   （`triton_backend.py:1352-1353`），已改正。
+2. **`moe_routing` 的 topk 校验方法本身是错的** —— 我原来按 expert id 对齐两个独立
+   top-k 再比权重。896 个专家下第 16/17 名的 biased 分数常在 fp32 噪声内并列，
+   kernel 与 torch 会选到不同专家，对齐后就在比不相干的专家（实测报出 8.7e-3 假误差）。
+   改成 tie-safe 双段校验：(A) 选择合法性 `min(biased[chosen]) ≥ max(biased[rest]) − eps`；
+   (B) 权重必须与 **kernel 自己选出的 id** 一致。改后误差降到 1.5e-8。
+3. **`moe_routing` 的 quant 校验假设了错误的 scale 布局** —— `out` 是按 token 行对齐的，
+   但 `scales` 是按排序 slot 且经硬件 swizzle 排布的（实测某行读出
+   `[119, 0, 119, 0, …]`，非零行数恰等于 `num_valid_ids`）。原来的 `scales[t]` 查表
+   反量化出全零（rel = 1.0）。改成**完全不依赖 scale 布局**的校验：从 payload 反推每组
+   隐含 scale，验证它是 2 的幂，再用 `q · 2^e` 与输入比对；scale 张量只做
+   "写入行数 == num_valid_ids" 的结构性检查。
+4. **`flydsl_hgemm` 有一个 case 根本没在测目标 kernel** —— `(M=64, N=6144, K=7168)` 在
+   `kimik3_bf16_tuned_gemm.csv` 里选的是 **`libtype=opus`**（`opus_gemm_flatmm_splitk_…`，
+   splitK=4），不是 FlyDSL；它还会把 `module_deepgemm_opus` 的大量实例编译拖进每次运行
+   （correctness 从 6.8 s 涨到 23 s）。已删除该 case（4→3），并在 `_prepare()` 里加了
+   **硬性守卫**：解析出的 `libtype` 必须等于 `params.require_libtype`（`flydsl`），
+   否则直接断言失败 —— 这把"不许绕开 FlyDSL"从 prompt 里的文字变成了机器强制。
+
+### 已知的一处小缺口（不阻塞运行）
+
+`src/perf_helper_materialization.py:104` 的 `image_kernel_targets()` 硬编码
+`tasks/image_kernel/*/scripts/task_runner.py`，**不扫 `tasks/kimi-k3/`**。影响仅限
+开发期工具 `make sync-perf-helpers` 不会同步这四个 task 里的 helper 占位块。
+
+**运行时不受影响**：`materialize_perf_helpers_in_workspace()` 作用于**拷贝出来的
+workspace**，只检查 `scripts/task_runner.py` 里有没有 AKA marker，与那个 glob 无关 ——
+上面四个 task 的 performance 实跑就是这么注入成功的。若要让开发期工具也覆盖，把
+`:104` 的 glob 改成同时匹配 `tasks/kimi-k3/*/scripts/task_runner.py` 即可。这属于
+Arena 基础设施、不在本目录内，我没有擅自改动。
+
+### Arena + forge-loop 端到端验证（四个 task 全部跑通）
+
+用 `/shared_nfs/jqliu/set_env.sh` 的环境 + `/shared_nfs/jqliu/run_arena/run.sh` 的运行方式
+（log/workspace 改到 `/tmp`，与 `config.forge_mxfp4.yaml` 里的注释一致，避免 NFS page cache
+把宿主 cgroup 顶到上限被 OOM kill），逐个跑到 forge-loop 主业务后停掉。
+KernelForge 从 `/shared_nfs/jqliu/KernelForge` 以 `pip install -e ".[claude]"` 装入
+`/opt/venv`（不含 torch 依赖，未影响镜像的 torch 2.9.1+rocm7.2.0）。
+
+| task | task id | fellow 解析 | forge baseline | 基线一致性 | 到达阶段 |
+|---|---|---|---|---|---|
+| attn_residual | `kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3` | `triton-fellow` | 0.539 ms | **7 / 7 case** | INITIAL_ANALYSIS |
+| moe_routing_sort_quant | `kimi-k3/mi355x_sglang_hip_moe_routing_sort_quant_kimi_k3` | `hip-fellow` | 0.050 ms | **5 / 5 case** | INITIAL_ANALYSIS |
+| mla_decode_grouped | `kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3` | `triton-fellow` | 0.247 ms | **4 / 4 case** | INITIAL_ANALYSIS |
+| flydsl_hgemm_small_m | `kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3` | `flydsl-fellow` | 0.009 ms | **3 / 3 case** | INITIAL_ANALYSIS |
+
+四个都干净走完了这条链路，没有一个秒挂：
+
+1. **task 被 Arena 发现** —— `src/tasks.py` 用 `tasks/**/config.yaml` 递归扫描，
+   task id 就是相对 `tasks/` 的路径，所以 `kimi-k3/` 这个新目录天然可用，
+   无需改 Arena 任何代码（439 个 task 中包含这 4 个）。
+2. **workspace seeding 正常** —— `image_repo_exclude` 生效：aiter 从 2.8 G 只拷出
+   **358 M**（`aiter/jit/flydsl_cache` 2.1 G 和 `aiter/jit/build` 78 M 被排除），
+   sglang 侧同理。
+3. **`repository_language` → fellow 映射全部正确**：triton / hip / flydsl 三种都命中。
+4. **prepare 阶段四个 task 全部跳过** —— 日志都是
+   `[prepare] task already conforms to the driver contract; skipping`，
+   省掉了 forge 先派一个 LLM agent 去写 driver 的那一步（这正是随包附带
+   `scripts/forge_driver.py` 的目的）。CLI 在这里用的门槛是
+   （`cli.py:1601-1608`）：
+
+   ```python
+   pf = preflight_task(driver=driver, snr_threshold=30.0,
+                       require_graph=True, require_profile=True,
+                       expected_case_ids=declared_case_ids(invocation_spec_file))
+   ```
+
+   即四项同时满足才算 conform，逐项实测余量：
+
+   | 门槛 | 要求 | attn_residual | mla_decode | flydsl_hgemm | moe_routing |
+   |---|---|---|---|---|---|
+   | `snr_threshold` | ≥ 30 dB | **55.63** | **54.51** | **52.23** | **138.92** |
+   | `require_graph` | bench 必须真跑 graph replay | ✓ | ✓ | ✓ | ✓ |
+   | `require_profile` | `--profile-run` 必须 exit 0 | ✓ | ✓ | ✓ | ✓ |
+   | `expected_case_ids` | `case_ms` 行数必须覆盖**全部**声明 case，子集不算 | 7/7 | 4/4 | 3/3 | 5/5 |
+
+   最后一项是最容易踩的：源码注释写得很直白 ——「a driver that times a subset of the
+   task's cases is not "already conforming", it just measures less than the task
+   asks for」。四个 driver 都是遍历同一份 `CASES`，所以天然全覆盖。
+   MoE 那个 138.92 dB 特别高，是因为它的 SNR 算在 top-k 路由权重上，
+   而权重误差只有 ~1.5e-8。
+5. **Arena 自己的 baseline 与 harness 实测一致** —— 例如 MoE task，Arena 测得
+   5 个 case 平均 0.0495 ms，与本文档上一节 harness 直接实测的
+   0.1019 / 0.0624 / 0.0287 / 0.0266 / 0.0286 ms 的均值吻合。
+6. **`pristine anchor agrees with the task reference on N of N measured case(s)`** ——
+   四个 task 的每一个 case 都被 forge 独立复测且与 `session_cases.json` 声明的数量一致，
+   说明 case 定义、correctness 与 performance 三者在 forge 侧也自洽。
+7. **进入 `[analysis] building commit-bound analysis bundle (INITIAL_ANALYSIS)`** ——
+   已是 forge-loop 的主业务（LLM 分析 + 并行 specialist 编排），验证到此即停。
+
+从启动到 baseline 完成的耗时：attn_residual ~80 s、mla_decode ~50 s、flydsl_hgemm ~90 s、
+**moe_routing ~9 min**。MoE 那个偏长是因为 forge 在 baseline 阶段会多次调用 driver，
+而每次调用都要付 `AITER_REBUILD=2` 的三模块重编（~50 s/次）—— 这是"编辑必须生效"
+换来的代价，单次调用仍远低于 5 分钟，只是 forge 的多次调用叠加起来偏慢。
+若要提速，可考虑让 forge 在同一次 driver 进程里跑完 correctness+bench，或接受首轮偏慢。
+
+一个值得记录的交互：forge 会把镜像里 11 个预编译 `.so`
+seed 进它自己的隔离 `forge_experiments/aiter_cache`
+（`[aiter-cache] seeded 11 prebuilt module(s)`）。**如果没有 `AITER_REBUILD=2`，
+agent 对 csrc 的修改就会被这批 seed 进来的 .so 完全遮蔽** —— 这恰好是上面修掉的那个 bug
+在真实 forge 流程下的表现形式，说明该修复是必需的而不是纸面推演。
+
+### 验证过程未污染镜像
+
+期间为了做 pickup 实测，临时改过 `aiter` 的 `quant_kernels.cu` /
+`topk_softmax_kernels_group.cu` / `moe_sorting_opus.h` / `splitk_hgemm.py` 和 sglang 的
+`attn_residual.py`，全部已还原：两个仓库 `git diff --name-only HEAD` 均为 0 个文件。
+
+## 两个待确认事项
+
+- **`bs=64` 的 decode case 是否保留。** profiling 用的是 `warmup 0s`，
+  所以 trace 只抓到 **bs=8** 的爬坡期；而这一轮真实稳态是 **bs=64**
+  （`conc=64`、`max_running_requests=64`，3077 个 decode 步里有 3072 个在 bs=64；
+  `median_itl_ms=46.73` vs bs=8 的 25.56 ms 佐证）。两者都是本次运行的真实 shape，
+  目前都参与打分。若要严格只用 trace 直读的 shape，
+  从各个 `session_cases.json` 里删掉 `*-bs64-*` 那几条即可，没有其他地方引用。
+- ~~四个 harness 一次都没有实跑过。~~ **已全部实跑并修复**，见上一节「实测验证结果」——这些 harness 是单 rank 的，不需要 TP=8，本机单卡即可运行。

--- a/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/config.yaml
+++ b/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/config.yaml
@@ -1,0 +1,86 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/aiter
+repo_subdir: aiter
+image_repo_exclude:
+- __pycache__
+- jit/build
+# The compute cores are FlyDSL (mfma_moe1_* / mfma_moe2_*, emitted by
+# ops/flydsl/kernels/mixed_moe_gemm_2stage.py). Must be one of the keys under
+# `knowledge` in src/prompts/cheatsheet/default_cheatsheet.yaml
+# (flydsl/hip/triton) -- 'python' hard-fails prompt_builder.
+repository_language: flydsl
+source_file_path:
+- fused_moe.py
+- ops/flydsl/moe_kernels.py
+editable_sources:
+- ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+- ops/flydsl/moe_common.py
+- configs/model_configs/minimax_m3_fp4_tuned_fmoe.csv
+- configs/tuned_fmoe.csv
+target_kernel_functions:
+- fused_moe
+- moe_gemm1
+- moe_gemm2
+kernel_identity:
+  logical_operator: aiter_mxfp4_moe_2stage
+  kernel_kind: flydsl
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: m3-moe-prefill-token8192
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the aiter FlyDSL MoE 2-stage GEMM pair that serves MiniMax-M3's
+    prefill token counts on MI355X/gfx950:
+    `mfma_moe1_silu_mul_afp4_wfp4_bf16_t128x128x256_pm1_async_v32` and
+    `mfma_moe2_afp4_wfp4_bf16_cshuffle_t128x128x256_vscale_fix3_fp4opt_v1_persist_cu256`,
+    both emitted by `aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py`
+    (kernel names are built at :273 for moe1 and :3111 for moe2).
+
+    Config, all taken from the session: 128 experts, top-4, model_dim=6144,
+    inter_dim=512 per rank under TP=8, mxfp4 weights AND mxfp4 activations
+    (QuantType.per_1x32, e8m0 group scales), ActivationType.Swiglu, bf16 in/out.
+
+    Routed-expert MoE GEMM is 18.60% of normalized end-to-end GPU time -- the
+    largest single computational function in the model. The FlyDSL pair covers the
+    prefill half of that, 6.01%.
+
+    Two concrete findings from the session:
+
+    1. `mfma_moe2` does HALF the FLOPs of `mfma_moe1` but takes TWICE the time --
+       602 vs 2315 TFLOP/s measured, a 3.8x efficiency gap for the same
+       expert-GEMM shape class. Neither is at a roof: measured traffic is 2.78 TB/s
+       (gemm1) and 1.79 TB/s (gemm2) against an 8 TB/s HBM peak. gemm2 is the
+       obvious target; its heuristic name ends in `_atomic`, so how the per-expert
+       partials are accumulated is worth looking at first.
+
+    2. The session never found a tuned config. server.log says: "[fused_moe] no
+       tuned FlyDSL config for ('gfx950', 256, 8192, 6144, 512, 128, 4,
+       ActivationType.Swiglu, ...), using heuristic FlyDSL fallback
+       (kn1='flydsl_moe1_afp4_wfp4_bf16_t128x128x256_w2_bnt0',
+       kn2='flydsl_moe2_afp4_wfp4_bf16_t128x128x256_atomic')". Producing a tuned
+       entry for this shape is part of the edit surface
+       (`configs/model_configs/minimax_m3_fp4_tuned_fmoe.csv`).
+
+    Both the prefill (token=8192) and decode (token=64) cases are scored so the
+    report shows the whole MoE picture, but only the prefill case runs FlyDSL --
+    token=64 dispatches to the CK-Tile pair, whose sources live in aiter_meta/
+    (C++/HIP), outside this task's edit surface, and which already runs at 90% of
+    HBM peak. Do not chase it here; the decode case is expected to stay flat.
+
+    Constraints: `aiter.fused_moe.fused_moe` keeps its public signature and its
+    weight/scale layout contract with vLLM's loader
+    (`vllm/model_executor/layers/fused_moe/oracle/mxfp4.py:973-1014`:
+    `e8m0_shuffle` on the scales, `rocm_aiter_ops.shuffle_weights` with the (16,16)
+    layout on the packed fp4 weights). Correctness is a cosine / relative-norm
+    check against a dequantized torch reference. The score is the CUDA-graph
+    measured time over the same case list.
+  cheatsheet: null

--- a/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/scripts/forge_driver.py
+++ b/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/scripts/task_runner.py
+++ b/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/scripts/task_runner.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Harness for MiniMax-M3's routed-expert MoE 2-stage GEMM (aiter, MXFP4 x MXFP4).
+
+One `aiter.fused_moe.fused_moe()` entry, two kernel families selected by token
+count -- exactly as the session runs it:
+
+  token = 8192 (chunked-prefill step) -> aiter FlyDSL MFMA pair
+        mfma_moe1_silu_mul_afp4_wfp4_bf16_t128x128x256_pm1_async_v32
+        mfma_moe2_afp4_wfp4_bf16_cshuffle_t128x128x256_..._persist_cu256
+  token = 64   (pure-decode step)     -> CK-Tile flat GEMM pair
+        ck_tile::MoeFlatmmKernel<MoeFlatmmKind=3>  (FFN gemm1, split-k)
+        ck_tile::MoeFlatmmKernel<MoeFlatmmKind=2>  (FFN gemm2)
+
+Both token counts are scored in BOTH MoE tasks so the report always shows the
+full MoE picture; each task's edit surface only reaches one of the two families.
+
+The weight preparation reproduces vLLM's AITER_MXFP4_MXFP4 loader
+(vllm/model_executor/layers/fused_moe/oracle/mxfp4.py:973-1014) rather than
+guessing: e8m0_shuffle on both scale tensors, view as float4_e2m1fn_x2, then
+rocm_aiter_ops.shuffle_weights on the packed weights.
+
+Correctness and performance run the SAME case list at the SAME sizes, and
+performance is measured under a CUDA/HIP graph.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MOE_CONFIG = SPEC["moe_config"]
+
+_IMAGE_AITER_META = Path("/usr/local/lib/python3.12/dist-packages/aiter_meta")
+
+
+def _link_aiter_meta() -> None:
+    """Give a workspace copy of `aiter` its sibling C++ tree.
+
+    aiter locates aiter_enum.h relative to the directory that *contains* the
+    package (aiter/utility/aiter_types.py:_find_aiter_enum_h uses parents[2] and
+    ignores AITER_META_DIR), so a workspace that only seeds `aiter` cannot import
+    it at all without this link.
+    """
+    link = WORKSPACE / "aiter_meta"
+    if link.exists() or link.is_symlink():
+        return
+    if _IMAGE_AITER_META.is_dir():
+        link.symlink_to(_IMAGE_AITER_META, target_is_directory=True)
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    if (WORKSPACE / "aiter").is_dir():
+        # FlyDSL task: the agent edits the seeded python package, which must
+        # shadow the in-image install.
+        #
+        # Deliberately NOT redirecting AITER_JIT_DIR. Left unset, aiter defaults
+        # to <workspace>/aiter/jit -- the copy that already carries all 108
+        # prebuilt .so modules, and which is per-run anyway, so isolation is
+        # preserved. Redirecting it to an empty build dir instead forces a
+        # from-source rebuild of whatever C++ module a case happens to need: the
+        # token=64 case reaches module_moe_cktile2stages, a ~6 minute CK-Tile
+        # build that is not even this task's edit surface. FlyDSL kernels are
+        # generated from the (editable) Python DSL at call time and do not go
+        # through this .so mechanism, so agent edits still take effect.
+        _link_aiter_meta()
+        sys.path.insert(0, str(WORKSPACE))
+        os.environ.setdefault("AITER_META_DIR", str(_IMAGE_AITER_META))
+    elif (WORKSPACE / "aiter_meta").is_dir():
+        # CK-Tile task: the agent edits C++/HIP sources, so point aiter's JIT at
+        # the workspace tree and force a rebuild. Here the rebuild IS the point,
+        # and the JIT output must not land in the image's aiter package.
+        os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "jit"))
+        os.environ["AITER_META_DIR"] = str(WORKSPACE / "aiter_meta")
+        os.environ.setdefault("AITER_REBUILD", "1")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _aiter():
+    import aiter
+
+    return aiter
+
+
+def _assert_vllm_contract(aiter, p: dict) -> None:
+    """Pin the two enum choices vLLM makes, so a patch that needs different ones
+    cannot pass here and then silently mismatch in production."""
+    if p["quant_type"] != "per_1x32":
+        raise AssertionError(f"session quant_type is per_1x32, got {p['quant_type']}")
+    if not hasattr(aiter.ActivationType, "Swiglu"):
+        raise AssertionError("this aiter build has no ActivationType.Swiglu")
+    if p["inter_dim"] * 2 != MOE_CONFIG["w1_n"]:
+        raise AssertionError(
+            f"w1 N ({MOE_CONFIG['w1_n']}) must be 2*inter_dim ({p['inter_dim']})"
+        )
+
+
+def _make(case: dict) -> dict:
+    """Build one case's inputs.
+
+    Named ``_make`` (not ``_prepare``) on purpose: forge-loop's shipped
+    ``scripts/forge_driver.py`` calls ``tr._make(case)`` for its --profile-run
+    contract. A task that names it anything else fails the profiling preflight
+    and makes forge-loop spend an LLM prep agent re-authoring a driver on every
+    single run.
+    """
+    torch = _torch()
+    aiter = _aiter()
+    from aiter import dtypes
+    from aiter.utility.fp4_utils import e8m0_shuffle
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    p = dict(case["params"])
+    _assert_vllm_contract(aiter, p)
+
+    token = p["token"]
+    experts, model_dim, inter_dim, topk = (
+        p["experts"], p["model_dim"], p["inter_dim"], p["topk"]
+    )
+    quant_type = aiter.QuantType.per_1x32
+    activation = aiter.ActivationType.Swiglu
+
+    torch.manual_seed(int(case.get("seed", 19)))
+    hidden = torch.randn((token, model_dim), device="cuda", dtype=dtypes.bf16) * 0.1
+    w1 = (
+        torch.randn(
+            (experts, inter_dim * 2, model_dim), device="cuda", dtype=dtypes.bf16
+        )
+        * 0.03
+    )
+    w2 = (
+        torch.randn((experts, model_dim, inter_dim), device="cuda", dtype=dtypes.bf16)
+        * 0.03
+    )
+
+    # Router: M3 uses sigmoid scoring with a routing bias, but the MoE kernel only
+    # consumes (topk_weights, topk_ids); the router itself is a separate GEMM and
+    # is not part of this task. Draw a realistic, seeded assignment.
+    score = torch.randn((token, experts), device="cuda", dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(torch.sigmoid(score), topk, dim=-1)
+    topk_weights = (topk_weights / topk_weights.sum(-1, keepdim=True)).to(
+        torch.float32
+    ) * MOE_CONFIG["routed_scaling_factor"]
+    topk_ids = topk_ids.to(torch.int32)
+
+    torch_quant = aiter.get_torch_quant(quant_type)
+    w1_quant, w1_scale = torch_quant(w1, quant_dtype=dtypes.fp4x2)
+    w2_quant, w2_scale = torch_quant(w2, quant_dtype=dtypes.fp4x2)
+
+    # ---- vLLM AITER_MXFP4_MXFP4 loader contract (oracle/mxfp4.py:973-1014) ----
+    # vLLM holds the scales as [E, N, K/32] from the checkpoint and reshapes to
+    # [E*N, K/32] before e8m0_shuffle; aiter's get_torch_quant already hands back
+    # that flat layout, so shuffle it directly. Same buffer, same bytes.
+    w1_scale_rt = e8m0_shuffle(w1_scale)
+    w2_scale_rt = e8m0_shuffle(w2_scale)
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    w1_view = w1_quant.view(fp4_dtype) if fp4_dtype is not None else w1_quant
+    w2_view = w2_quant.view(fp4_dtype) if fp4_dtype is not None else w2_quant
+    w1_rt, w2_rt = rocm_aiter_ops.shuffle_weights(w1_view, w2_view)
+    # -------------------------------------------------------------------------
+
+    return {
+        "cfg": case,
+        "params": p,
+        "token": token,
+        "topk": topk,
+        "hidden": hidden,
+        "w1": w1_rt,
+        "w2": w2_rt,
+        "w1_scale": w1_scale_rt,
+        "w2_scale": w2_scale_rt,
+        # Unshuffled copies drive the torch reference.
+        "w1_reference": w1_quant,
+        "w2_reference": w2_quant,
+        "w1_scale_reference": w1_scale,
+        "w2_scale_reference": w2_scale,
+        "topk_weights": topk_weights,
+        "topk_ids": topk_ids,
+        "quant_type": quant_type,
+        "activation": activation,
+    }
+
+
+def _run(inputs: dict):
+    torch = _torch()
+    from aiter.fused_moe import fused_moe
+
+    return fused_moe(
+        inputs["hidden"],
+        inputs["w1"],
+        inputs["w2"],
+        inputs["topk_weights"],
+        inputs["topk_ids"],
+        w1_scale=inputs["w1_scale"],
+        w2_scale=inputs["w2_scale"],
+        quant_type=inputs["quant_type"],
+        activation=inputs["activation"],
+        dtype=torch.bfloat16,
+    )
+
+
+def _reference(inputs: dict):
+    """Dequantized torch reference for the same two-stage MoE.
+
+    Uses aiter's own torch_moe_stage1/torch_moe_stage2, which unpack the mxfp4
+    nibbles, apply the per-1x32 e8m0 group scales and accumulate in fp32 -- an
+    independent implementation of the op, not a wrapper around the kernel under
+    test. Both stages are single batched GEMMs over the expert dimension, so the
+    reference is vectorized, not a per-expert Python loop.
+    """
+    torch = _torch()
+    from aiter.fused_moe import torch_moe_stage1, torch_moe_stage2
+
+    token, topk = inputs["token"], inputs["topk"]
+    stage1 = torch_moe_stage1(
+        inputs["hidden"],
+        inputs["w1_reference"],
+        inputs["w2_reference"],
+        inputs["topk_weights"],
+        inputs["topk_ids"],
+        dtype=torch.bfloat16,
+        activation=inputs["activation"],
+        quant_type=inputs["quant_type"],
+        a1_scale=None,
+        w1_scale=inputs["w1_scale_reference"],
+    )
+    return torch_moe_stage2(
+        stage1.view(token, topk, -1),
+        inputs["w1_reference"],
+        inputs["w2_reference"],
+        inputs["topk_weights"],
+        inputs["topk_ids"],
+        dtype=torch.bfloat16,
+        quant_type=inputs["quant_type"],
+        w2_scale=inputs["w2_scale_reference"],
+        a2_scale=None,
+    )
+
+
+def _moe_deviation(got, expected):
+    torch = _torch()
+    g, e = got.float().flatten(), expected.float().flatten()
+    cos = torch.nn.functional.cosine_similarity(g, e, dim=0).item()
+    err = ((g - e).norm() / e.norm().clamp_min(1e-8)).item()
+    return cos, err
+
+
+def _assert_moe_within_tolerance(case: dict, cos: float, err: float, label: str) -> None:
+    tol = case["params"]
+    assert cos > tol.get("min_cosine", 0.97), (
+        case["id"],
+        f"{label} cosine {cos:.6f} vs torch reference too low",
+    )
+    assert err < tol.get("max_rel_norm_err", 0.25), (
+        case["id"],
+        f"{label} relative norm error {err:.4f} too high",
+    )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh the activation in place so a replayed graph sees fresh values.
+
+    Only ``hidden`` is redrawn: the routing tensors are kernel inputs rather than
+    something the kernel derives, and the quantized weights have shuffled runtime
+    copies that would have to be rebuilt in lockstep.
+    """
+    torch = _torch()
+    torch.manual_seed(43)
+    inputs["hidden"].normal_(0.0, 0.1)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    got = timed.rerun()
+    cos, err = _moe_deviation(got, _reference(inputs))
+    _assert_moe_within_tolerance(case, cos, err, "timed")
+
+
+def run_compile() -> None:
+    inputs = _make(CASES[0])
+    out = _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        cos, err = _moe_deviation(got, _reference(inputs))
+        _assert_moe_within_tolerance(case, cos, err, "correctness")
+        print(f"correctness PASS {case['id']}  cos={cos:.6f} rel_err={err:.4f}")
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(case, inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "session_id": case.get("session_id"),
+            "phase": case.get("phase"),
+            "gpu_pct": case.get("gpu_pct"),
+            "kernel_family": case.get("kernel_family"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/session_cases.json
+++ b/tasks/minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3/session_cases.json
@@ -1,0 +1,142 @@
+{
+  "source_day": "2026-08-15",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.26.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.26.0",
+  "task_name": "mi355x-minimax-m3-flydsl-mxfp4-moe-2stage-20260815",
+  "operator": "aiter_mxfp4_moe_2stage",
+  "selection": "routed-expert MoE 2-stage GEMM, 18.60% of normalized E2E GPU time -- the single largest computational function in the model. This task's edit surface is the aiter FlyDSL pair that serves the prefill token counts (6.01% of E2E).",
+  "provenance": {
+    "model": "MiniMax-M3-MXFP4",
+    "session_id": "20260815T100002Z",
+    "session_path": "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260815T100002Z",
+    "trace": "runs/roofline/ca746c43c5564616b0ff91a3582c73ab/benchmark_vllm_20260815_111805/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1786793700435294667.pt.trace.json.gz",
+    "workload": "ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312 / TP=8 / quark MXFP4",
+    "entry": "aiter.fused_moe.fused_moe(); vLLM reaches it through vllm::rocm_aiter_fused_moe -> aiter::fused_moe_",
+    "backend_log": "server.log: \"Using 'AITER_MXFP4_MXFP4' Mxfp4 MoE backend\" / \"Using AITER_MXFP4_MXFP4 backend for OCP_MX_Scheme.w_mxfp4_a_mxfp4\"",
+    "dispatch_log": "server.log: \"[fused_moe] using 2stage default for ('gfx950', 256, 8192, 6144, 512, 128, 4, <ActivationType.Swiglu: 2>, 'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', 'QuantType.per_1x32', True, False)\" and \"[fused_moe] no tuned FlyDSL config for (...), using heuristic FlyDSL fallback (kn1='flydsl_moe1_afp4_wfp4_bf16_t128x128x256_w2_bnt0', kn2='flydsl_moe2_afp4_wfp4_bf16_t128x128x256_atomic')\"",
+    "measured_kernels": [
+      {
+        "kernel": "mfma_moe1_silu_mul_afp4_wfp4_bf16_t128x128x256_pm1_async_v32",
+        "phase": "prefill",
+        "normalized_e2e_pct": 2.06,
+        "prefill_step_pct": 5.12,
+        "calls_per_step": 55.6,
+        "us_per_call": 178.1,
+        "grid": "(4,383,1)",
+        "block": "(256,1,1)",
+        "achieved_tflops": 2315
+      },
+      {
+        "kernel": "mfma_moe2_afp4_wfp4_bf16_cshuffle_t128x128x256_vscale_fix3_fp4opt_v1_persist_cu256",
+        "phase": "prefill",
+        "normalized_e2e_pct": 3.95,
+        "prefill_step_pct": 9.83,
+        "calls_per_step": 55.6,
+        "us_per_call": 342.3,
+        "grid": "(48,256,1)",
+        "block": "(256,1,1)",
+        "achieved_tflops": 602
+      },
+      {
+        "kernel": "ck_tile::MoeFlatmmKernel<MoeFlatmmKind=3>",
+        "phase": "decode",
+        "normalized_e2e_pct": 8.14,
+        "decode_step_pct": 13.58,
+        "calls_per_step": 57,
+        "us_per_call": 47.0
+      },
+      {
+        "kernel": "ck_tile::MoeFlatmmKernel<MoeFlatmmKind=2>",
+        "phase": "decode",
+        "normalized_e2e_pct": 4.48,
+        "decode_step_pct": 7.47,
+        "calls_per_step": 57,
+        "us_per_call": 25.8
+      }
+    ],
+    "headroom_note": "gemm2 does half the FLOPs of gemm1 but takes twice the time: 602 vs 2315 TFLOP/s, a 3.8x efficiency gap for the same expert-GEMM shape class. Neither kernel is at a roof -- traffic is 2.78 TB/s (gemm1) and 1.79 TB/s (gemm2) against an 8 TB/s HBM peak -- and the dispatch log says no tuned FlyDSL config was found for this shape.",
+    "shape_evidence": "torch profiler cpu_op aiter::fused_moe_ Input Dims (prefill step): [[8192,6144],[128,1024,3072],[128,6144,256],[8192,4],[8192,4],...,[128,1024,192],[128,6144,16]] with Input type [BFloat16, Float4_e2m1fn_x2, Float4_e2m1fn_x2, float, int, ..., unsigned char, unsigned char]. Same op at [[64,6144],...] in the bs=64 capture trace. Concrete Inputs pin activation=2 (Swiglu) and quant_type=3 (per_1x32).",
+    "padding_note": "inter_dim is 512, not 384. The model's MoE intermediate_size is 3072 and TP=8 gives 384 per rank, but the routed-expert weights are padded to 512 (w1 N = 1024 = 2*512, w2 K = 512) -- confirmed by both the traced tensor shapes and the aiter dispatch log's inter_dim=512. The shared expert on the same layer is NOT padded (768 = 2*384). Roughly 3.1% of end-to-end time is spent on the padded third.",
+    "harness_agreement": "harness 0.609 ms at m3-moe-prefill-token8192 vs 178.1+342.3 us for the two FlyDSL GEMMs plus ~20 us of sorting/quant kernels in the session trace -- within 13%. Decode 0.114 ms vs ~89 us; the harness routes with uniform-random expert assignment rather than the model's learned routing, which changes the sorted-token padding."
+  },
+  "moe_config": {
+    "source": "MiniMax-M3 config.json text_config + traced aiter::fused_moe_ shapes",
+    "activation": "Swiglu",
+    "quant_type": "per_1x32",
+    "a_dtype": "mxfp4 (quantized inside fused_moe from bf16 activations)",
+    "w_dtype": "mxfp4 (fp4_e2m1, 2 values per byte)",
+    "scale_dtype": "e8m0",
+    "w1_n": 1024,
+    "w1_k": 6144,
+    "w2_n": 6144,
+    "w2_k": 512,
+    "routed_scaling_factor": 2.0,
+    "vllm_loader_contract": "vllm/model_executor/layers/fused_moe/oracle/mxfp4.py:973-1014 -- e8m0_shuffle both scale tensors (viewed as [E*N, K/32]), view the packed weights as torch.float4_e2m1fn_x2, then rocm_aiter_ops.shuffle_weights(w13, w2) with the default (16,16) layout. The harness uses those exact entry points."
+  },
+  "cases": [
+    {
+      "id": "m3-moe-prefill-token8192",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "chunked-prefill step",
+      "kernel_family": "aiter FlyDSL mfma_moe1/mfma_moe2 (this task's edit surface)",
+      "gpu_pct": 6.01,
+      "seed": 19,
+      "params": {
+        "token": 8192,
+        "experts": 128,
+        "model_dim": 6144,
+        "inter_dim": 512,
+        "topk": 4,
+        "quant_type": "per_1x32",
+        "activation": "Swiglu",
+        "a_dtype": "bf16",
+        "w_dtype": "fp4",
+        "min_cosine": 0.97,
+        "max_rel_norm_err": 0.25
+      },
+      "trace_input_shapes": [
+        "hidden (8192,6144) bf16",
+        "w1 (128,1024,3072) float4_e2m1fn_x2  [logical (128,1024,6144)]",
+        "w2 (128,6144,256) float4_e2m1fn_x2  [logical (128,6144,512)]",
+        "topk_weights (8192,4) fp32",
+        "topk_ids (8192,4) int32",
+        "w1_scale (128,1024,192) e8m0",
+        "w2_scale (128,6144,16) e8m0"
+      ]
+    },
+    {
+      "id": "m3-moe-decode-token64",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "pure-decode step",
+      "kernel_family": "CK-Tile MoeFlatmmKernel -- sources in aiter_meta/ (C++/HIP), outside this task's edit surface; scored here only so the report shows the whole MoE picture, expected to stay flat",
+      "gpu_pct": 12.62,
+      "seed": 19,
+      "params": {
+        "token": 64,
+        "experts": 128,
+        "model_dim": 6144,
+        "inter_dim": 512,
+        "topk": 4,
+        "quant_type": "per_1x32",
+        "activation": "Swiglu",
+        "a_dtype": "bf16",
+        "w_dtype": "fp4",
+        "min_cosine": 0.97,
+        "max_rel_norm_err": 0.25
+      },
+      "trace_input_shapes": [
+        "hidden (64,6144) bf16",
+        "w1 (128,1024,3072) float4_e2m1fn_x2",
+        "w2 (128,6144,256) float4_e2m1fn_x2",
+        "topk_weights (64,4) fp32",
+        "topk_ids (64,4) int32",
+        "w1_scale (128,1024,192) e8m0",
+        "w2_scale (128,6144,16) e8m0"
+      ]
+    }
+  ]
+}

--- a/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/config.yaml
+++ b/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/config.yaml
@@ -1,0 +1,64 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/vllm/models/minimax_m3
+repo_subdir: vllm_models_minimax_m3
+image_repo_exclude:
+- __pycache__
+- nvidia
+repository_language: triton
+source_file_path:
+- amd/ops/sparse_attn.py
+editable_sources:
+- common/ops/sparse_attn.py
+target_kernel_functions:
+- _gqa_sparse_fwd_kernel
+- minimax_m3_sparse_attn
+- _sparse_attn_prefill_kwargs
+kernel_identity:
+  logical_operator: gqa_sparse_attn_prefill
+  kernel_kind: triton
+  source_owner: vllm
+  workload:
+    source: session_cases.json
+    primary_case: m3-prefill-b1-q8131-prefix0
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the Triton block-sparse GQA prefill attention kernel
+    `_gqa_sparse_fwd_kernel` in
+    `vllm/models/minimax_m3/amd/ops/sparse_attn.py` on MI355X/gfx950.
+
+    This is MiniMax-M3's prefill attention for its 57 block-sparse layers: each
+    query token attends only to the top-16 selected 128-token KV blocks. Per-rank
+    geometry under TP=8 is num_heads=8, num_kv_heads=1 (GQA group width 8),
+    head_dim=128, BF16 KV, block_size=128, topk=16. It is 8.53% of normalized
+    end-to-end GPU time in the source session and 21.20% of every chunked-prefill
+    step, called 57 times per step at 720 us each.
+
+    The measured problem: 83.6 TFLOP/s, about 3.6% of the BF16 peak. The launcher
+    (`minimax_m3_sparse_attn`, same file) passes `BLOCK_SIZE_Q=1`, so one workgroup
+    handles a single query token, and `_sparse_attn_prefill_kwargs()` pins
+    `num_warps=1` -- the measured block is (64,1,1), one wavefront. The QK GEMM
+    therefore has M=8 (the GQA group width) and cannot fill an MFMA_16x16 tile,
+    even though `matrix_instr_nonkdim=16` selects that instruction. The KV side is
+    not the constraint: one layer's KV working set for a sequence is only ~4.2 MB
+    and stays resident in the 256 MB Infinity Cache.
+
+    Suggested direction (not binding): process several query tokens per workgroup
+    so the QK/PV MFMAs get a real M dimension. Queries within a chunk share most of
+    their selected block sets, so a tile over (query, selected block) may let one
+    KV block load serve many queries. `SUB_K` (currently 64 on gfx950) and the
+    num_warps / num_stages / kpack choices in `_sparse_attn_prefill_kwargs()` are
+    part of the edit surface.
+
+    Constraints: do not change the public signature of `minimax_m3_sparse_attn`;
+    `topk_idx` keeps its `[num_kv_heads, total_q, topk]` int32 layout with -1
+    padding; keep every correctness case passing. The score is the CUDA-graph
+    measured time over the same case list.
+  cheatsheet: null

--- a/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/scripts/forge_driver.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/scripts/task_runner.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/scripts/task_runner.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Harness for MiniMax-M3's block-sparse GQA prefill attention kernel
+``_gqa_sparse_fwd_kernel`` (vllm/models/minimax_m3/amd/ops/sparse_attn.py).
+
+The kernel is loaded from the editable workspace copy of the in-image source
+tree, so agent edits to amd/ops/sparse_attn.py take effect. Everything the module
+imports (common.ops.sparse_attn, vllm.platforms.rocm, vllm.triton_utils) is an
+absolute import and keeps resolving against the installed vllm package.
+
+Shapes, dtypes, sequence/prefix lengths and the launch geometry all come from the
+20260815T100002Z session trace; see session_cases.json. Correctness and
+performance run the SAME case list at the SAME sizes, and performance is measured
+under a CUDA/HIP graph.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MODEL_CONFIG = SPEC["model_config"]
+
+REPO_SUBDIR = "vllm_models_minimax_m3"
+KERNEL_FILE = Path("amd") / "ops" / "sparse_attn.py"
+EDIT_MODULE_NAME = "vllm.models.minimax_m3.amd.ops._ka_sparse_attn"
+
+# Reference chunk size over the query dimension. The gathered KV for one chunk is
+# chunk * topk * 128 * 256 elements; 128 keeps the fp32 working set around 400 MB.
+_REF_Q_CHUNK = 128
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _load_kernel_module():
+    # Import the package first so the edited copy's absolute imports resolve.
+    import vllm.models.minimax_m3.common.ops.sparse_attn  # noqa: F401
+
+    path = WORKSPACE / REPO_SUBDIR / KERNEL_FILE
+    spec = importlib.util.spec_from_file_location(EDIT_MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[EDIT_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Tiny stand-in used ONLY by the compile smoke test.
+
+    run_correctness and run_performance both iterate the full CASES list at the
+    session sizes.
+    """
+    p = dict(case["params"])
+    p["query_lens"] = [min(q, 256) for q in p["query_lens"]]
+    p["seq_lens"] = [min(s, 512) for s in p["seq_lens"]]
+    p["prefix_lens"] = [
+        min(pf, s - q) for pf, s, q in zip(p["prefix_lens"], p["seq_lens"], p["query_lens"])
+    ]
+    p["num_blocks"] = 512
+    return {**case, "params": p}
+
+
+def _make_topk_idx(torch, params, device):
+    """Deterministic, causally valid top-k block selection.
+
+    For query i of sequence b (absolute position ``prefix_lens[b] + i``) the
+    visible block count is ``ceil((pos+1)/128)``. We keep the local block (M3 sets
+    sparse_local_block=1) and fill the rest with a seeded random subset of the
+    remaining visible blocks, sorted ascending and right-padded with -1 -- the
+    layout the kernel expects (``real_topk = sum(topk_idx >= 0)``, entries read
+    sequentially).
+    """
+    topk = params["topk"]
+    blk = params["sparse_block_size"]
+    gen = torch.Generator(device=device).manual_seed(1234)
+
+    rows = []
+    for b, (q_len, prefix) in enumerate(zip(params["query_lens"], params["prefix_lens"])):
+        pos = prefix + torch.arange(q_len, device=device)
+        n_vis = (pos // blk) + 1  # [q_len]
+        local = n_vis - 1  # block containing the query
+        max_vis = int(n_vis.max().item())
+        # Random priority per (query, block); invisible blocks get +inf so they
+        # sort last, the local block gets the lowest priority so it always
+        # survives the cut.
+        pri = torch.rand((q_len, max_vis), generator=gen, device=device)
+        blocks = torch.arange(max_vis, device=device).unsqueeze(0)
+        pri = torch.where(blocks < n_vis.unsqueeze(1), pri, torch.inf)
+        # -1.0, not -inf: the finite check below is what separates "selected"
+        # from "padding", and -inf would classify the forced local block as
+        # padding. Queries below position 128 have the local block as their only
+        # visible block, so that would hand the kernel an empty selection.
+        pri.scatter_(1, local.unsqueeze(1), -1.0)
+        order = pri.argsort(dim=1)[:, :topk]  # [q_len, topk]
+        chosen = order.to(torch.int32)
+        keep = torch.gather(pri, 1, order).isfinite()
+        chosen = torch.where(keep, chosen, torch.full_like(chosen, 2**30))
+        chosen, _ = chosen.sort(dim=1)
+        chosen = torch.where(
+            chosen == 2**30, torch.full_like(chosen, -1), chosen
+        )
+        rows.append(chosen)
+    return torch.cat(rows, dim=0).unsqueeze(0).contiguous()  # [1, total_q, topk]
+
+
+def _make(case: dict) -> dict:
+    torch = _torch()
+    p = dict(case["params"])
+    dev = "cuda"
+    dtype = torch.bfloat16
+
+    batch = p["batch"]
+    query_lens = list(p["query_lens"])
+    seq_lens = list(p["seq_lens"])
+    prefix_lens = list(p["prefix_lens"])
+    total_q = sum(query_lens)
+    H, KVH, D = p["num_heads"], p["num_kv_heads"], p["head_dim"]
+    blk = p["sparse_block_size"]
+    max_blocks = (MODEL_CONFIG["max_model_len"] + blk - 1) // blk
+    # The page pool must cover every sequence's full block_table row.
+    num_blocks = max(p["num_blocks"], batch * max_blocks + 1)
+
+    torch.manual_seed(23)
+
+    q = torch.randn((total_q, H, D), device=dev, dtype=dtype)
+    output = torch.empty_like(q)
+    # Main KV cache: [num_blocks, num_kv_heads, 128, 2*head_dim], K then V.
+    kv_cache = torch.randn(
+        (num_blocks, KVH, blk, 2 * D), device=dev, dtype=dtype
+    )
+
+    # Non-contiguous page assignment, as a live server's allocator produces.
+    gen = torch.Generator(device="cpu").manual_seed(77)
+    perm = torch.randperm(num_blocks, generator=gen)[: batch * max_blocks]
+    block_table = perm.view(batch, max_blocks).to(dev, torch.int32).contiguous()
+
+    cu_seqlens_q = torch.zeros(batch + 1, device=dev, dtype=torch.int32)
+    cu_seqlens_q[1:] = torch.tensor(query_lens, device=dev, dtype=torch.int32).cumsum(0)
+    seq_lens_t = torch.tensor(seq_lens, device=dev, dtype=torch.int32)
+    prefix_lens_t = torch.tensor(prefix_lens, device=dev, dtype=torch.int32)
+
+    topk_idx = _make_topk_idx(torch, p, dev)
+
+    return {
+        "cfg": case,
+        "params": p,
+        "module": _load_kernel_module(),
+        "q": q,
+        "output": output,
+        "kv_cache": kv_cache,
+        "topk_idx": topk_idx,
+        "block_table": block_table,
+        "cu_seqlens_q": cu_seqlens_q,
+        "seq_lens": seq_lens_t,
+        "prefix_lens": prefix_lens_t,
+        "query_lens": query_lens,
+        "seq_lens_list": seq_lens,
+        "prefix_lens_list": prefix_lens,
+        "max_query_len": max(query_lens),
+        "num_kv_heads": KVH,
+        "num_heads": H,
+        "head_dim": D,
+        "sm_scale": D**-0.5,
+        "sparse_block_size": blk,
+    }
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh data inputs in place so a replayed graph consumes fresh values."""
+    torch = _torch()
+    torch.manual_seed(37)
+    inputs["q"].normal_()
+    inputs["kv_cache"].normal_()
+
+
+def _run(inputs: dict):
+    inputs["module"].minimax_m3_sparse_attn(
+        inputs["q"],
+        inputs["kv_cache"],
+        inputs["topk_idx"],
+        inputs["block_table"],
+        inputs["cu_seqlens_q"],
+        inputs["seq_lens"],
+        inputs["prefix_lens"],
+        inputs["max_query_len"],
+        inputs["num_kv_heads"],
+        inputs["sm_scale"],
+        inputs["output"],
+    )
+    return inputs["output"]
+
+
+def _reference(inputs: dict):
+    """Block-sparse GQA attention reference.
+
+    Vectorized over (queries in a chunk) x (selected blocks) x (positions in a
+    block) x (heads); the only Python loop is the chunking over the query
+    dimension, which exists to bound the gathered-KV working set.
+
+    Semantics taken from the kernel body (sparse_attn.py:119-235):
+      * absolute query position = prefix_lens[b] + i
+      * a selected block ``blk`` covers KV positions ``blk*128 + [0,128)``
+      * a position is valid iff ``pos < seq_lens[b]`` (kernel: pos_mask_sub) AND
+        ``pos <= prefix + i`` (kernel: off_q_sub >= c, i.e. causal)
+      * K is kv_cache[page, kvh, :, :head_dim], V is [..., head_dim:]
+    """
+    torch = _torch()
+    H = inputs["num_heads"]
+    KVH = inputs["num_kv_heads"]
+    D = inputs["head_dim"]
+    blk = inputs["sparse_block_size"]
+    scale = inputs["sm_scale"]
+    group = H // KVH
+    kv_cache = inputs["kv_cache"]
+    topk = inputs["topk_idx"].shape[-1]
+
+    out = torch.empty(
+        (inputs["q"].shape[0], H, D), device=inputs["q"].device, dtype=torch.float32
+    )
+    pos_in_blk = torch.arange(blk, device=kv_cache.device)
+
+    q_off = 0
+    for b, q_len in enumerate(inputs["query_lens"]):
+        prefix = inputs["prefix_lens_list"][b]
+        seq_len = inputs["seq_lens_list"][b]
+        bt = inputs["block_table"][b].long()
+        for c0 in range(0, q_len, _REF_Q_CHUNK):
+            c1 = min(c0 + _REF_Q_CHUNK, q_len)
+            n = c1 - c0
+            g0 = q_off + c0
+
+            idx = inputs["topk_idx"][:, g0 : g0 + n, :]  # [KVH, n, topk]
+            valid = idx >= 0
+            safe = idx.clamp(min=0).long()
+            pages = bt[safe]  # [KVH, n, topk]
+
+            kvh_ids = torch.arange(KVH, device=kv_cache.device).view(KVH, 1, 1)
+            kv = kv_cache[pages, kvh_ids.expand_as(pages)]  # [KVH,n,topk,blk,2D]
+            k = kv[..., :D].float()
+            v = kv[..., D:].float()
+
+            # [KVH, n, topk, blk] absolute KV positions and their validity
+            pos = safe.unsqueeze(-1) * blk + pos_in_blk
+            qpos = (prefix + torch.arange(c0, c1, device=kv_cache.device)).view(
+                1, n, 1, 1
+            )
+            ok = valid.unsqueeze(-1) & (pos < seq_len) & (pos <= qpos)
+
+            qc = inputs["q"][g0 : g0 + n].float().view(n, KVH, group, D)
+            qc = qc.permute(1, 0, 2, 3)  # [KVH, n, group, D]
+
+            # [KVH, n, group, topk*blk]
+            scores = torch.einsum("hngd,hntpd->hngtp", qc, k)
+            scores = scores.reshape(KVH, n, group, topk * blk) * scale
+            mask = ok.reshape(KVH, n, 1, topk * blk)
+            scores = scores.masked_fill(~mask, float("-inf"))
+            probs = torch.softmax(scores, dim=-1)
+            probs = torch.nan_to_num(probs, nan=0.0)
+
+            vv = v.reshape(KVH, n, topk * blk, D)
+            o = torch.einsum("hngs,hnsd->hngd", probs, vv)  # [KVH,n,group,D]
+            out[g0 : g0 + n] = o.permute(1, 0, 2, 3).reshape(n, H, D)
+
+            del kv, k, v, scores, probs, vv, o
+        q_off += q_len
+
+    return out.to(inputs["output"].dtype)
+
+
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.08, rtol=0.08)
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    inputs["output"].fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **{k: v for k, v in case["params"].items()},
+            "model": case.get("model"),
+            "session_id": case.get("session_id"),
+            "phase": case.get("phase"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/session_cases.json
+++ b/tasks/minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3/session_cases.json
@@ -1,0 +1,157 @@
+{
+  "source_day": "2026-08-15",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.26.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.26.0",
+  "task_name": "mi355x-minimax-m3-gqa-sparse-attn-prefill-20260815",
+  "operator": "gqa_sparse_attn_prefill",
+  "selection": "hot leaf _gqa_sparse_fwd_kernel, 8.53% of normalized E2E GPU time (rank #3 of the whole session), 21.20% of every chunked-prefill step",
+  "provenance": {
+    "model": "MiniMax-M3-MXFP4",
+    "session_id": "20260815T100002Z",
+    "session_path": "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260815T100002Z",
+    "trace": "runs/roofline/ca746c43c5564616b0ff91a3582c73ab/benchmark_vllm_20260815_111805/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1786793700435294667.pt.trace.json.gz",
+    "workload": "ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312 / TP=8 / quark MXFP4",
+    "device_kernel": "_gqa_sparse_fwd_kernel",
+    "entry": "vllm/models/minimax_m3/amd/ops/sparse_attn.py:73 (kernel), launcher minimax_m3_sparse_attn() at :243, launch at :286",
+    "call_chain": "MiniMaxM3SparseForConditionalGeneration -> models/minimax_m3/amd/model.py -> minimax_m3_sparse_attn",
+    "phase": "prefill only -- 57 calls per chunked-prefill step (one per block-sparse layer), 0 calls in pure-decode steps",
+    "measured": {
+      "normalized_e2e_pct": 8.53,
+      "prefill_step_pct": 21.2,
+      "decode_step_pct": 0.0,
+      "calls_per_prefill_step": 57,
+      "us_per_call": 720.0,
+      "grid": "(max_query_len, num_kv_heads, batch) -- measured (8131,1,1) x57, (8132,1,1) x57, (8073,1,2) x57, (61,1,1) x57",
+      "block": "(64,1,1) -- one wavefront, because _sparse_attn_prefill_kwargs() sets num_warps=1",
+      "achieved_tflops": 83.6,
+      "pct_of_bf16_peak": 3.6,
+      "note": "BLOCK_SIZE_Q=1 means one CTA handles a single query token, so the QK GEMM has M=8 (the GQA group width) and cannot fill an MFMA_16x16 tile. Effective FLOPs use the causal-corrected average of 14.11 selected blocks per query (queries below position 2048 see fewer than topk=16 blocks)."
+    },
+    "shape_evidence": "grid dims read directly off the kernel events; batch = grid[2], max_query_len = grid[0]. Query/sequence lengths cross-checked against the step annotations execute_8192_context_1(sq8131sk8131...), context_1(sq8132sk8132...), context_2(sq8133sk16265...) and execute_121_context_1(sq61sk8192...). num_blocks=41215 and the kv_cache layout [41215,1,128,256] bf16 come from _C::fused_minimax_m3_qknorm_rope_kv_insert arg 15 in the bs=64 capture trace.",
+    "constants_evidence": "num_heads=8 = 64/TP8, num_kv_heads=1 = max(1, 4/TP8), head_dim=128, topk=16 (sparse_topk_blocks), BLOCK_SIZE_K=128 (sparse_block_size), SUB_K=64 (= 128//2 because on_gfx950() is true, sparse_attn.py:28), USE_FP8=False and KV_SCALE_MODE=0 (kv_cache_dtype=auto -> bf16), launch kwargs num_warps=1 / matrix_instr_nonkdim=16 / kpack=2 / num_stages=1 (_sparse_attn_prefill_kwargs, sparse_attn.py:33) -- consistent with the measured block (64,1,1).",
+    "harness_agreement": "harness 0.7175 ms at m3-prefill-b1-q8131-prefix0 vs 720.0 us/call in the session trace -- 99.7% agreement."
+  },
+  "model_config": {
+    "num_heads_per_rank": 8,
+    "num_kv_heads_per_rank": 1,
+    "head_dim": 128,
+    "sparse_block_size": 128,
+    "sparse_topk_blocks": 16,
+    "sparse_init_block": 0,
+    "sparse_local_block": 1,
+    "num_blocks": 41215,
+    "max_model_len": 13312,
+    "max_num_batched_tokens": 8192,
+    "dtype": "bf16"
+  },
+  "shape_notes": {
+    "kv_cache_size": "The cache is allocated at the session's real 41215 blocks (2.70 GB) and each sequence is given a shuffled, non-contiguous page set, so the kernel sees the address spread it sees in production rather than one tight contiguous range.",
+    "topk_idx": "Generated deterministically per query: block ids drawn from the causally visible range [0, ceil((prefix+i+1)/128)), always including the local block (sparse_local_block=1), sorted ascending and right-padded with -1. Queries below position 2048 therefore carry fewer than 16 entries, which is what makes the measured average 14.11 blocks/query."
+  },
+  "cases": [
+    {
+      "id": "m3-prefill-b1-q8131-prefix0",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "chunked-prefill step, first chunk of an 8192-token prompt (37 of the 40 sampled prefill steps)",
+      "gpu_pct": 21.2,
+      "params": {
+        "batch": 1,
+        "query_lens": [
+          8131
+        ],
+        "seq_lens": [
+          8131
+        ],
+        "prefix_lens": [
+          0
+        ],
+        "num_heads": 8,
+        "num_kv_heads": 1,
+        "head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "num_blocks": 41215,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "q (8131,8,128) bf16",
+        "kv_cache (41215,1,128,256) bf16",
+        "topk_idx (1,8131,16) int32",
+        "block_table (1,104) int32",
+        "grid (8131,1,1) block (64,1,1)"
+      ]
+    },
+    {
+      "id": "m3-prefill-b2-q8073p60",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "chunked-prefill step with two context sequences (annotation context_2(sq8133 sk16265))",
+      "gpu_pct": null,
+      "params": {
+        "batch": 2,
+        "query_lens": [
+          8073,
+          60
+        ],
+        "seq_lens": [
+          8073,
+          8192
+        ],
+        "prefix_lens": [
+          0,
+          8132
+        ],
+        "num_heads": 8,
+        "num_kv_heads": 1,
+        "head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "num_blocks": 41215,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "q (8133,8,128) bf16",
+        "kv_cache (41215,1,128,256) bf16",
+        "topk_idx (1,8133,16) int32",
+        "block_table (2,104) int32",
+        "grid (8073,1,2) block (64,1,1)"
+      ]
+    },
+    {
+      "id": "m3-prefill-b1-q61-prefix8131",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "chunked-prefill tail chunk (annotation execute_121_context_1(sq61 sk8192))",
+      "gpu_pct": null,
+      "params": {
+        "batch": 1,
+        "query_lens": [
+          61
+        ],
+        "seq_lens": [
+          8192
+        ],
+        "prefix_lens": [
+          8131
+        ],
+        "num_heads": 8,
+        "num_kv_heads": 1,
+        "head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "num_blocks": 41215,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "q (61,8,128) bf16",
+        "kv_cache (41215,1,128,256) bf16",
+        "topk_idx (1,61,16) int32",
+        "block_table (1,104) int32",
+        "grid (61,1,1) block (64,1,1)"
+      ]
+    }
+  ]
+}

--- a/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/config.yaml
+++ b/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/config.yaml
@@ -1,0 +1,57 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/vllm/v1/attention/ops
+repo_subdir: vllm_v1_attention_ops
+image_repo_exclude:
+- __pycache__
+repository_language: triton
+source_file_path:
+- chunked_prefill_paged_decode.py
+target_kernel_functions:
+- kernel_paged_attention_2d
+kernel_identity:
+  logical_operator: paged_attention_2d
+  kernel_kind: triton
+  source_owner: vllm
+  workload:
+    source: session_cases.json
+    primary_case: m3-decode-bs64-ctx9098
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize the Triton decode paged-attention kernel `kernel_paged_attention_2d`
+    in `chunked_prefill_paged_decode.py` on MI355X/gfx950, for the MiniMax-M3-MXFP4
+    serving regime (block_size=128, head_size=128, GQA 8:1, BF16 KV, per-sequence
+    context ~9098 tokens, batch 61-64).
+
+    Why this kernel is on the critical path: MiniMax-M3 sets block_size=128 because
+    its 57 block-sparse attention layers require sparse_block_size=128. vLLM's
+    hand-written ROCm asm paged attention only accepts block_size 16 or 32
+    (vllm/platforms/rocm.py:346 `use_rocm_custom_paged_attention`), so the 3 dense
+    attention layers fall back to this Triton kernel. It is 11.35% of normalized
+    end-to-end GPU time in the source session -- the second largest kernel overall,
+    and 17.76% of every pure-decode step.
+
+    The measured problem: at batch 64 / ctx 9098 the kernel reads 298 MB of KV per
+    call in 1168 us, i.e. 255 GB/s -- 3.2% of the 8 TB/s HBM peak. The launch grid
+    is `(num_seqs, num_kv_heads)` = (64, 1): 64 workgroups on 256 CUs, with each CTA
+    serially walking its own sequence's entire 9098-token KV. There is no split over
+    the KV length. For comparison, `_decode_index_score_kernel` in the same trace
+    splits the KV into 8 chunks and reaches 5.32 TB/s on the same hardware.
+
+    Suggested direction (not binding): introduce a KV split-K dimension plus a
+    reduction pass, in the shape of `kernel_unified_attention_3d` + `reduce_segments`
+    in aiter's `ops/triton/_triton_kernels/attention/unified_attention.py`. The chunk
+    count must be derivable from shape constants only, because vLLM captures the
+    decode path in a CUDA graph.
+
+    Constraints: do not change the public signature of `chunked_prefill_paged_decode`
+    or of `kernel_paged_attention_2d`; keep every correctness case passing; the score
+    is the CUDA-graph-measured time over the same case list.
+  cheatsheet: null

--- a/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/scripts/forge_driver.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/scripts/task_runner.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/scripts/task_runner.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Harness for the vLLM Triton decode paged-attention kernel
+``kernel_paged_attention_2d`` as MiniMax-M3-MXFP4 drives it (block_size=128).
+
+The kernel is loaded from the editable workspace copy of the in-image source tree
+so an optimizing agent's edits to chunked_prefill_paged_decode.py take effect.
+
+Shapes, dtypes and context lengths come from the 20260815T100002Z session trace;
+see session_cases.json. Correctness and performance run the SAME case list at the
+SAME sizes, and performance is measured under a CUDA/HIP graph.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+
+REPO_SUBDIR = "vllm_v1_attention_ops"
+KERNEL_FILE = "chunked_prefill_paged_decode.py"
+# Dotted name so the edited copy's relative `from .prefix_prefill import ...`
+# resolves against the installed vllm package.
+EDIT_MODULE_NAME = "vllm.v1.attention.ops._ka_chunked_prefill_paged_decode"
+
+# q/k/v are slices of one fused qkv buffer in the model, so the query row stride
+# is 8*128 (q) + 128 (k) + 128 (v) = 1280, not 8*128. Reproduced here because a
+# non-unit row stride changes the kernel's global-load pattern.
+QKV_ROW_STRIDE = 1280
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _load_kernel_module():
+    import vllm.v1.attention.ops.prefix_prefill  # noqa: F401
+
+    path = WORKSPACE / REPO_SUBDIR / KERNEL_FILE
+    spec = importlib.util.spec_from_file_location(EDIT_MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[EDIT_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    """Small stand-in used ONLY by the compile smoke test.
+
+    run_correctness and run_performance both iterate the full CASES list at the
+    session sizes; this shrink exists so `compile` stays a few-second check.
+    """
+    smoke = {**case, "params": dict(case["params"])}
+    smoke["params"]["num_seqs"] = min(case["params"]["num_seqs"], 8)
+    smoke["params"]["num_padded_tokens"] = min(
+        case["params"]["num_padded_tokens"], 8
+    )
+    smoke["params"]["ctx_len"] = min(case["params"]["ctx_len"], 512)
+    smoke["params"]["num_blocks"] = 512
+    return smoke
+
+
+def _make(case: dict) -> dict:
+    torch = _torch()
+    p = dict(case["params"])
+    num_seqs = p["num_seqs"]
+    num_padded = max(p["num_padded_tokens"], num_seqs)
+    num_query_heads = p["num_query_heads"]
+    num_kv_heads = p["num_kv_heads"]
+    head_size = p["head_size"]
+    block_size = p["block_size"]
+    ctx_len = p["ctx_len"]
+    dtype = torch.bfloat16
+    scale = head_size**-0.5
+
+    torch.manual_seed(23)
+
+    # Fused qkv buffer -> query/key/value are strided views, as in the model.
+    row = max(QKV_ROW_STRIDE, (num_query_heads + 2 * num_kv_heads) * head_size)
+    qkv = torch.randn((num_padded, row), device="cuda", dtype=dtype)
+    query = qkv[:, : num_query_heads * head_size].view(
+        num_padded, num_query_heads, head_size
+    )
+    out_buf = torch.empty(
+        (num_padded, num_query_heads * head_size), device="cuda", dtype=dtype
+    )
+    output = out_buf.view(num_padded, num_query_heads, head_size)
+
+    # Decode batch: one query token per sequence, occupying rows [0, num_seqs).
+    query_start_loc = torch.arange(num_seqs + 1, device="cuda", dtype=torch.int32)
+    seq_lens = torch.full((num_seqs,), ctx_len, device="cuda", dtype=torch.int32)
+
+    # Contiguous per-sequence context KV. Drives both the paged cache the kernel
+    # reads and the reference, so the two always describe the same workload.
+    key = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+    value = torch.randn(
+        (num_seqs, ctx_len, num_kv_heads, head_size), device="cuda", dtype=dtype
+    )
+
+    # Allocate the session's real cache size and scatter each sequence's pages
+    # across it. A tight per-sequence range would let the 298 MB working set sit
+    # in the 256 MB Infinity Cache across graph replays and understate the cost
+    # by ~3x (measured: 0.38 ms contiguous vs 1.14 ms fragmented, against the
+    # session's 1.168 ms).
+    pages_per_seq = (ctx_len + block_size - 1) // block_size
+    num_blocks = max(p.get("num_blocks", 0), num_seqs * pages_per_seq + 1)
+
+    kv_cache = torch.zeros(
+        (2, num_blocks, block_size, num_kv_heads, head_size),
+        device="cuda",
+        dtype=dtype,
+    )
+    from vllm.v1.attention.ops.paged_attn import PagedAttention
+
+    key_cache, value_cache = PagedAttention.split_kv_cache(
+        kv_cache, num_kv_heads, head_size
+    )
+
+    gen = torch.Generator(device="cpu").manual_seed(77)
+    block_table = (
+        torch.randperm(num_blocks, generator=gen)[: num_seqs * pages_per_seq]
+        .view(num_seqs, pages_per_seq)
+        .to("cuda", torch.int32)
+        .contiguous()
+    )
+
+    seq_idx = torch.arange(num_seqs, device="cuda").view(-1, 1).expand(-1, ctx_len)
+    pos = torch.arange(ctx_len, device="cuda").view(1, -1).expand(num_seqs, -1)
+    phys_block = block_table[seq_idx, pos // block_size].long()
+    slot_mapping = (phys_block * block_size + (pos % block_size)).reshape(-1)
+
+    one = torch.ones(1, device="cuda", dtype=torch.float32)
+
+    inputs = {
+        "cfg": case,
+        "module": _load_kernel_module(),
+        "qkv": qkv,
+        "query": query,
+        "output": output,
+        "out_buf": out_buf,
+        "key": key,
+        "value": value,
+        "key_cache": key_cache,
+        "value_cache": value_cache,
+        "block_table": block_table,
+        "query_start_loc": query_start_loc,
+        "seq_lens": seq_lens,
+        "max_seq_len": ctx_len,
+        "scale": scale,
+        "one": one,
+        "slot_mapping": slot_mapping,
+        "num_seqs": num_seqs,
+        "num_kv_heads": num_kv_heads,
+        "num_query_heads": num_query_heads,
+        "head_size": head_size,
+    }
+    _fill_kv_cache(inputs)
+    return inputs
+
+
+def _fill_kv_cache(inputs: dict) -> None:
+    """Page the contiguous key/value into the cache the kernel reads."""
+    import vllm._custom_ops as ops
+
+    num_kv_heads = inputs["num_kv_heads"]
+    head_size = inputs["head_size"]
+    ops.reshape_and_cache(
+        inputs["key"].reshape(-1, num_kv_heads, head_size),
+        inputs["value"].reshape(-1, num_kv_heads, head_size),
+        inputs["key_cache"],
+        inputs["value_cache"],
+        inputs["slot_mapping"],
+        "auto",
+        inputs["one"],
+        inputs["one"],
+    )
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    """Refresh data inputs in place with values no earlier launch has seen.
+
+    A replayed CUDA graph reads the captured input addresses, so writing through
+    them changes what the scored kernel consumes.
+    """
+    torch = _torch()
+    torch.manual_seed(37)
+    inputs["qkv"].normal_()
+    inputs["key"].normal_()
+    inputs["value"].normal_()
+    _fill_kv_cache(inputs)
+
+
+def _run(inputs: dict):
+    inputs["module"].chunked_prefill_paged_decode(
+        query=inputs["query"][: inputs["num_seqs"]],
+        key=None,
+        value=None,
+        output=inputs["output"][: inputs["num_seqs"]],
+        kv_cache_dtype="auto",
+        key_cache=inputs["key_cache"],
+        value_cache=inputs["value_cache"],
+        block_table=inputs["block_table"],
+        query_start_loc=inputs["query_start_loc"],
+        seq_lens=inputs["seq_lens"],
+        max_seq_len=inputs["max_seq_len"],
+        max_query_len=1,
+        k_scale=inputs["one"],
+        v_scale=inputs["one"],
+        sm_scale=inputs["scale"],
+        causal=True,
+    )
+    return inputs["output"][: inputs["num_seqs"]]
+
+
+def _reference(inputs: dict):
+    """Fully vectorized decode attention reference (no per-sequence loop).
+
+    GQA is handled by folding the group width into the query tensor rather than
+    broadcasting the KV heads, so the expanded KV is never materialized. Peak
+    intermediate is the score tensor [S, Hkv, group, ctx] in fp32, e.g.
+    64*1*8*9216*4 = 18.9 MB for the largest case.
+    """
+    torch = _torch()
+    S = inputs["num_seqs"]
+    Hkv = inputs["num_kv_heads"]
+    D = inputs["head_size"]
+    group = inputs["num_query_heads"] // Hkv
+
+    q = inputs["query"][:S].float().view(S, Hkv, group, D)  # [S, Hkv, g, D]
+    k = inputs["key"].float()  # [S, ctx, Hkv, D]
+    v = inputs["value"].float()
+
+    scores = torch.einsum("shgd,skhd->shgk", q, k) * inputs["scale"]
+    probs = torch.softmax(scores, dim=-1)
+    out = torch.einsum("shgk,skhd->shgd", probs, v)
+    return out.reshape(S, Hkv * group, D).to(inputs["output"].dtype)
+
+
+def _assert_close(inputs: dict, got) -> None:
+    _torch().testing.assert_close(got, _reference(inputs), atol=0.08, rtol=0.08)
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed."""
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    inputs["out_buf"].fill_(float("nan"))
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    inputs = _make(_compile_smoke_case(CASES[0]))
+    _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "session_id": case.get("session_id"),
+            "phase": case.get("phase"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/session_cases.json
+++ b/tasks/minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3/session_cases.json
@@ -1,0 +1,140 @@
+{
+  "source_day": "2026-08-15",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.26.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.26.0",
+  "task_name": "mi355x-minimax-m3-paged-attention-2d-20260815",
+  "operator": "paged_attention_2d",
+  "selection": "hot leaf kernel_paged_attention_2d, 11.35% of normalized E2E GPU time (rank #2 of the whole session); Triton fallback forced by block_size=128",
+  "provenance": {
+    "model": "MiniMax-M3-MXFP4",
+    "session_id": "20260815T100002Z",
+    "session_path": "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260815T100002Z",
+    "trace": "runs/roofline/ca746c43c5564616b0ff91a3582c73ab/benchmark_vllm_20260815_111805/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1786793700435294667.pt.trace.json.gz",
+    "workload": "ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312 / TP=8 / quark MXFP4",
+    "device_kernel": "kernel_paged_attention_2d",
+    "entry": "vllm/v1/attention/ops/chunked_prefill_paged_decode.py:46 (kernel), launched at :447 by chunked_prefill_paged_decode",
+    "call_chain": "vllm::unified_attention_with_output -> v1/attention/backends/rocm_attn.py -> chunked_prefill_paged_decode -> kernel_paged_attention_2d",
+    "why_triton": "vllm/platforms/rocm.py:346 use_rocm_custom_paged_attention() requires block_size in {16,32}; MiniMax-M3 runs block_size=128 (forced by sparse_block_size=128), so the hand-written ROCm asm paged attention is rejected. head_size=128 and gqa_ratio=8 would both have been accepted. server.log:'Cannot use ROCm custom paged attention kernel, falling back to Triton implementation.'",
+    "layers": "only the 3 dense-attention layers use this path; the other 57 layers are block-sparse (sparse_attention_freq = [0,0,0,1,...,1])",
+    "measured": {
+      "normalized_e2e_pct": 11.35,
+      "prefill_step_pct": 1.82,
+      "decode_step_pct": 17.76,
+      "calls_per_step": 3,
+      "us_per_call_prefill_step": 1172.3,
+      "us_per_call_decode_step": 1167.6,
+      "grid": "(num_seqs, num_kv_heads) -- measured (61,1) in chunked-prefill steps, (64,1) in pure-decode steps",
+      "block": "(256,1,1)",
+      "achieved_bandwidth_GBs": 255,
+      "pct_of_hbm_peak": 3.2,
+      "note": "64 workgroups on 256 CUs with no split-K over the KV length. The same trace's _decode_index_score_kernel, which does split over 8 KV chunks, reaches 5.32 TB/s -- 21x the bandwidth efficiency.",
+      "harness_agreement": "1.135 ms measured by this harness at m3-decode-bs64-ctx9098 vs 1.168 us/call in the session trace -- 97% agreement."
+    },
+    "shape_evidence": "torch profiler cpu_op vllm::unified_attention_with_output Input Dims: prefill step [[8192,8,128],[8192,1,128],[8192,1,128],[8192,8,128]] bf16 with query stride [1280,128,1]; decode step (capture_64_FULL) [[64,8,128],[64,1,128],[64,1,128],[64,8,128]] bf16. num_blocks=41215 from _C::fused_minimax_m3_qknorm_rope_kv_insert arg 15 [41215,1,128,256]. seq_lens from the decode-step annotation generation_64(sq64 sk582305) -> 64 sequences, 582305 KV tokens, mean 9098."
+  },
+  "shape_notes": {
+    "why_decode_only_batches": "In a chunked-prefill step this kernel does NOT see the 8133 prefill tokens: chunked_prefill_paged_decode passes filter_by_query_len=True and the kernel returns immediately for any row with query_len > 1 (chunked_prefill_paged_decode.py:92-97). Its real work in a prefill step is exactly the 61 piggybacked query-len-1 rows, which is why the measured per-call cost is the same in both step types (1172 vs 1168 us). Cases m3-chunkedstep-* therefore reproduce that invocation as a 61-row decode batch and additionally pad the query buffer to 8192 rows so the kernel sees the real query stride.",
+    "query_stride": "q/k/v are slices of one fused qkv buffer: query stride is [1280,128,1] (1280 = 8*128 q + 1*128 k + 1*128 v). The harness reproduces this rather than passing a contiguous [S,8,128] tensor, because a non-unit row stride changes the kernel's load pattern.",
+    "ctx_len_range": "A request holds 8192 prompt tokens and generates up to 1024, so decode-step context length sweeps 8192 -> 9216 across a request's lifetime. The sampled window measured a mean of 9098. All three points are kept.",
+    "kv_cache_size": "The cache is allocated at the session's real 41215 blocks (2.70 GB for K+V) and each sequence gets a seeded shuffled page set. This is load-bearing, not cosmetic: with a tight per-sequence contiguous range the 298 MB working set stays resident in the 256 MB Infinity Cache across CUDA-graph replays and the kernel measures 0.38 ms instead of 1.14 ms. The fragmented full-size cache reproduces the session's 1.168 ms to within 3%."
+  },
+  "cases": [
+    {
+      "id": "m3-decode-bs64-ctx9098",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "decode step",
+      "gpu_pct": 17.76,
+      "params": {
+        "num_seqs": 64,
+        "num_padded_tokens": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 128,
+        "block_size": 128,
+        "ctx_len": 9098,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16",
+        "num_blocks": 41215
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,128) bf16 stride (1280,128,1)",
+        "K/V step (64,1,128) bf16",
+        "seq_lens (64,) int32 = 9098",
+        "block_table (64,72) int32"
+      ]
+    },
+    {
+      "id": "m3-decode-bs64-ctx8192",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "decode step (start of generation)",
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_padded_tokens": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 128,
+        "block_size": 128,
+        "ctx_len": 8192,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16",
+        "num_blocks": 41215
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,128) bf16 stride (1280,128,1)",
+        "K/V step (64,1,128) bf16"
+      ]
+    },
+    {
+      "id": "m3-decode-bs64-ctx9216",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "decode step (end of generation, ISL+OSL)",
+      "gpu_pct": null,
+      "params": {
+        "num_seqs": 64,
+        "num_padded_tokens": 64,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 128,
+        "block_size": 128,
+        "ctx_len": 9216,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16",
+        "num_blocks": 41215
+      },
+      "trace_input_shapes": [
+        "Q/O (64,8,128) bf16 stride (1280,128,1)",
+        "K/V step (64,1,128) bf16"
+      ]
+    },
+    {
+      "id": "m3-chunkedstep-bs61-ctx9098",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "phase": "chunked-prefill step (the 61 piggybacked decode rows; query buffer padded to max_num_batched_tokens=8192)",
+      "gpu_pct": 1.82,
+      "params": {
+        "num_seqs": 61,
+        "num_padded_tokens": 8192,
+        "num_query_heads": 8,
+        "num_kv_heads": 1,
+        "head_size": 128,
+        "block_size": 128,
+        "ctx_len": 9098,
+        "kv_cache_dtype": "auto",
+        "dtype": "bf16",
+        "num_blocks": 41215
+      },
+      "trace_input_shapes": [
+        "Q/O buffer (8192,8,128) bf16 stride (1280,128,1), 61 valid rows",
+        "K/V buffer (8192,1,128) bf16",
+        "measured grid (61,1,1)"
+      ]
+    }
+  ]
+}

--- a/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/config.yaml
+++ b/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/config.yaml
@@ -1,0 +1,78 @@
+task_type: image_kernel
+image_repo_path: /usr/local/lib/python3.12/dist-packages/vllm/models/minimax_m3
+repo_subdir: vllm_models_minimax_m3
+image_repo_exclude:
+- __pycache__
+- nvidia
+repository_language: triton
+source_file_path:
+- amd/ops/index_topk.py
+editable_sources:
+- common/ops/index_topk.py
+target_kernel_functions:
+- _decode_index_score_kernel
+- _topk_index_partial_kernel
+- _topk_index_merge_kernel
+- _index_block_score_kernel
+- _topk_index_kernel
+- minimax_m3_index_decode
+- minimax_m3_index_score
+- minimax_m3_index_topk
+kernel_identity:
+  logical_operator: sparse_index_topk
+  kernel_kind: triton
+  source_owner: vllm
+  workload:
+    source: session_cases.json
+    primary_case: m3-decodepath-bs64-ctx9098
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+task_result_template: null
+prompt:
+  source_code: null
+  instructions: >-
+    Optimize MiniMax-M3's sparse block-selection chain in
+    `vllm/models/minimax_m3/amd/ops/index_topk.py` on MI355X/gfx950.
+
+    This chain decides, for every query token of every one of the 57 block-sparse
+    layers, which 16 of the up-to-104 128-token KV blocks the attention kernel will
+    read. It produces no attention output -- it is pure overhead that block-sparse
+    attention pays -- and it costs 8.01% of normalized end-to-end GPU time in the
+    source session, versus 3.53% for the kernel that actually computes sparse
+    decode attention.
+
+    Two paths, both scored:
+      decode  `minimax_m3_index_decode()` -> `_decode_index_score_kernel` (5.23%)
+              + `_topk_index_partial_kernel` (0.96%) + `_topk_index_merge_kernel`
+              (0.77%)
+      prefill `minimax_m3_index_score()` -> `_index_block_score_kernel` (0.89%),
+              then `minimax_m3_index_topk()` -> `_topk_index_kernel` (0.16%)
+
+    Where the headroom is: `_decode_index_score_kernel` already reaches 5.32 TB/s,
+    66.5% of the 8 TB/s HBM peak, so it is close to its roof and squeezing it
+    further will not pay. The opportunity is the *chain*, not the individual
+    kernels. At batch 64 with `max_block = 104` the top-16 selection is split into
+    a partial pass over 8 chunks plus a merge pass (1.73% combined) over a
+    [1, 64, 112] fp32 score buffer -- a tiny problem that is paying two kernel
+    launches and a round trip through global memory. Fusing the selection into the
+    score pass, or collapsing partial+merge into one pass, is the direction worth
+    exploring.
+
+    Hard constraint -- the decode path is captured in a CUDA graph. Every launch
+    grid and every intermediate buffer shape must be derivable from shape constants
+    alone (that is why `num_kv_chunks` is computed from `TARGET_GRID` rather than
+    from `seq_lens`, and why the score stride is rounded up to a multiple of 16).
+    Anything that makes a grid depend on runtime tensor values will break capture.
+
+    Other constraints: `minimax_m3_index_decode`, `minimax_m3_index_score` and
+    `minimax_m3_index_topk` keep their public signatures, including the `out=`
+    buffer contract (write into `out[:, :total_q, :]`); the returned `topk_idx`
+    keeps its `[num_idx_heads, total_q, topk]` int32 layout with -1 padding and
+    the forced init/local blocks (`sparse_init_block=0`, `sparse_local_block=1`).
+    Intermediate buffer layouts between the passes are yours to change. The score
+    is the CUDA-graph measured time over the same case list.
+  cheatsheet: null

--- a/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/scripts/forge_driver.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/scripts/forge_driver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver (generic, delegates to the task's task_runner).
+
+Why this file exists
+--------------------
+The Arena forge launcher (``agents/forge/launch_agent.py``) prefers a
+task-shipped ``scripts/forge_driver.py`` and copies it VERBATIM to the run
+workspace root as ``forge_driver.py``. If it is absent, the launcher generates a
+generic shim that delegates to ``arena_task_adapter`` — which does NOT implement
+``--profile-run`` — so forge-loop's pre-loop "task preparation" then spends an
+LLM agent (minutes) authoring/repairing a profiling-capable driver every run.
+
+Shipping this file makes forge-loop's driver preflight pass on the first check
+(correctness + graph-timed bench + profiling), so task preparation is skipped
+entirely and no per-run driver authoring can fail.
+
+How it satisfies the contract without per-kernel reimplementation
+-----------------------------------------------------------------
+Every image_kernel ``scripts/task_runner.py`` in this suite exposes the same
+canonical entry points: ``_configure`` / ``_torch`` / ``_make(case)``
+/ ``_run(inputs)`` / ``run_correctness()`` / ``run_performance()`` (the latter
+writes ``build/performance_report.json`` and times under a CUDA/HIP graph via
+``_benchmark_cuda_graph_or_events``). This driver REUSES those, so it measures
+exactly the same op — and per-operator correctness reference — that Arena scores.
+No kernel-specific math is duplicated here, which is why the file is identical
+across the tasks that share this task_runner shape.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout — see kernel_agents.mcp_server.tools.{test,bench} and
+kernel_agents.loop.task_preparer.DRIVER_CONTRACT_SPEC):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        runs the task's own ``run_correctness()`` (per-operator reference +
+        tolerance) and prints ``allclose: True/False``. We deliberately do NOT
+        print an ``SNR: <db> dB`` line: these quantized / attention ops sit below
+        forge's default 30 dB SNR gate, so emitting SNR would fail even the
+        PRISTINE kernel. ``allclose`` is a valid contract fallback (test tool:
+        SNR preferred, allclose otherwise).
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        runs the task's own ``run_performance()`` (graph-timed) and then, from
+        the ``build/performance_report.json`` it wrote, prints
+        ``case_ms: <case_id> <ms>`` for every case plus a single ``mean_ms: <ms>``
+        aggregate (arithmetic mean across cases, matching Arena's evaluator). The
+        real CUDA/HIP-graph replays satisfy forge-loop's graph probe.
+
+  * Profiling    ``--profile-run``
+        builds ONE case's inputs (``_make(case)``) and launches
+        ONLY the target region (``_run``): a few warmups to settle Triton JIT, a
+        couple of profiled launches, one synchronize, exit 0. No timing printed.
+
+This file is the correctness ORACLE and perf MEASURER; forge-loop never edits it.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness (scripts/task_runner.py), robustly.
+
+    In a real run the launcher copies this file to ``<workspace>/forge_driver.py``
+    while task_runner stays at ``<workspace>/scripts/task_runner.py``; when run
+    in place from the task dir both files sit in ``scripts/``. Search both.
+    """
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        tr = cand / "task_runner.py"
+        if tr.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", tr)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = mod
+            spec.loader.exec_module(mod)
+            return mod, cand
+    raise RuntimeError(f"task_runner.py not found near {here}")
+
+
+def _report_path(tr) -> Path:
+    return Path(tr.WORKSPACE) / "build" / "performance_report.json"
+
+
+def _run_correctness(tr) -> int:
+    """Delegate to the task's own per-operator correctness; map to allclose."""
+    ok = True
+    try:
+        tr.run_correctness()  # asserts / raises on any failing case
+    except Exception as exc:  # noqa: BLE001 - any failure is a correctness fail
+        ok = False
+        print(f"# correctness failed: {type(exc).__name__}: {str(exc)[:300]}")
+    print(f"allclose: {ok}")
+    return 0
+
+
+def _run_bench(tr) -> int:
+    """Delegate to the task's graph-timed run_performance(); expose per-case ms."""
+    tr.run_performance()  # writes build/performance_report.json, graph-timed
+    rows = json.loads(_report_path(tr).read_text())
+    expected_ids = [str(case.get("id") or "") for case in tr.CASES]
+    if not isinstance(rows, list):
+        print("error: performance report must be a list", file=sys.stderr)
+        return 1
+    timings = []
+    seen_ids = set()
+    try:
+        for row in rows:
+            cid = str(row.get("test_case_id") or "")
+            ms = float(row.get("execution_time_ms"))
+            if not cid or cid in seen_ids or not math.isfinite(ms) or ms <= 0:
+                raise ValueError(f"invalid or duplicate performance case {cid!r}")
+            seen_ids.add(cid)
+            timings.append((cid, ms))
+    except (AttributeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    missing = [case_id for case_id in expected_ids if case_id not in seen_ids]
+    unexpected = [case_id for case_id, _ in timings if case_id not in expected_ids]
+    if missing or unexpected:
+        print(
+            f"error: incomplete performance suite: missing={missing}, unexpected={unexpected}",
+            file=sys.stderr,
+        )
+        return 1
+    for cid, ms in timings:
+        print(f"case_ms: {cid.replace(' ', '_')} {ms:.6f}")
+    times = [ms for _, ms in timings]
+    print(f"mean_ms: {sum(times) / len(times):.6f}")
+    return 0
+
+
+def _pick_profile_case(tr) -> dict:
+    cases = {c["id"]: c for c in tr.CASES}
+    # Prefer the slowest case from a prior complete performance run.
+    rp = _report_path(tr)
+    if rp.is_file():
+        try:
+            rows = json.loads(rp.read_text())
+            best = max(rows, key=lambda r: float(r.get("execution_time_ms") or 0))
+            if best.get("test_case_id") in cases:
+                return cases[best["test_case_id"]]
+        except Exception:  # noqa: BLE001 - best-effort fallback
+            pass
+    return tr.CASES[-1]
+
+
+def _run_profile(tr) -> int:
+    torch = tr._torch()
+    case = _pick_profile_case(tr)
+    inputs = tr._make(case)
+    for _ in range(5):          # settle Triton JIT / autotune selection
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):          # profiled launches (profiler replays per group)
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generic image_kernel forge driver")
+    parser.add_argument("--mode", default="full")       # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args = parser.parse_args()
+
+    tr, _scripts_dir = _import_task_runner()
+    tr._configure()  # arch env + make the seeded (agent-editable) repo importable
+
+    import torch
+    if not torch.cuda.is_available():
+        print("error: ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr)
+    if args.bench_mode:
+        return _run_bench(tr)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/scripts/task_runner.py
+++ b/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/scripts/task_runner.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Harness for MiniMax-M3's sparse block-selection chain
+(vllm/models/minimax_m3/amd/ops/index_topk.py).
+
+Two scored paths, both driven through their public launchers:
+
+  decode  : minimax_m3_index_decode()  -> _decode_index_score_kernel
+                                          + _topk_index_partial_kernel
+                                          + _topk_index_merge_kernel
+  prefill : minimax_m3_index_score()   -> _index_block_score_kernel
+            minimax_m3_index_topk()    -> _topk_index_kernel
+
+Shapes, dtypes and sequence lengths come from the 20260815T100002Z session trace;
+see session_cases.json. Correctness and performance run the SAME case list at the
+SAME sizes, and performance is measured under a CUDA/HIP graph.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MODEL_CONFIG = SPEC["model_config"]
+
+REPO_SUBDIR = "vllm_models_minimax_m3"
+KERNEL_FILE = Path("amd") / "ops" / "index_topk.py"
+EDIT_MODULE_NAME = "vllm.models.minimax_m3.amd.ops._ka_index_topk"
+
+_FORCE_INIT = 1e30
+_FORCE_LOCAL = 1e29
+# Reference chunk over the query dimension for the prefill path; bounds the
+# [chunk, max_block*128] fp32 score matrix.
+_REF_Q_CHUNK = 4096
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+
+
+def _benchmark_cuda_graph_or_events(*args, **kwargs):
+    raise RuntimeError(
+        "CUDA-graph benchmark helpers were not materialized. "
+        "Run this task through AgentKernelArena so setup_workspace() can inject "
+        "src/tools/perf/vllm_cuda_graph_block.py into the workspace."
+    )
+# <<< AKA-GENERATED <<<
+
+
+def _write_report(rows: list[dict]) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU is required")
+    return torch
+
+
+def _load_kernel_module():
+    import vllm.models.minimax_m3.common.ops.index_topk  # noqa: F401
+
+    path = WORKSPACE / REPO_SUBDIR / KERNEL_FILE
+    spec = importlib.util.spec_from_file_location(EDIT_MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[EDIT_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile_smoke_case(case: dict) -> dict:
+    p = dict(case["params"])
+    p["num_blocks"] = 512
+    if p["path"] == "decode":
+        p["num_reqs"] = min(p["num_reqs"], 8)
+        p["total_q"] = p["num_reqs"]
+        p["seq_len"] = min(p["seq_len"], 1024)
+    else:
+        p["query_lens"] = [min(q, 256) for q in p["query_lens"]]
+        p["seq_lens"] = [min(s, 512) for s in p["seq_lens"]]
+        p["prefix_lens"] = [
+            min(pf, s - q)
+            for pf, s, q in zip(p["prefix_lens"], p["seq_lens"], p["query_lens"])
+        ]
+    return {**case, "params": p}
+
+
+def _make(case: dict) -> dict:
+    torch = _torch()
+    p = dict(case["params"])
+    dev = "cuda"
+    dtype = torch.bfloat16
+    blk = p["sparse_block_size"]
+    D = p["index_head_dim"]
+    H = p["num_idx_heads"]
+    max_blocks = (p["max_seq_len"] + blk - 1) // blk
+
+    torch.manual_seed(23)
+
+    if p["path"] == "decode":
+        batch = p["num_reqs"]
+        total_q = p["total_q"]
+        seq_lens_list = [p["seq_len"]] * batch
+        prefix_lens_list = [p["seq_len"] - 1] * batch  # query is the last token
+        query_lens = [1] * batch
+    else:
+        batch = p["batch"]
+        query_lens = list(p["query_lens"])
+        seq_lens_list = list(p["seq_lens"])
+        prefix_lens_list = list(p["prefix_lens"])
+        total_q = sum(query_lens)
+
+    # The page pool must cover every sequence's full block_table row.
+    num_blocks = max(p["num_blocks"], batch * max_blocks + 1)
+
+    # Scaled down so bf16 dot products stay in a sane range; the kernel and the
+    # reference see the same values either way.
+    idx_q = torch.randn((total_q, H, D), device=dev, dtype=dtype) * 0.25
+    index_kv_cache = torch.randn((num_blocks, blk, D), device=dev, dtype=dtype) * 0.25
+
+    gen = torch.Generator(device="cpu").manual_seed(77)
+    perm = torch.randperm(num_blocks, generator=gen)[: batch * max_blocks]
+    block_table = perm.view(batch, max_blocks).to(dev, torch.int32).contiguous()
+
+    seq_lens_t = torch.tensor(seq_lens_list, device=dev, dtype=torch.int32)
+    prefix_lens_t = torch.tensor(prefix_lens_list, device=dev, dtype=torch.int32)
+    cu_seqlens_q = torch.zeros(batch + 1, device=dev, dtype=torch.int32)
+    cu_seqlens_q[1:] = torch.tensor(query_lens, device=dev, dtype=torch.int32).cumsum(0)
+
+    # Stable output buffer, as vLLM's persistent topk_indices_buffer provides.
+    out_buf = torch.empty((H, total_q, p["topk"]), device=dev, dtype=torch.int32)
+
+    return {
+        "cfg": case,
+        "params": p,
+        "module": _load_kernel_module(),
+        "idx_q": idx_q,
+        "index_kv_cache": index_kv_cache,
+        "block_table": block_table,
+        "seq_lens": seq_lens_t,
+        "prefix_lens": prefix_lens_t,
+        "cu_seqlens_q": cu_seqlens_q,
+        "out_buf": out_buf,
+        "batch": batch,
+        "total_q": total_q,
+        "query_lens": query_lens,
+        "seq_lens_list": seq_lens_list,
+        "prefix_lens_list": prefix_lens_list,
+        "max_query_len": max(query_lens),
+    }
+
+
+def _perturb_inputs(inputs: dict) -> None:
+    torch = _torch()
+    torch.manual_seed(37)
+    inputs["idx_q"].normal_().mul_(0.25)
+    inputs["index_kv_cache"].normal_().mul_(0.25)
+
+
+def _run(inputs: dict):
+    p = inputs["params"]
+    m = inputs["module"]
+    if p["path"] == "decode":
+        return m.minimax_m3_index_decode(
+            inputs["idx_q"],
+            inputs["index_kv_cache"],
+            inputs["block_table"],
+            inputs["seq_lens"],
+            p["max_seq_len"],
+            p["topk"],
+            p["init_blocks"],
+            p["local_blocks"],
+            p["num_idx_heads"],
+            p["decode_query_len"],
+            p["decode_query_len"],
+            out=inputs["out_buf"],
+        )
+    score = m.minimax_m3_index_score(
+        inputs["idx_q"],
+        inputs["index_kv_cache"],
+        inputs["block_table"],
+        inputs["cu_seqlens_q"],
+        inputs["seq_lens"],
+        inputs["prefix_lens"],
+        inputs["max_query_len"],
+        p["max_seq_len"],
+        p["num_idx_heads"],
+    )
+    return m.minimax_m3_index_topk(
+        score,
+        inputs["cu_seqlens_q"],
+        inputs["prefix_lens"],
+        inputs["max_query_len"],
+        p["topk"],
+        p["init_blocks"],
+        p["local_blocks"],
+        out=inputs["out_buf"],
+    )
+
+
+def _reference_scores(inputs: dict):
+    """Per-(head, query, block) score, matching both kernels' semantics.
+
+    score[h, q, blk] = max over the 128 positions of blk of (k . q), with
+    positions masked out when ``pos > absolute_query_position`` (causal) or
+    ``pos >= seq_len``. Blocks beyond the query's causal reach get -inf.
+    Forced blocks then override: init -> 1e30, local -> 1e29
+    (index_topk.py:390-392 for decode; _topk_index_kernel takes init/local
+    directly on the prefill path -- same selection either way).
+
+    Vectorized over (queries in a chunk) x blocks x positions x heads; the only
+    Python loops are over the batch and over query chunks.
+    """
+    torch = _torch()
+    p = inputs["params"]
+    blk = p["sparse_block_size"]
+    D = p["index_head_dim"]
+    H = p["num_idx_heads"]
+    cache = inputs["index_kv_cache"]
+    max_block = (p["max_seq_len"] + blk - 1) // blk
+
+    scores = torch.full(
+        (H, inputs["total_q"], max_block), float("-inf"), device=cache.device,
+        dtype=torch.float32,
+    )
+    nvis_all = torch.empty(inputs["total_q"], device=cache.device, dtype=torch.long)
+
+    q_off = 0
+    for b, q_len in enumerate(inputs["query_lens"]):
+        seq_len = inputs["seq_lens_list"][b]
+        prefix = inputs["prefix_lens_list"][b]
+        n_blk = (seq_len + blk - 1) // blk
+        pages = inputs["block_table"][b, :n_blk].long()
+        # [n_blk*blk, D] contiguous view of this sequence's index-K
+        k = cache[pages].reshape(n_blk * blk, D).float()
+        pos = torch.arange(n_blk * blk, device=cache.device)
+
+        for c0 in range(0, q_len, _REF_Q_CHUNK):
+            c1 = min(c0 + _REF_Q_CHUNK, q_len)
+            n = c1 - c0
+            g0 = q_off + c0
+            qpos = prefix + torch.arange(c0, c1, device=cache.device)  # [n]
+            nvis = (qpos // blk) + 1
+            nvis_all[g0 : g0 + n] = nvis
+
+            qc = inputs["idx_q"][g0 : g0 + n].float()  # [n, H, D]
+            s = torch.einsum("nhd,pd->hnp", qc, k)  # [H, n, n_blk*blk]
+            ok = (pos.view(1, 1, -1) <= qpos.view(1, n, 1)) & (
+                pos.view(1, 1, -1) < seq_len
+            )
+            s = s.masked_fill(~ok, float("-inf"))
+            s = s.view(H, n, n_blk, blk).amax(dim=-1)  # [H, n, n_blk]
+
+            blocks = torch.arange(n_blk, device=cache.device).view(1, 1, -1)
+            visible = blocks < nvis.view(1, n, 1)
+            is_init = (blocks < p["init_blocks"]) & visible
+            is_local = (blocks >= (nvis.view(1, n, 1) - p["local_blocks"])) & visible
+            s = torch.where(is_local, torch.full_like(s, _FORCE_LOCAL), s)
+            s = torch.where(is_init, torch.full_like(s, _FORCE_INIT), s)
+            s = s.masked_fill(~visible, float("-inf"))
+            scores[:, g0 : g0 + n, :n_blk] = s
+            del s, ok, qc
+        del k
+        q_off += q_len
+    return scores, nvis_all
+
+
+def _assert_close(inputs: dict, got) -> None:
+    """Validate the selected block set, tie-safely.
+
+    Top-k over floats has no unique answer when scores tie, so comparing indices
+    element-by-element against torch.topk would be wrong. Instead we require, per
+    (head, query): the right number of entries, all distinct and causally
+    visible, and a selected-score multiset equal to torch's top-k multiset.
+    """
+    torch = _torch()
+    p = inputs["params"]
+    topk = p["topk"]
+    scores, nvis = _reference_scores(inputs)
+    H, Q, _ = scores.shape
+    got = got[:, : inputs["total_q"], :].to(torch.int64)
+
+    expect_n = torch.clamp(nvis, max=topk)  # [Q]
+    n_sel = (got >= 0).sum(dim=-1)  # [H, Q]
+    if not torch.equal(n_sel, expect_n.view(1, Q).expand(H, Q)):
+        bad = (n_sel != expect_n.view(1, Q)).nonzero()[:5].tolist()
+        raise AssertionError(
+            f"wrong number of selected blocks at (head,query) {bad}; "
+            f"got {n_sel.flatten()[:8].tolist()} expected "
+            f"{expect_n[:8].tolist()}"
+        )
+
+    safe = got.clamp(min=0)
+    if (safe >= nvis.view(1, Q, 1)).logical_and(got >= 0).any():
+        raise AssertionError("selected a block outside the causally visible range")
+    # distinctness among the valid entries
+    marked = torch.where(got >= 0, safe, torch.arange(topk, device=got.device) + 10**6)
+    if (marked.sort(dim=-1).values.diff(dim=-1) == 0).any():
+        raise AssertionError("duplicate block ids in the selection")
+
+    got_scores = torch.gather(scores, 2, safe)
+    got_scores = torch.where(
+        got >= 0, got_scores, torch.full_like(got_scores, float("-inf"))
+    )
+    ref_scores = scores.topk(topk, dim=-1).values
+    got_scores, _ = got_scores.sort(dim=-1, descending=True)
+    ref_scores, _ = ref_scores.sort(dim=-1, descending=True)
+    finite = torch.isfinite(ref_scores)
+    torch.testing.assert_close(
+        got_scores[finite], ref_scores[finite], atol=2e-2, rtol=2e-2
+    )
+
+
+def _assert_timed_outputs(inputs: dict, timed) -> None:
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb_inputs(inputs)
+    inputs["out_buf"].fill_(-1)
+    _assert_close(inputs, timed.rerun())
+
+
+def run_compile() -> None:
+    for case in (CASES[0], next(c for c in CASES if c["params"]["path"] == "prefill")):
+        inputs = _make(_compile_smoke_case(case))
+        _run(inputs)
+        _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        inputs = _make(case)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        _assert_close(inputs, got)
+        print("correctness PASS", case["id"])
+        del inputs, got
+        torch.cuda.empty_cache()
+
+
+def run_performance() -> None:
+    torch = _torch()
+    rows = []
+    for case in CASES:
+        inputs = _make(case)
+        _run(inputs)
+        torch.cuda.synchronize()
+        timed = _TimedRun()
+        execution_time_ms, bench_meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=10,
+            repetition=100,
+            target_ms=1.0,
+            max_graph_repeats=1000,
+            timed_run=timed,
+        )
+        _assert_timed_outputs(inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "session_id": case.get("session_id"),
+            "phase": case.get("phase"),
+            "gpu_pct": case.get("gpu_pct"),
+            "benchmark_method": bench_meta.get("benchmark_method"),
+        }
+        metadata.update(
+            {k: v for k, v in bench_meta.items() if k.startswith("benchmark_")}
+        )
+        rows.append(
+            {
+                "test_case_id": case["id"],
+                "shape": case.get("trace_input_shapes"),
+                "execution_time_ms": execution_time_ms,
+                "metadata": metadata,
+            }
+        )
+        print(
+            case["id"],
+            f"{execution_time_ms:.6f} ms",
+            bench_meta.get("benchmark_method"),
+            bench_meta.get("benchmark_fallback_reason", ""),
+        )
+        del inputs
+        torch.cuda.empty_cache()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["compile", "correctness", "performance", "manifest"]
+    )
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/session_cases.json
+++ b/tasks/minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3/session_cases.json
@@ -1,0 +1,220 @@
+{
+  "source_day": "2026-08-15",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950",
+  "framework": "vllm 0.26.0",
+  "base_image": "harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.26.0",
+  "task_name": "mi355x-minimax-m3-sparse-index-topk-20260815",
+  "operator": "sparse_index_topk",
+  "selection": "the whole block-selection chain of MiniMax-M3's block-sparse attention: 8.01% of normalized E2E GPU time across 5 Triton kernels, none of which produces attention output",
+  "provenance": {
+    "model": "MiniMax-M3-MXFP4",
+    "session_id": "20260815T100002Z",
+    "session_path": "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260815T100002Z",
+    "trace": "runs/roofline/ca746c43c5564616b0ff91a3582c73ab/benchmark_vllm_20260815_111805/torch_trace/dp0_pp0_tp0_dcp0_ep0_rank0.1786793700435294667.pt.trace.json.gz",
+    "workload": "ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312 / TP=8 / quark MXFP4",
+    "entry": "vllm/models/minimax_m3/amd/ops/index_topk.py -- decode path minimax_m3_index_decode() at :767, prefill path minimax_m3_index_score() at :655 + minimax_m3_index_topk() at :714",
+    "call_chain": "MiniMaxM3IndexerTritonImpl.forward (vllm/models/minimax_m3/common/indexer.py:432 decode / :449,:460 prefill) -> the launchers above; the resulting topk_idx feeds _gqa_sparse_fwd_kernel (prefill) and _gqa_sparse_decode_kernel (decode)",
+    "phase": "both -- the decode path runs 57x in every step (pure-decode steps and the piggybacked decode rows of chunked-prefill steps); the prefill path runs 57x in chunked-prefill steps only",
+    "measured_kernels": [
+      {
+        "kernel": "_decode_index_score_kernel",
+        "normalized_e2e_pct": 5.23,
+        "prefill_step_pct": 0.95,
+        "decode_step_pct": 8.1,
+        "calls_per_step": 57,
+        "us_per_call_decode": 28.0,
+        "grid": "(num_reqs, num_kv_chunks=8)",
+        "block": "(256,1,1)",
+        "achieved_bandwidth_TBs": 5.32,
+        "pct_of_hbm_peak": 66.5
+      },
+      {
+        "kernel": "_topk_index_partial_kernel",
+        "normalized_e2e_pct": 0.96,
+        "prefill_step_pct": 0.17,
+        "decode_step_pct": 1.49,
+        "calls_per_step": 57
+      },
+      {
+        "kernel": "_topk_index_merge_kernel",
+        "normalized_e2e_pct": 0.77,
+        "prefill_step_pct": 0.12,
+        "decode_step_pct": 1.21,
+        "calls_per_step": 57
+      },
+      {
+        "kernel": "_index_block_score_kernel",
+        "normalized_e2e_pct": 0.89,
+        "prefill_step_pct": 2.2,
+        "decode_step_pct": 0.0,
+        "calls_per_prefill_step": 57,
+        "us_per_call": 74.7
+      },
+      {
+        "kernel": "_topk_index_kernel",
+        "normalized_e2e_pct": 0.16,
+        "prefill_step_pct": 0.41,
+        "decode_step_pct": 0.0,
+        "calls_per_prefill_step": 57
+      }
+    ],
+    "scope_note": "8.01% = 5.23 + 0.96 + 0.77 + 0.89 + 0.16. A separate 1.26% bf16->fp32 `vectorized_elementwise` kernel runs 57x per step in the same region of the timeline, but MiniMaxM3IndexerTritonImpl.forward passes index_query through as bf16 (common/indexer.py:419) so it is NOT attributed to this chain and is NOT part of this task.",
+    "shape_evidence": "grid (59,8,1)/(60,8,1)/(61,8,1) for _decode_index_score_kernel and (128,1,1)/(116,2,1)/(105,2,1) for _index_block_score_kernel read off the kernel events. index cache shape [41215,128,128] bf16 from _C::fused_minimax_m3_qknorm_rope_kv_insert arg 16 in the bs=64 capture trace. Sequence counts and lengths from the step annotations.",
+    "harness_agreement": "harness 0.0858 ms at m3-prefillpath-b1-q8131-prefix0 vs 74.7+13.9 = 88.6 us for _index_block_score_kernel + _topk_index_kernel in the session trace -- 97% agreement. Decode path 0.0294 ms vs ~37 us for the three decode kernels; the harness uses uniform seq_lens, which removes the tail the session's mixed lengths create."
+  },
+  "model_config": {
+    "num_idx_heads_per_rank": 1,
+    "num_kv_heads_per_rank": 1,
+    "index_head_dim": 128,
+    "sparse_block_size": 128,
+    "sparse_topk_blocks": 16,
+    "sparse_init_block": 0,
+    "sparse_local_block": 1,
+    "num_blocks": 41215,
+    "max_model_len": 13312,
+    "dtype": "bf16"
+  },
+  "shape_notes": {
+    "num_kv_chunks": "8, from index_topk.py:820 -- TARGET_GRID=512, target = min(256, 512 // num_reqs) with num_reqs 59..64 -> 8, rounded down to a power of two. It must stay derivable from shape constants because the decode path is captured in a CUDA graph.",
+    "score_buffer": "[num_idx_heads, total_q, round_up(cdiv(13312,128),16)] = [1, total_q, 112] fp32; max_block is 104 and the stride is rounded up to 112 to keep Triton from recompiling.",
+    "forced_blocks": "sparse_init_block=0 and sparse_local_block=1, so exactly one block per query (the one containing the query position) is force-selected. The decode kernel bakes this into the score (1e30 for init, 1e29 for local, index_topk.py:390-392); the prefill path passes init_blocks/local_blocks to _topk_index_kernel instead.",
+    "cache_size": "The index cache is allocated at the session's real 41215 blocks (1.35 GB) and each sequence gets a shuffled, non-contiguous page set."
+  },
+  "cases": [
+    {
+      "id": "m3-decodepath-bs64-ctx9098",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "path": "decode",
+      "phase": "pure-decode step",
+      "gpu_pct": 10.8,
+      "params": {
+        "path": "decode",
+        "num_reqs": 64,
+        "total_q": 64,
+        "decode_query_len": 1,
+        "seq_len": 9098,
+        "num_idx_heads": 1,
+        "index_head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "init_blocks": 0,
+        "local_blocks": 1,
+        "num_blocks": 41215,
+        "max_seq_len": 13312,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "idx_q (64,1,128) bf16",
+        "index_kv_cache (41215,128,128) bf16",
+        "block_table (64,104) int32",
+        "seq_lens (64,) int32 = 9098",
+        "score (1,64,112) fp32",
+        "topk_idx (1,64,16) int32",
+        "score grid (64,8) block (256,1,1)"
+      ]
+    },
+    {
+      "id": "m3-decodepath-bs61-ctx9098",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "path": "decode",
+      "phase": "chunked-prefill step (the 61 piggybacked decode rows)",
+      "gpu_pct": 1.24,
+      "params": {
+        "path": "decode",
+        "num_reqs": 61,
+        "total_q": 61,
+        "decode_query_len": 1,
+        "seq_len": 9098,
+        "num_idx_heads": 1,
+        "index_head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "init_blocks": 0,
+        "local_blocks": 1,
+        "num_blocks": 41215,
+        "max_seq_len": 13312,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "idx_q (61,1,128) bf16",
+        "index_kv_cache (41215,128,128) bf16",
+        "score grid (61,8) block (256,1,1)"
+      ]
+    },
+    {
+      "id": "m3-prefillpath-b1-q8131-prefix0",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "path": "prefill",
+      "phase": "chunked-prefill step, first chunk of an 8192-token prompt",
+      "gpu_pct": 1.05,
+      "params": {
+        "path": "prefill",
+        "batch": 1,
+        "query_lens": [
+          8131
+        ],
+        "seq_lens": [
+          8131
+        ],
+        "prefix_lens": [
+          0
+        ],
+        "num_idx_heads": 1,
+        "index_head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "init_blocks": 0,
+        "local_blocks": 1,
+        "num_blocks": 41215,
+        "max_seq_len": 13312,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "idx_q (8131,1,128) bf16",
+        "index_kv_cache (41215,128,128) bf16",
+        "score (1,8131,112) fp32",
+        "topk_idx (1,8131,16) int32",
+        "score grid (128,1,1) block (256,1,1)"
+      ]
+    },
+    {
+      "id": "m3-prefillpath-b1-q61-prefix8131",
+      "model": "MiniMax-M3-MXFP4",
+      "session_id": "20260815T100002Z",
+      "path": "prefill",
+      "phase": "chunked-prefill tail chunk (annotation execute_121_context_1(sq61 sk8192))",
+      "gpu_pct": null,
+      "params": {
+        "path": "prefill",
+        "batch": 1,
+        "query_lens": [
+          61
+        ],
+        "seq_lens": [
+          8192
+        ],
+        "prefix_lens": [
+          8131
+        ],
+        "num_idx_heads": 1,
+        "index_head_dim": 128,
+        "topk": 16,
+        "sparse_block_size": 128,
+        "init_blocks": 0,
+        "local_blocks": 1,
+        "num_blocks": 41215,
+        "max_seq_len": 13312,
+        "dtype": "bf16"
+      },
+      "trace_input_shapes": [
+        "idx_q (61,1,128) bf16",
+        "index_kv_cache (41215,128,128) bf16",
+        "score grid (1,1,1) block (256,1,1)"
+      ]
+    }
+  ]
+}

--- a/tasks/minimax-m3/task_overview.md
+++ b/tasks/minimax-m3/task_overview.md
@@ -1,0 +1,577 @@
+# MiniMax-M3-MXFP4 算子 task 总览（session 20260815T100002Z）
+
+从一个 Hyperloom session 里抽出的 4 个 `image_kernel` task。
+
+```text
+session   /shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260815T100002Z
+硬件/软件  MI355X x8 / TP=8 / quark MXFP4 / vllm 0.26.0 / ROCm 7.2.3 / aiter 0.1.16.post3
+负载      ISL 8192 / OSL 1024 / conc 64 / max_model_len 13312 / block_size 128
+镜像      harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.26.0
+```
+
+运行方式：
+
+```yaml
+tasks:
+  - minimax-m3/mi355x_vllm_triton_paged_attention_2d_minimax_m3
+  - minimax-m3/mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3
+  - minimax-m3/mi355x_vllm_triton_sparse_index_topk_minimax_m3
+  - minimax-m3/mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3
+```
+
+**E2E 占比的口径**：归一化端到端 GPU 时间占比（prefill 步权重 40.2% + decode 步权重 59.8% 加权），
+不是采样窗口占比——两者能差 2 倍以上。完整推导见
+`/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/minimax-m3-hot-kernels.md`。
+
+---
+
+## 一、四个 task 一览（按预期收益排序）
+
+| # | task | E2E% | 语言 | **调用构成** | 当前效率 | 头部空间 |
+|---|---|---|---|---|---|---|
+| 1 | `..._triton_paged_attention_2d_minimax_m3` | **11.35%** | triton | **单算子**（1 个 kernel） | 255 GB/s = **HBM 峰值的 3.2%** | **大** —— 64 个 CTA 跑在 256 CU 上，且没有 KV split-K |
+| 2 | `..._triton_gqa_sparse_attn_prefill_minimax_m3` | **8.53%** | triton | **单算子**（1 个 kernel） | 83.6 TFLOP/s = **bf16 峰值的 3.6%** | 大 —— `BLOCK_SIZE_Q=1`、`num_warps=1`，QK GEMM 的 M 只有 8 |
+| 3 | `..._triton_sparse_index_topk_minimax_m3` | **8.01%** | triton | **多算子链**（decode 3 个 / prefill 2 个） | 打分 kernel 已到 HBM 峰值的 66.5% | 中 —— 收益在链路融合，不在单个 kernel |
+| 4 | `..._flydsl_mxfp4_moe_2stage_minimax_m3` | 6.01%（属 18.60% 的功能） | flydsl | **多算子链**（prefill 10 个 / decode 6 个） | gemm2 602 vs gemm1 2315 TFLOP/s | 中 —— 同类 shape 差 3.8 倍，且没命中调优表 |
+
+> **"调用构成"指的是被计时区间（`task_runner.py` 的 `_run()`）里实际发出的 GPU kernel 数**，用 torch profiler
+> 在本容器实测得到，不是估计。这个区别直接决定 agent 的优化空间：单算子 task 只能靠把那一个 kernel 做快；
+> 多算子链 task 还可以**减少 launch、砍掉中间的全局显存往返、把小 pass 融进 epilogue** —— 计分用的是整个
+> `_run()` 的墙钟时间，所以删掉一个 pass 和加速一个 kernel 同样算数。
+
+按模块归类：
+
+| 模块 | 归一化 E2E% | 本目录覆盖 |
+|---|---|---|
+| 注意力（全部） | 42.13% | task 1 / 2 / 3 = **27.89%** |
+| MoE（全部） | 35.67% | task 4 = **6.01%**（路由专家 GEMM 的 prefill 一半；decode 一半 12.62% 未覆盖，见第五节） |
+| 通信 all-reduce | 17.31% | 不做（见第五节） |
+| 其它（Norm / 稠密 MLP / LM head / 搬运 / 空闲） | 4.89% | 不做 |
+
+---
+
+## 二、先看模型结构：这 4 个 task 分别落在哪
+
+MiniMax-M3 有 **60 层**，是个混合结构。`config.json` 里 `sparse_attention_freq` 和 `moe_layer_freq`
+的前 3 项都是 0、后 57 项都是 1，也就是：
+
+```
+                     ┌─ 第 0~2 层（3 层，"稠密层"）─────────────────────────────────────┐
+                     │   RMSNorm                                                       │
+                     │   qkv 投影  [.,6144]x[6144,1280]                                 │
+                     │   qk-norm + RoPE + KV 写入                                       │
+   输入 [T, 6144] ──▶│   ★ 稠密 GQA 注意力  ◀═══════════════════ task 1                 │──▶
+                     │   o 投影   [.,1024]x[1024,6144]                                  │
+                     │   all-reduce                                                     │
+                     │   RMSNorm                                                        │
+                     │   稠密 MLP（inter 12288/TP8 = 1536，bf16 未量化）                  │
+                     │   all-reduce                                                     │
+                     └─────────────────────────────────────────────────────────────────┘
+                     ┌─ 第 3~59 层（57 层，"稀疏层"）────────────────────────────────────┐
+                     │   RMSNorm                                                        │
+                     │   qkv 投影  [.,6144]x[6144,1536]                                  │
+                     │             （1536 = 1024 q + 256 kv + 256 index）                │
+                     │   qk-norm + RoPE + KV 写入 + index-K 写入                          │
+                     │   ★ 选块器：给 <=104 个 128-token 块打分，选 top-16 ◀════ task 3    │
+                     │   ★ 块稀疏 GQA 注意力（只读选中的 16 个块）      ◀══════ task 2      │──▶
+                     │   o 投影   [.,1024]x[1024,6144]                                   │
+                     │   all-reduce                                                      │
+                     │   RMSNorm                                                         │
+                     │   MoE：router gate → top-4 → token 排序                             │
+                     │        ★ 128 个路由专家的 2 段 FFN GEMM ◀══════ task 4             │
+                     │        + 1 个共享专家（inter 384，未补齐）                           │
+                     │        缩放 x2.0 → 与共享专家相加                                   │
+                     │   all-reduce                                                       │
+                     └──────────────────────────────────────────────────────────────────┘
+```
+
+每 rank（TP=8）的几何：`hidden=6144`、**8 个 q 头 / 1 个 kv 头**（GQA 8:1）、`head_dim=128`、
+1 个 index 头（`index_dim=128`）、128 个专家 top-4、专家 `inter=512`（3072/8=384 **补齐到 512**）、
+`block_size=128`、KV cache `num_blocks=41215`。
+
+---
+
+## 三、逐个 task
+
+### Task 1 —— `mi355x_vllm_triton_paged_attention_2d_minimax_m3`
+
+#### 调用构成：单算子
+
+被计时区间 `chunked_prefill_paged_decode(...)` 在纯 decode 批下**只发 1 个 kernel**（实测）：
+
+```text
+x1  kernel_paged_attention_2d
+```
+
+`key=None/value=None` 所以不写 KV cache；`max_query_len=1` 所以 prefill 分支
+（`_fwd_kernel`）整个跳过。**agent 的全部空间就在这一个 kernel 里。**
+
+#### 是什么算子
+
+vLLM 的 Triton 分页注意力 decode kernel **`kernel_paged_attention_2d`**
+（`vllm/v1/attention/ops/chunked_prefill_paged_decode.py:46`，launcher 在同文件 `:447`），
+经 `vllm::unified_attention_with_output` 调用。一次调用处理一批 query 长度为 1 的行，
+每行从分页 KV cache 里读完自己整条序列的 K/V 做一次完整 softmax attention。
+
+#### E2E 占比
+
+**11.35%** —— 全 session 排第 2 的单个 kernel。
+
+| | |
+|---|---|
+| decode 步内 | 17.76% |
+| chunked-prefill 步内 | 1.82% |
+| 调用次数 | 3 次/步（两种步都有） |
+| 单次耗时 | 1168 µs（decode）/ 1172 µs（prefill 步） |
+
+#### 对应模型结构的哪个部分
+
+**前 3 层稠密注意力层的注意力核心**，只覆盖其中的 decode token 路径。
+
+- 这 3 层是 `sparse_attention_freq` 里为 0 的层，不走块稀疏，用标准 vLLM `Attention` 层。
+- 纯 decode 步里它处理 64 个 decode token；chunked-prefill 步里处理夹带的 61 个 decode token
+  —— `filter_by_query_len=True` 会让它直接跳过那 8133 个 prefill 行，prefill 部分由同文件的
+  `_fwd_kernel` 负责（占 0.91%，不在本 task 内）。
+- 输入：`q [64,8,128]` bf16（stride `[1280,128,1]`，因为是 fused qkv buffer 的切片）、
+  KV cache 每层 41215 blocks x 128 tokens x 1 kv head x 128、`seq_lens` 均值 9098。
+
+#### 为什么值得做
+
+grid 就是 `(num_seqs, num_kv_heads) = (64, 1)`：**64 个 workgroup 跑在 256 个 CU 上，且没有对 KV 长度做
+split-K**，每个 CTA 顺序扫完自己那条 9098 token 的 KV。实测 **255 GB/s = HBM 峰值的 3.2%**。
+同一份 trace 里做了 8 路 split-K 的 `_decode_index_score_kernel`（task 3）跑到 5.32 TB/s，
+**效率是它的 21 倍**。
+
+它落到 Triton 的原因：`use_rocm_custom_paged_attention()`（`vllm/platforms/rocm.py:346`）只接受
+`block_size ∈ {16,32}`，而 M3 因为块稀疏必须用 `block_size=128`；`head_size=128`、`gqa_ratio=8`
+本来都是合格的。server.log 里有对应的
+`Cannot use ROCm custom paged attention kernel, falling back to Triton implementation.`
+
+#### 测试 case（精度 / 性能同一份，同尺寸）
+
+| id | 阶段 | num_seqs | query buffer 行数 | ctx_len |
+|---|---|---|---|---|
+| `m3-decode-bs64-ctx9098`（primary） | decode 步，平均上下文 | 64 | 64 | 9098 |
+| `m3-decode-bs64-ctx8192` | decode 步，刚开始生成 | 64 | 64 | 8192 |
+| `m3-decode-bs64-ctx9216` | decode 步，生成到头（ISL+OSL） | 64 | 64 | 9216 |
+| `m3-chunkedstep-bs61-ctx9098` | chunked-prefill 步 | 61 | 8192 | 9098 |
+
+公共：`num_query_heads=8`、`num_kv_heads=1`、`head_size=128`、`block_size=128`、bf16、`num_blocks=41215`。
+
+两个刻意复现的细节：**query stride 是 1280 不是 1024**（q/k/v 是同一 fused qkv buffer 的切片，
+非单位行 stride 会改变 kernel 的访存模式）；**KV cache 按真实 41215 blocks 分配且页打散**
+（见第七节，不这么做会测出 3 倍偏快的假结果）。
+
+`m3-chunkedstep-*` 之所以建成 61 行的 decode 批：chunked-prefill 步里这个 kernel 根本看不到那
+8133 个 prefill 行（`filter_by_query_len=True`，`chunked_prefill_paged_decode.py:92-97` 直接 return），
+它的真实工作量就是那 61 个 query 长度为 1 的行 —— 这也是为什么两种步的单次耗时几乎一样（1172 vs 1168 µs）。
+
+#### 参考实现与容差
+
+一对批量 `einsum`，无逐序列循环。GQA 通过把组宽折进 query（`[S,Hkv,g,D]`）来处理，
+不展开 KV 头，所以峰值中间量只有 `[S,Hkv,g,ctx]` fp32（最大 case 18.9 MB）。
+参考读连续的 `key`/`value`，kernel 读分页 cache，`_fill_kv_cache()` 每次一起刷新，
+保证两边始终描述同一份负载。容差 `assert_close(atol=rtol=0.08)`。
+
+---
+
+### Task 2 —— `mi355x_vllm_triton_gqa_sparse_attn_prefill_minimax_m3`
+
+#### 调用构成：单算子
+
+被计时区间 `minimax_m3_sparse_attn(...)` **只发 1 个 kernel**（实测）：
+
+```text
+x1  _gqa_sparse_fwd_kernel
+```
+
+launcher 里就一次 `_gqa_sparse_fwd_kernel[grid](...)`，没有前后处理。
+**agent 的全部空间就在这一个 kernel 里。**
+
+#### 是什么算子
+
+MiniMax-M3 自带的块稀疏 GQA prefill 注意力 Triton kernel **`_gqa_sparse_fwd_kernel`**
+（`vllm/models/minimax_m3/amd/ops/sparse_attn.py:73`，launcher `minimax_m3_sparse_attn()` 在 `:243`）。
+每个 query token 只对 task 3 选出来的 top-16 个 128-token KV 块做 attention，而不是整条序列。
+
+#### E2E 占比
+
+**8.53%** —— 全 session 排第 3。
+
+| | |
+|---|---|
+| chunked-prefill 步内 | 21.20% |
+| decode 步内 | 0（decode 走 `_gqa_sparse_decode_kernel`，3.53%，不在本 task 内） |
+| 调用次数 | 57 次/prefill 步 |
+| 单次耗时 | 720 µs |
+
+#### 对应模型结构的哪个部分
+
+**后 57 层块稀疏注意力层的注意力核心，prefill 路径。**
+
+- 一次 prefill 步处理 8133 个 context token（`max_num_batched_tokens=8192` 减去夹带的约 59 个
+  decode token），57 层各调一次。
+- 输入：`q [8133,8,128]` bf16、`kv_cache [41215,1,128,256]` bf16（最后一维前 128 是 K、后 128 是 V）、
+  `topk_idx [1,8133,16]` int32、`block_table`、`cu_seqlens_q`、`seq_lens`、`prefix_lens`。
+- 3 个 case 对应 trace 里实测的 3 种 launch 几何：batch=1/q=8131（40 个 prefill 步里占 37 个）、
+  batch=2/q=[8073,60]、收尾 chunk batch=1/q=61/prefix=8131。
+
+#### 为什么值得做
+
+实测 **83.6 TFLOP/s ≈ bf16 峰值的 3.6%**。根因在 launcher 的两个参数：`BLOCK_SIZE_Q = 1`
+（**一个 CTA 只处理一个 query token**）+ `num_warps=1`（实测 block 就是 `(64,1,1)`，一个 wavefront）。
+QK GEMM 的 M 维只有 8（GQA 组宽），喂不饱 `matrix_instr_nonkdim=16` 选中的 MFMA_16x16 tile。
+带宽不是瓶颈：单层单序列的 KV 工作集只有 4.2 MB，稳在 256 MB Infinity Cache 里。
+
+（session 里 GEAK 挑的就是这个 kernel，微基准做到 1.36x；按真实负载端到端上限是 2.3%。）
+
+#### 测试 case（精度 / 性能同一份，同尺寸）
+
+| id | batch | query_lens | seq_lens | prefix_lens | grid |
+|---|---|---|---|---|---|
+| `m3-prefill-b1-q8131-prefix0`（primary） | 1 | [8131] | [8131] | [0] | (8131,1,1) |
+| `m3-prefill-b2-q8073p60` | 2 | [8073, 60] | [8073, 8192] | [0, 8132] | (8073,1,2) |
+| `m3-prefill-b1-q61-prefix8131` | 1 | [61] | [8192] | [8131] | (61,1,1) |
+
+这三个就是 trace 里实测到的三种 launch 几何，第一个覆盖 40 个 prefill 步里的 37 个。
+公共：`num_heads=8`、`num_kv_heads=1`、`head_dim=128`、`topk=16`、`sparse_block_size=128`、
+`num_blocks=41215`、`USE_FP8=False`、`SUB_K=64`。
+
+`topk_idx` 是按因果可见范围 `[0, ceil((prefix+i+1)/128))` 采样生成的，必定包含 local 块
+（`sparse_local_block=1`），升序排列、右侧用 -1 补齐 —— 就是 kernel 期望的布局
+（`real_topk = sum(topk_idx >= 0)`，顺序读取）。这也是"每 query 平均 14.11 个块"的来源。
+
+#### 参考实现与容差
+
+严格照 kernel 主体（`sparse_attn.py:119-235`）：绝对 query 位置 = `prefix_lens[b] + i`；
+选中块 `blk` 覆盖 KV 位置 `blk*128 + [0,128)`；位置有效当且仅当 `pos < seq_lens[b]` **且**
+`pos <= prefix + i`；K 是 `kv_cache[page,kvh,:,:128]`、V 是 `[...,128:]`。
+
+对"选中块 × 块内位置 × 头"全向量化，唯一的 Python 循环是 query 维上每 128 个一块 ——
+纯粹为了把 gather 出来的 KV 压到几百 MB（一次性铺开 8131×2048 个 key 在 fp32 下要约 2 GB）。
+容差 `assert_close(atol=rtol=0.08)`。
+
+---
+
+### Task 3 —— `mi355x_vllm_triton_sparse_index_topk_minimax_m3`
+
+#### 调用构成：多算子链（decode 3 个 / prefill 2 个）
+
+实测：
+
+```text
+decode  minimax_m3_index_decode()        →  x1 _decode_index_score_kernel
+                                            x1 _topk_index_partial_kernel
+                                            x1 _topk_index_merge_kernel
+prefill minimax_m3_index_score()         →  x1 _index_block_score_kernel
+        + minimax_m3_index_topk()           x1 _topk_index_kernel
+```
+
+**这个 task 的价值主要就在"链"上**：打分 kernel 本身已经 66.5% HBM 峰值，
+但后面 partial + merge 两趟（合计 1.73% E2E）是为一个 `[1,64,112]` fp32 的小问题
+付了两次 launch 加一次全局往返。融掉它们和加速打分 kernel 是同等的得分。
+
+#### 是什么算子
+
+块稀疏注意力的**选块器（indexer）**，5 个 Triton kernel 组成的一条链
+（全在 `vllm/models/minimax_m3/amd/ops/index_topk.py`）：
+
+| 路径 | 入口 | kernel |
+|---|---|---|
+| decode | `minimax_m3_index_decode()` `:767` | `_decode_index_score_kernel` + `_topk_index_partial_kernel` + `_topk_index_merge_kernel` |
+| prefill | `minimax_m3_index_score()` `:655` → `minimax_m3_index_topk()` `:714` | `_index_block_score_kernel` + `_topk_index_kernel` |
+
+它用一套独立的 index-Q / index-K（`sparse_index_dim=128`，和主注意力的 Q/K 不是同一组），
+对每个 query 给 ≤104 个 128-token 块各算一个分数（块内 128 个位置的 `k·q` 取 max），
+再选出 top-16 交给 task 2 / `_gqa_sparse_decode_kernel`。
+
+#### E2E 占比
+
+**8.01%** = 5.23 + 0.96 + 0.77 + 0.89 + 0.16。
+
+| kernel | E2E% | prefill 步内 | decode 步内 |
+|---|---|---|---|
+| `_decode_index_score_kernel` | 5.23% | 0.95% | 8.10% |
+| `_topk_index_partial_kernel` | 0.96% | 0.17% | 1.49% |
+| `_topk_index_merge_kernel` | 0.77% | 0.12% | 1.21% |
+| `_index_block_score_kernel` | 0.89% | 2.20% | 0 |
+| `_topk_index_kernel` | 0.16% | 0.41% | 0 |
+
+#### 对应模型结构的哪个部分
+
+**后 57 层块稀疏注意力层里、注意力之前的那一步。** 层内位置是
+`qkv 投影 → qk-norm+RoPE+KV写入 → 【选块器】 → 块稀疏注意力 → o 投影`。
+
+- decode 路径每一步都跑（纯 decode 步的 64 个 token，以及 chunked-prefill 步里夹带的 61 个 token），
+  prefill 路径只在 chunked-prefill 步跑（8133 个 token）。两条都做成了 case。
+- 输入：`idx_q [total_q,1,128]` bf16、`index_kv_cache [41215,128,128]` bf16、
+  中间 `score [1,total_q,112]` fp32（112 = `round_up(cdiv(13312,128),16)`）、
+  输出 `topk_idx [1,total_q,16]` int32。
+- `sparse_init_block=0` / `sparse_local_block=1`，所以每个 query 有且只有 1 个块（query 自己所在的块）
+  被强制选中。
+
+#### 为什么值得做
+
+**这条链不产生任何注意力输出**，是块稀疏为了"挑块"付的固定成本 —— 而它比真正算稀疏 decode 注意力的
+`_gqa_sparse_decode_kernel`（3.53%）还贵一倍多。
+
+但收益点要看清：`_decode_index_score_kernel` 本身已经 **5.32 TB/s = HBM 峰值的 66.5%**
+（它做了 8 路 split-K，512 个 CTA 铺满 256 CU），逼它没用。能拿的是**链路融合**：batch 64 /
+`max_block=104` 这么小的问题，top-16 却拆成 partial + merge 两趟（合计 1.73%），
+中间还要过一次 `[1,64,112]` 的全局显存往返。
+
+硬约束：decode 路径在 cudagraph 里，所有 grid 和中间 buffer 形状必须只依赖 shape 常量。
+
+#### 测试 case（精度 / 性能同一份，同尺寸）
+
+| id | 路径 | batch | total_q | seq / prefix | 打分 kernel grid |
+|---|---|---|---|---|---|
+| `m3-decodepath-bs64-ctx9098`（primary） | decode | 64 | 64 | 9098 / — | (64, 8) |
+| `m3-decodepath-bs61-ctx9098` | decode | 61 | 61 | 9098 / — | (61, 8) |
+| `m3-prefillpath-b1-q8131-prefix0` | prefill | 1 | 8131 | 8131 / 0 | (128, 1) |
+| `m3-prefillpath-b1-q61-prefix8131` | prefill | 1 | 61 | 8192 / 8131 | (1, 1) |
+
+两条路径都覆盖，因为 session 里两条都跑：decode 路径**每一步**都跑 57 次，prefill 路径只在
+chunked-prefill 步跑 57 次。公共：`num_idx_heads = num_kv_heads = 1`、`index_head_dim=128`、
+`topk=16`、`init_blocks=0`、`local_blocks=1`、`num_blocks=41215`、`max_seq_len=13312`。
+
+#### 参考实现与容差 —— 并列（tie）问题
+
+参考复现两个打分 kernel 的语义：`score[h,q,blk]` = 块内 128 个位置 `k·q` 的 max，
+位置需满足 `pos <= prefix+i`（因果）且 `pos < seq_len`，超出因果范围的块为 `-inf`；
+再套上强制块 —— init → `1e30`、local → `1e29`（decode 侧烘进分数里，见
+`index_topk.py:390-392`；prefill 侧则是把 `init_blocks`/`local_blocks` 传给 `_topk_index_kernel`，
+选择结果等价）。实现上是每个 query chunk 一次 `einsum` 打全序列，再对块内 128 个位置 `amax`。
+
+**浮点 top-k 在分数并列时没有唯一解**，所以 `_assert_close` 不拿 index 去和 `torch.topk`
+逐元素比。它对每个 (head, query) 校验三件事：
+
+1. 选中个数正确 —— `min(topk, 可见块数)`
+2. 每个选中块互不相同、且都在因果可见范围内
+3. **选中分数的多重集**等于 torch top-k 分数的多重集（排序后比，`atol=rtol=2e-2`）
+
+这样任何合法的并列打破方式都能通过，但选错块一定会被抓到。
+
+---
+
+### Task 4 —— `mi355x_vllm_flydsl_mxfp4_moe_2stage_minimax_m3`
+
+#### 调用构成：多算子链（prefill 10 个 / decode 6 个）
+
+被计时区间是 `aiter.fused_moe.fused_moe(...)` 一整个调用。实测 token=8192（本 task 的主 case）
+发出 **10 个 kernel**，其中只有 2 个是本 task 要优化的 GEMM：
+
+```text
+x1  opus_moe_sorting_entry<MoeSortingClearWorkspaceKernel>   ┐
+x1  opus_moe_sorting_entry<MoeSortingMultiPhaseKernel_P0_v1> │
+x1  opus_moe_sorting_entry<MoeSortingMultiPhaseKernel_P1>    │ token 排序 / 分组
+x1  opus_moe_sorting_entry<MoeSortingMultiPhaseKernel_P23>   │
+x1  mxfp4_moe_sort_kernel<256,32,24,32>                      │
+x1  mxfp4_moe_sort_kernel<256,64,4,32>                       ┘
+x2  dynamic_per_group_scaled_quant_kernel                      激活量化（bf16→mxfp4）
+x1  mfma_moe1_silu_mul_afp4_wfp4_...     ★ 本 task 的目标
+x1  mfma_moe2_afp4_wfp4_...              ★ 本 task 的目标
+```
+
+注意：**router gate GEMM 和 top-k 选专家不在被计时区间里** —— harness 用 torch 事先算好
+`topk_weights` / `topk_ids` 再传进来，和 vLLM 的调用方式一致。
+
+#### 是什么算子
+
+MoE 路由专家的两段 FFN GEMM，**prefill 侧实现**：aiter FlyDSL 生成的一对 MFMA kernel
+
+```text
+mfma_moe1_silu_mul_afp4_wfp4_bf16_t128x128x256_pm1_async_v32      gemm1（gate+up，融了 silu·mul）
+mfma_moe2_afp4_wfp4_bf16_cshuffle_t128x128x256_..._persist_cu256  gemm2（down）
+```
+
+由 `aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py` 生成（kernel 名在 `:273` / `:3111` 拼出），
+经 `aiter.fused_moe.fused_moe()` 分发。**既不是 Triton，也不是手写 .co 汇编**，
+是 aiter 自带的 FLIR/MLIR Python DSL。
+
+#### E2E 占比
+
+路由专家 GEMM 作为**一个功能**是 **18.60%**，是全模型最大的单一计算功能。
+本 task 的编辑面覆盖其中的 prefill 一半 = **6.01%**。
+
+| kernel | E2E% | prefill 步内 | 单次耗时 | 实测算力 |
+|---|---|---|---|---|
+| `mfma_moe1_silu_mul_...` | 2.06% | 5.12% | 178.1 µs | 2315 TFLOP/s |
+| `mfma_moe2_..._persist_cu256` | 3.95% | 9.83% | 342.3 µs | **602 TFLOP/s** |
+
+#### 对应模型结构的哪个部分
+
+**后 57 层 MoE 层里的路由专家 FFN**（不含共享专家、不含 router gate）。
+
+- 每 prefill 步 55.6 次调用（57 个 MoE 层，其中一个收尾小 chunk 走了别的分支）。
+- 权重（每 rank）：`w1 [128, 1024, 6144]`（`1024 = 2x512` gate+up）、`w2 [128, 6144, 512]`，
+  mxfp4 打包成 `[128,1024,3072]` / `[128,6144,256]`，per-1x32 的 e8m0 scale。
+- 激活 bf16 进来、在 `fused_moe` 内部量化成 mxfp4（所以 kernel 名是 `afp4_wfp4`，a 和 w 都是 fp4）。
+- 一次 prefill 步 8192 个 token x top-4 = 32768 个 (token, expert) 分配。
+
+#### 为什么值得做
+
+两条来自 session 的具体证据：
+
+1. **gemm2 的 FLOPs 只有 gemm1 的一半，耗时却是 2 倍** —— 602 vs 2315 TFLOP/s，同类 shape 差 3.8 倍。
+   两者都没到带宽墙（2.78 / 1.79 TB/s vs 8 TB/s）。gemm2 的启发式名字以 `_atomic` 结尾，
+   per-expert 局部结果怎么累加是第一个该看的地方。
+2. **这个 shape 根本没命中调优表。** server.log 原文：
+   `[fused_moe] no tuned FlyDSL config for ('gfx950', 256, 8192, 6144, 512, 128, 4,
+   ActivationType.Swiglu, ...), using heuristic FlyDSL fallback`。
+   `configs/model_configs/minimax_m3_fp4_tuned_fmoe.csv` 在编辑面里。
+
+#### 测试 case（精度 / 性能同一份，同尺寸）
+
+| id | 阶段 | token | 分发到 |
+|---|---|---|---|
+| `m3-moe-prefill-token8192`（primary） | chunked-prefill 步 | 8192 | aiter FlyDSL 对 —— **本 task 的编辑面** |
+| `m3-moe-decode-token64` | 纯 decode 步 | 64 | CK-Tile 对（**不在本 task 的编辑面内**，只作参照，见第五节） |
+
+公共：128 专家、top-4、`model_dim=6144`、`inter_dim=512`、`QuantType.per_1x32`、
+`ActivationType.Swiglu`、bf16 激活在 `fused_moe` 内部量化成 mxfp4、e8m0 组 scale。
+
+权重准备照搬 vLLM 的 `AITER_MXFP4_MXFP4` loader
+（`vllm/model_executor/layers/fused_moe/oracle/mxfp4.py:973-1014`）的**同一批入口**，不臆测等价布局：
+`e8m0_shuffle` 两个 scale → 权重 view 成 `torch.float4_e2m1fn_x2` → `rocm_aiter_ops.shuffle_weights`
+默认 (16,16)。未 shuffle 的量化副本留给参考实现用。
+
+#### 参考实现与容差
+
+用 aiter 自带的 `torch_moe_stage1` / `torch_moe_stage2` —— 它们解 mxfp4 半字节、套 per-1×32 的
+e8m0 组 scale、在 fp32 累加，是**独立实现**而不是对被测 kernel 的包装；两段都是专家维上的批量 GEMM，
+没有逐专家的 Python 循环。
+
+fp4 运算过不了 `assert_close`，所以容差用余弦相似度 + 相对范数误差
+（`min_cosine=0.97`、`max_rel_norm_err=0.25`），对普通调用和 CUDA-graph 计时调用各校验一次
+（后者会先扰动激活）。实测 prefill `cos=0.9839 / rel_err=0.179`、decode `cos=0.99999 / rel_err=0.005`
+—— 差距是真实的：prefill 走 a4w4（激活也被量化成 fp4），decode 的 CK-Tile 路径直接吃 bf16 激活（a16w4）。
+
+精度测试约 6 分钟，瓶颈是参考实现在 token=8192 下把 128 个专家的权重全部反量化。
+
+---
+
+## 四、task 4 为什么只覆盖 MoE 的一半
+
+`aiter.fused_moe.fused_moe()` 是一个入口，但**按 token 数分发到两套完全不同的实现**：
+
+```text
+token = 8192（prefill 步） ─▶ aiter FlyDSL 对  ─▶ 源码在 aiter/ (python DSL)     ← task 4 覆盖
+token =   64（decode 步）  ─▶ CK-Tile 对       ─▶ 源码在 aiter_meta/ (C++/HIP)   ← 未覆盖
+```
+
+两边源码在两棵不同的树里，而 `image_repo_path` 只能指一个目录，所以一个 task 吃不下两边。
+decode 那半（12.62%）没有做成 task，原因见第五节。
+
+task 4 仍然**两个 token 都跑**（8192 和 64），这样报告里能看到 MoE 的完整画面；
+agent 的编辑只会推动 8192 那个 case，64 那个保持不变 —— 这是诚实的结果，不是 bug。
+
+## 五、刻意没做成 kernel task 的候选
+
+| 候选 | E2E% | 为什么不做 |
+|---|---|---|
+| `ncclDevKernel_Generic_1` all-reduce | 12.22% | RCCL 是预编译的 `librccl.so`；而且真正的修法是改配置——96 MiB 的 prefill 消息超过了 AITER custom-AR 的 64 MiB 阈值（`aiter/dist/device_communicators/custom_all_reduce.py:525`），`max_num_batched_tokens <= 5461` 就能落回快路径 |
+| `aiter::cross_device_reduce_2stage` | 5.16% | 768 KiB 的小消息，纯同步延迟域，改 kernel 够不着 |
+| qkv / o 投影、router gate GEMM、LM head（`Cijk_*`） | 10.2% | hipBLASLt 预编译的 Tensile 汇编，镜像里没有可编辑源码，也没有对应的 `repository_language` |
+| MoE `inter_dim` 从 384 补齐到 512 | 约 3.1% | 是 vLLM 的权重打包问题，不是 kernel 问题 |
+| **MoE decode 侧的 CK-Tile GEMM 对**（`ck_tile::MoeFlatmmKernel`） | **12.62%** | 三条理由叠加，见下方说明 |
+| `_gemma_fused_add_rmsnorm_kernel` | 3.06% | 收益薄，且 `pass_config.fuse_allreduce_rms=True` 已经融了一部分 |
+
+### 关于 MoE decode 侧的 CK-Tile GEMM（曾做过一版，实测后放弃）
+
+这一条本来做成了第 5 个 task（`mi355x_vllm_ck_cktile_moe_2stage_minimax_m3`），实测后删掉了。
+三条理由，都是量出来的：
+
+**1. 编译过不了 5 分钟这条线。** 它是唯一需要真正走 hipcc 重编 C++ 的 task
+（另外四个是 Triton / FlyDSL，改 Python 即时生效，所以都是秒级）。实测 `compile` 各模块耗时：
+
+```text
+module_aiter_core          10.1 s
+module_moe_sorting_opus     6.6 s
+module_moe_cktile2stages  337.8 s   ← 主要开销
+module_activation          17.3 s
+总墙钟 ≈ 10.5 分钟
+```
+
+前后三个是 `AITER_REBUILD=1` 顺带的、能省掉约 34 s；但 **337.8 s 的 CK-Tile 模板实例化省不掉
+—— 重编这个模块正是这种 task 存在的意义。** 就算只留它也在 6 分钟量级。
+
+**2. 目标算子已经到顶。** 两个 GEMM 在 decode 下跑到 **7.18 TB/s ≈ HBM 峰值的 90%**
+（64 token × top-4 触达约 110.8 个专家 = 523 MB fp4 权重，72.8 µs 搬完）。真正能拿的是它们周围
+那 4 个小 pass（清零 / 排序 ×2 / 激活，加上调用方的两个 `[64,6144]` elementwise，合计约 3.7%），
+但那要靠 epilogue 融合，收益远小于编译代价。
+
+**3. 和已有 task 高度重复。** 与 `image_kernel/mi355x_vllm_ck_cktile_moe_2stage`
+**同源码文件、同目标函数**，配置只差 `model_dim`（3072 → 6144）。M3 的 decode 形状如果确实需要，
+给那个已有 task 加一个 case 就够了，不必新开。
+
+顺带记录一个在这个过程中查出来、对别人有用的坑：`module_moe_cktile2stages` 的实例表由一个 blob
+步骤生成，aiter 用裸 `os.system(f"{PY} .../gen_instances.py ...")` 起子进程
+（`aiter/jit/core.py:866`），该子进程只继承环境变量，而 `gen_instances.py` 要
+`from chip_info import get_gfx` —— `chip_info.py` 在 `aiter/jit/utils/` 下、不在任何 path 上，
+于是 `ModuleNotFoundError` → 生成不出 `moe_cktile2stages_lookup.h` → `hipcc` 报
+`fatal error: 'moe_cktile2stages_lookup.h' file not found`。给子进程补 `PYTHONPATH` 即可。
+**已有的 `mi355x_vllm_ck_cktile_moe_2stage` 的 `_configure()` 里同样没设 `PYTHONPATH`，
+很可能撞同一个问题，值得单独查一下。**
+
+---
+
+## 六、四个 task 共同遵守的约定
+
+1. **shape 与 session 一致。** 每个 case 的 shape、dtype、序列长度、launch 几何都是从 torch profiler
+   trace 里读出来的（外层 `cpu_op` 的 `Input Dims` / `Input type`，kernel 事件的
+   `args.grid` / `args.block`）；decode 段被 cudagraph 吞掉调用上下文的，改用 `capture_64_FULL`
+   捕获 trace 补齐。**凡是 prefill 和 decode 都调用的算子，两种 shape 都做成了 case。**
+2. **精度和性能用同一份 case 列表、同一尺寸。** 只有 `compile` 冒烟会缩小。
+3. **性能在 CUDA/HIP graph 下测量**，走 arena 的 `_benchmark_cuda_graph_or_events`；
+   而且*被计时的那一次*调用会在扰动输入后重新校验，防止 kernel 在被打分的路径上比在精度路径上少干活。
+4. **ref 用 torch 且向量化。** 没有逐序列 / 逐专家的 Python 循环；确实塞不下完整中间张量的地方
+   （稀疏 prefill 注意力、prefill 选块打分），循环只是 query 维上的粗分块，
+   块大小按"把工作集压到几百 MB"来定。
+
+---
+
+## 七、实测验证（本容器 MI355X）
+
+### 7.1 agent 的编辑是否真的生效（不是跑旧产物）
+
+对每个 task 往 workspace 源码里注入可观测的改动，看运行结果是否随之改变。
+
+| task | 探针 | 结果 |
+|---|---|---|
+| 1 | 在 `kernel_paged_attention_2d` 体内插 `tl.static_assert(False,"AKA_EDIT_PROBE")` | ✅ 报错同时带 `AKA_EDIT_PROBE` 和 workspace 路径 |
+| 2 | 同上，插进 `_gqa_sparse_fwd_kernel` | ✅ 同上 |
+| 3 | 同上，插进 `_decode_index_score_kernel` | ✅ 同上 |
+| 4 | 改 `mixed_moe_gemm_2stage.py` 里生成的 kernel 名后缀 `_v32` → `_AKAPROBE2` | ✅ profiler 里实际跑的 kernel 变成 `mfma_moe1_..._async_AKAPROBE2`，还原后变回 `_v32`（说明 `aiter/jit/flydsl_cache` 里那 1825 条缓存没有把旧 kernel 顶上来） |
+
+task 1~3 是 Triton，`task_runner` 用 `spec_from_file_location` 从 workspace 副本加载模块，
+Triton 在调用时按 Python 源码 JIT，天然不存在旧产物问题。
+task 4 是 FlyDSL，`aiter/` 整包被 seed 进 workspace 并插到 `sys.path` 最前，
+FlyDSL kernel 在调用时从（可编辑的）Python DSL 生成，**不走 `.so` 缓存**，探针已证实。
+
+### 7.2 耗时与 AITER 重编（要求：每项 < 5 分钟，不触发全量 AITER 编译）
+
+**四个 task 全部通过，最慢一项 11 秒。**
+
+| task | compile | correctness | performance | 重编的 aiter 模块 |
+|---|---|---|---|---|
+| 1 paged_attention_2d | 3 s | 5 s | 6 s | — |
+| 2 gqa_sparse_attn_prefill | 7 s | 10 s | 10 s | — |
+| 3 sparse_index_topk | 7 s | 10 s | 9 s | — |
+| 4 flydsl_mxfp4_moe_2stage | 9 s | 11 s | 11 s | **0 个** |
+
+**task 4 原本 correctness 要 6 分 16 秒，已定位并修复。** 原因不是参考实现慢（实测
+`_reference` 只要 1.07 s / 0.05 s），而是 `_configure()` 里把 `AITER_JIT_DIR` 重定向到了空的
+`<workspace>/build/jit`，于是 token=64 那个 case 走 CK-Tile 时找不到预编译模块、
+**从源码重编了 `module_moe_cktile2stages`（367 s）—— 而那根本不是本 task 的编辑面。**
+修法：FlyDSL 分支不再重定向 `AITER_JIT_DIR`。留空时 aiter 默认用
+`<workspace>/aiter/jit`，那里本来就带着随包拷进来的 108 个预编译 `.so`，而且本身就是
+per-run 的，隔离性不受影响。修完 **9/11/11 秒，零重编**，且编辑探针复测仍然生效。
+
+## 八、CI 注意事项
+
+`src/perf_helper_materialization.py:104` 只 glob `tasks/image_kernel/*/scripts/task_runner.py`，
+所以 `make check-perf-helpers` 看不到这四个。运行时不受影响——
+`materialize_perf_helpers_in_workspace()` 是按路径改 workspace 副本的
+`<workspace>/scripts/task_runner.py`，跟 task 源码在哪个目录无关。
+要把它们也纳入 lint，就放宽那个 glob，或者把本目录挪到 `tasks/image_kernel/` 下。

--- a/tasks/qwen3-8/README.md
+++ b/tasks/qwen3-8/README.md
@@ -1,0 +1,625 @@
+# qwen3-8 — 从 session 100137 抽取的 kernel task
+
+Source: **Qwen3.8-2.4T-A95B-Quark-MXFP4**, session `100137`,
+`/shared_nfs/hyperloom-claw/Qwen3.8-2.4T-A95B-Quark-MXFP4/20260814T175123Z`,
+sglang `0.5.17.dev20260812+gdc5f6c4883` / ROCm 7.2.0 / aiter `d9e5ef7ce`,
+8× MI355X (gfx950), TP=8 EP=8, mxfp4 (Quark), KV fp8_e4m3,
+ISL 8192 / OSL 1024 / conc 64, chunked-prefill 16384, 654.09 s @ 1214.85 tok/s。
+
+完整负载分析：
+`/shared_nfs/jqliu/new-image-hot-kernels/hot-kernels-analysis/qwen38-100137-hot-kernels.md`
+
+E2E 占比的分母是整场压测墙上时间 **654.09 s**（decode 占 56.7%，prefill 40.8%，调度残差 2.5%）。
+decode 侧的数字是 8 rank torch trace 实测；prefill 侧这个 session 没有 trace，只有 shape 是确定的。
+
+模型结构（`config.json`）：92 层，每层 = 一个注意力块 + 一个 MoE 块。
+`layer_types` = **23 层 full_attention + 69 层 linear_attention**（`full_attention_interval=4`）。
+hidden 8192，512 experts / topk 10 / moe_intermediate 2048，shared expert intermediate 2048。
+
+## 筛选标准
+
+每个 task 的计算核都是**镜像里可编辑的源码**，并且运行时从该源码 JIT 编译——
+补丁改的就是真正跑起来的东西。按设计排除：
+
+- **通信算子**（按要求排除）—— prefill RCCL all-reduce（~15.3% E2E）和 decode
+  `cross_device_reduce_2stage`（8.05% E2E）。这两个加起来是 workload 的最大单项。
+- **预编译二进制算子** —— 实现只以编译产物存在的。
+- **后端 tuning 类工作** —— 填调优表、改派发启发式，而不是改 kernel 代码。
+
+## 总览
+
+| task | 算子 | **任务形态** | E2E | 后端 | 覆盖层数 |
+|---|---|---|---|---|---|
+| `mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38` | MoE routed-expert 两段 grouped GEMM | **单算子**（1 次 API 调用 → 6 个 kernel） | **17.9%** | FlyDSL → MLIR → AMDGCN | 92 / 92 |
+| `mi355x_sglang_triton_gdn_linear_attn_qwen38` | Gated DeltaNet 线性注意力 decode 核心 | **多算子链路**（5 个 kernel + torch split/cat） | **5.76%**（整链） | Triton | 69 / 92 |
+| `mi355x_sglang_aiter_paged_attention_decode_qwen38` | paged GQA decode 注意力 | **单算子**（1 次 API 调用 → 2 个 kernel） | **3.36%** | HIP C++（`csrc/cpp_itfs/pa`） | 23 / 92 |
+
+合计 **27.0% E2E** —— 这基本就是这个 workload 里「非通信 + 源码可编辑 + decode trace 能归因」的全部计算。
+
+## 与 `tasks/image_kernel/` 下已有 task 的重叠
+
+三个 task 里**两个和已有 task 命中同一个 kernel**，都不是完全重复，但差异点必须写清楚：
+
+| 本 task | 已有 task | 重叠程度 | 区分点 |
+|---|---|---|---|
+| MoE 2-stage | `mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3` | **同一个源文件，不同 builder 函数** | K3 是 a16w4 → `compile_mixed_moe_gemm1_a16w4`(:4959) / `_a16w4`(:7215)；本 task 是 a4w4 → `compile_mixed_moe_gemm1`(:147) / `compile_mixed_moe_gemm2`(:3079)。另外 K3 走 tuned 路径、SiTUv2、vllm，本 task 走 heuristic fallback、Silu、sglang |
+| paged attention | `mi300x_sglang_hip_pa_ragged`（最接近）、`mi300x_sglang_hip_pa_decode`、`mi355x_vllm_hip_paged_attention_decode` | **同一个 kernel、同一个入口、同一套源文件** | 已有的都是 head 128/64 + KV `auto`(bf16) + block 16 + ctx ≤4097；本 task 是 head **256** + KV **fp8_e4m3** + block **1** + ctx 8192–9216。前三项决定了这是**另一个模板实例** |
+| GDN 线性注意力 | `mi355x_vllm_triton_kda_linear_attn_kimi_k3`（形态相似） | **不重叠** | KDA ≠ GDN，是两个算法；kernel 名、仓库（vllm vs sglang）都不同 |
+
+两点后续处理：
+
+- MoE task 的 `logical_operator` 原本和 K3 那个**字符串完全相同**（`aiter_mxfp4_moe_2stage`），
+  已改成 `aiter_mxfp4_moe_2stage_a4w4`；`target_kernel_functions` 也从三个共用的包装函数
+  改成直接指两个 a4w4 builder，让两个 task 按 target 就能区分，而不是只靠名字。
+- paged attention task 和 `mi300x_sglang_hip_pa_ragged` 是**同一 kernel 的不同实例化**。
+  保留成独立 task 是因为 fp8 KV + head 256 走的是另一份编译产物；
+  但如果不想在这个 kernel 上挂第四个 task，`session_cases.json` 里那三个 case
+  可以直接并进 `mi300x_sglang_hip_pa_ragged`。
+
+> 顺带：之前被移除的 dense bf16 GEMM task 也会和 `mi300x_sglang_triton_gemm`
+> （同仓库、同 `_gemm_a16_w16_kernel`）部分重叠，现在不存在这个问题了。
+
+## 单算子 vs 多算子链路
+
+两种形态在这套 task 里的含义不同，写 patch 和读分数时要区分：
+
+- **单算子任务**（task 1、task 3）——计时单元是**一次库函数调用**，是模型代码里实际调用的那个
+  API 边界。它内部派发多少个 kernel 由库自己决定：MoE 是 6 个（2 个 GEMM + 4 个排序/量化辅助），
+  paged attention 是 2 个（主 kernel + 跨 partition 归约）。这些 kernel 不是「凑」在一起的，
+  是同一个算子的内部阶段，边界由库定义而不是由这套 task 定义。
+- **多算子链路任务**（task 2）——计时单元是**模型代码里连续调用的一串独立算子**，
+  边界是这套 task 自己划的（两个输入投影之后、输出投影之前）。之所以这样划，
+  是因为链路里 5.76 个 E2E 点中有 2.35 点是算子之间的数据搬运，
+  单独打其中任何一个 kernel 都看不到这块。**跨算子融合在这个 task 里是合法且预期的优化手段**，
+  在两个单算子 task 里则不是——那里改的是一个已有算子的内部实现。
+
+---
+
+# 1. `mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38`
+
+> **任务形态：单算子。** 计时单元是一次 `aiter.fused_moe.fused_moe` 调用——
+> 就是 sglang 的 MoE runner 实际调的那个 API 边界。
+
+## 是什么算子
+
+**MoE routed-expert 的两段 grouped GEMM**，一次 `aiter.fused_moe.fused_moe` 调用里的 stage-1 和 stage-2：
+
+| kernel | 做什么 |
+|---|---|
+| `mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32` | stage-1：gate_up 投影（8192 → 2×2048）+ 融合的 SiLU·Mul |
+| `mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_vscale_fix3_fp4opt_v1_persist_cu256` | stage-2：down 投影（2048 → 8192）+ 按 topk 权重加权合并 |
+
+后端是 **FlyDSL**（aiter 自研 Python kernel DSL → MLIR → AMDGCN，运行期 JIT）。
+数据类型是 **a4w4**：激活和权重都是 MXFP4（group_size 32，e8m0 scale），输出 bf16。
+
+一次调用内部实测派发 **6 个 kernel**（本容器 M=64，profiler 实测）：
+
+| kernel | us | 角色 |
+|---|---|---|
+| `mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32` | 136.0 | **优化目标** |
+| `mfma_moe2_afp4_wfp4_bf16_cshuffle_..._persist_cu256` | 68.4 | **优化目标** |
+| `opus_moe_sorting_entry<...P0_v2>` | 6.0 | expert 排序 |
+| `fused_mx_quant_moe_sort_kernel<bf16, fp4_t, 256, 32>` | 5.9 | stage-1 输入量化 |
+| `fused_mx_quant_moe_sort_kernel<bf16, fp4_t, 256, 8>` | 5.3 | stage-2 输入量化 |
+| `opus_moe_sorting_entry<...P23>` | 4.4 | expert 排序 |
+| 合计 | 226.0 | 两个 GEMM 占 **90.4%** |
+
+后四个是同一算子内部的辅助阶段，一起被计时（因为改 GEMM 的 tile 会改变它们的输入布局，
+拆开计时会漏掉这部分代价），但优化目标是前两个。
+
+## E2E 占比
+
+| | ms/step（8 rank 均值） | %decode step | **%E2E** |
+|---|---|---|---|
+| stage-1 | 6.3257 | 20.50% | **11.62%** |
+| stage-2 | 3.3994 | 11.02% | **6.25%** |
+| 合计 | 9.7251 | 31.52% | **17.9%** |
+
+**这是整个 workload 里最大的非通信算子。** prefill 侧还有一份未计入的贡献，
+因为 session 没抓 prefill trace，无法定量。
+
+## 对应模型结构的哪个部分
+
+**全部 92 层的 MoE 块中的 routed expert 部分**。每层调用一次，每步 92 次。
+
+```
+layer[i]:
+  ├── attention block            → task 2 / task 3
+  └── MoE block
+        ├── router mlp.gate       (dense GEMM，不在本 task)
+        ├── shared expert         (dense GEMM + act，不在本 task)
+        └── routed experts  ←──── 本 task
+              512 experts，EP=8 后每卡 64 个，topk=10
+              stage-1: [tokens, 8192] × w1[64, 4096, 8192]  → SiLU·Mul → [tokens×10, 2048]
+              stage-2: [tokens×10, 2048] × w2[64, 8192, 2048] → 加权合并 → [tokens, 8192]
+```
+
+MoE 块里的 router gate 和 shared expert 走 dense bf16 GEMM（hipBLASLt 预编译 Tensile），
+**不在这个 task 里**。
+
+## 覆盖的 shape
+
+三个 M 桶，派发**三个不同的 kernel 对**（`aiter/fused_moe.py:2249-2255` 的启发式）：
+
+| case | M | session 里的来源 | tile |
+|---|---|---|---|
+| `qwen38-moe-decode-m64` | 64 | 被 profile 的那个 decode step（conc 64） | t32x128x256 |
+| `qwen38-moe-prefill-m8192` | 8192 | 429 个 prefill batch 里的 26 个 | t128x128x256 |
+| `qwen38-moe-prefill-m16384` | 16384 | 429 个 prefill batch 里的 403 个 | t64x128x256 |
+
+## 编辑面与 harness 约束
+
+编辑面是 **FlyDSL MLIR builder**：`ops/flydsl/kernels/mixed_moe_gemm_2stage.py`
+（`compile_mixed_moe_gemm1` :147 / kernel :468，`compile_mixed_moe_gemm2` :3079 / kernel :3275）。
+杠杆：MFMA 流水、tile/block 循环结构、LDS 与 ping-pong staging、async-copy 调度、
+stage-2 persistent CU 映射、CShuffle epilogue、atomic 归约。
+
+tuned CSV **刻意不在编辑面里**——填查表是后端 tuning，不是 kernel 工作。
+但「session 从来没调优过」是 headroom 的来源：server.log 打了 **120 次**
+`no tuned FlyDSL config`，覆盖全部 15 个 M 桶、8 个 rank。
+
+harness 强制的不变量：
+
+1. **断言走 FlyDSL 派发。** `use_mxfp4_flydsl`（`aiter/fused_moe.py:2198`）要求
+   `is_shuffled` 且 `not doweight_stage1`；缺一个就会静默掉到 CK 2-stage 路径——完全是另一个 kernel。
+2. **按 case 钉死 kernel 对**（`expected_dispatch`），防止某个 case 漂到别的 M 桶、
+   去打一个从未被校验过的 kernel。
+3. **权重准备复刻 sglang loader**（`quark_w4a4_mxfp4_moe.py:577-597`）：
+   先 `e8m0_shuffle` 二维 scale 视图，再 `shuffle_weight(w, (16,16))`，再置 `is_shuffled = True`。
+4. **correctness 取 3 次最差**——stage-2 用 atomic 归约，单次可能撞运气。
+5. **被计时的那次调用会被重新校验**（扰动输入 + NaN 毒化输出 + 重放图），而不是信任旁边一次调用。
+
+## 参考实现
+
+独立的向量化 torch 实现，不是包装。aiter 自带的 `torch_moe_stage1/2` 用不了：
+它会 dequant 到 fp32 并展开 `[token, topk, 2·inter]`，在 prefill M=16384 下是 2.7 TB。
+本实现每次只 dequant 一个 expert（唯一的 Python 循环是对 64 个本地 expert，每次两个稠密 GEMM），
+并且把激活和 stage-1 输出按 kernel 的方式做 MXFP4 fake-quant，所以只剩累加顺序的差异。
+
+---
+
+# 2. `mi355x_sglang_triton_gdn_linear_attn_qwen38`
+
+> **任务形态：多算子链路。** 计时单元是模型代码里连续调用的 5 个独立算子加 torch 的
+> split/cat，边界由本 task 划定（两个输入投影之后、输出投影之前）。
+> **跨算子融合是本 task 预期的优化手段。**
+
+## 是什么算子
+
+**Gated DeltaNet（线性注意力）的 decode 核心**——模型在两个输入投影之后、输出投影之前做的全部事情。
+计时单位是整条链路而不是单个 kernel，因为在 session 的 trace 里它每层打出 5 个 kernel：
+
+| kernel | 做什么 | 后端 |
+|---|---|---|
+| `fused_recurrent_gated_delta_rule_packed_decode_kernel` | 门控 delta rule 递推（含 qk L2-norm） | Triton |
+| `at::native::elementwise_kernel_manual_unroll` (`aten::copy_`) | b/a 门的 `.contiguous()` + norm 输出 reshape | ATen |
+| `at::native::CatArrayBatchedCopy` (`aten::cat`) | 拼 `mixed_qkv` | ATen |
+| `_causal_conv1d_update_kernel` | 短卷积状态更新（width 4） | Triton |
+| `_layer_norm_fwd_1pass_kernel` | 输出 gated RMSNorm（swish 门） | Triton |
+
+## E2E 占比
+
+| kernel | 次/step | ms/step (TP-0) | %decode step | **%E2E** |
+|---|---|---|---|---|
+| `fused_recurrent_gated_delta_rule_packed_decode` | 69 | 1.2397 | 4.018% | 2.278% |
+| `aten::copy_` | 208 | 0.9052 | 2.934% | **1.663%** |
+| `aten::cat` | 69 | 0.3765 | 1.220% | **0.692%** |
+| `_causal_conv1d_update` | 69 | 0.3148 | 1.020% | 0.578% |
+| `_layer_norm_fwd_1pass` | 69 | 0.3005 | 0.974% | 0.552% |
+| **整链** | | **3.1367** | **10.17%** | **5.76%** |
+
+单看递推 kernel 只有 2.278%，够不到 5% 的热点线。**打包计时的理由是：5.76 个点里有 2.35 个点是纯数据搬运。**
+Qwen3.8 的 `num_v_heads // num_k_heads = 128 // 16 = 8`，不在 `(1, 2, 4)` 里，
+所以 `srt/models/qwen3_5.py:640` 不走融合的 split/cat helper，落进朴素 torch 分支——
+每步那 208 次 `aten::copy_` 和 69 次 `aten::cat` 就是从这来的。只打递推 kernel 会把最大的杠杆藏起来。
+harness 会断言这个 head 比例，配置一旦变化导致模型改走融合 helper，task 会直接失败而不是默默测别的东西。
+
+## 对应模型结构的哪个部分
+
+**69 层 linear_attention 层的注意力块核心**（`Qwen3_5GatedDeltaNet`）。每层调用一次，每步 69 次。
+
+```
+linear_attention layer[i]:
+  ├── in_proj_qkvz  [., 8192] × [8192, 4608]   (dense GEMM，不在本 task)
+  ├── in_proj_ba    [., 8192] × [8192, 32]     (dense GEMM，不在本 task)
+  ├── ┌─────────────────────────────────────┐
+  │   │ fix_query_key_value_ordering (split) │
+  │   │ torch.cat(q, k, v) → mixed_qkv       │  ←── 本 task 的计时单位
+  │   │ causal_conv1d_update  (width 4)      │
+  │   │ fused_recurrent_gated_delta_rule     │
+  │   │ RMSNormGated(core_attn_out, z)       │
+  │   └─────────────────────────────────────┘
+  └── out_proj      [., 2048] × [8192, 2048]   (dense GEMM，不在本 task)
+```
+
+单卡几何（TP=8）：2 个 k head × 128，16 个 v head × 128，conv_dim 2560，
+SSM state `[slots, 16, 128, 128]` bf16（`--mamba-ssm-dtype bfloat16`）。
+
+## 覆盖的 shape
+
+`qwen38-gdn-decode-bs64`，bs=64（conc 64），只有 decode。
+
+**没有 prefill case 是刻意的**：这个算子的 prefill 走的是**另一个 kernel**
+（`kernels/ops/attention/fla/chunk.py::chunk_gated_delta_rule`，chunked scan 而不是单步递推），
+而 session 100137 根本没抓 prefill trace，造一个合成 prefill case 只会去打一个 session 无法证实的形状。
+
+## 有状态算子的处理
+
+conv cache 和 SSM state 都**原地更新**（`gdn_triton.py` 传的是 `ht=initial_state`）。
+CUDA graph 重放会把状态推进 N 次。harness 正面处理而不是绕开：
+
+- prepare 时对 cache 做快照，每次测量前恢复；
+- 计时校验读 `benchmark_effective_repeats`，把 torch 参考从**同一快照**步进**同样次数**；
+- correctness 额外校验 `conv_state` 和 `ssm_state`——输出对但把 cache 写坏的实现会毁掉下一个 token，必须拦住。
+
+## 参考实现
+
+完全向量化的 torch，从 Triton 源码转写而非调用它：batch 和 head 维都没有 Python 循环，
+递推步是 `[B, HV, V, K]` 上的批量外积更新加两个 `einsum`。
+
+---
+
+# 3. `mi355x_sglang_aiter_paged_attention_decode_qwen38`
+
+> **任务形态：单算子。** 计时单元是一次 `aiter.ops.attention.paged_attention_ragged`
+> 调用——sglang 的 aiter backend 实际调的那个 API 边界。它派发 2 个 kernel，
+> 是同一算子的两个阶段（分 partition 计算 + 跨 partition 归约），不是两个独立算子。
+
+## 是什么算子
+
+**paged GQA decode 注意力**，aiter 的 ll4mi 实现，两个 kernel：
+
+| kernel | 做什么 |
+|---|---|
+| `paged_attention_ll4mi_QKV_mfma16_kernel<0, __hip_bfloat16, unsigned char, (vllm::Fp8KVCacheDataType)1, 1, 256, 256, false, 8, 1, ck_tile::ComposedAttention<...>>` | 分 partition 的 QK^T·softmax·V，fp8 KV 在 kernel 内反量化 |
+| `paged_attention_ll4mi_reduce_kernel<__hip_bfloat16, __hip_bfloat16, 256, 256, 256, 1, false>` | 跨 partition 归约 |
+
+后端是 **HIP C++**（`aiter/csrc/cpp_itfs/pa/pa_kernels.cuh` 2275 行 + `pa_ragged.cuh` / `pa.cuh`），
+运行期 JIT 编译——跑 harness 时能看到它现场 build，所以是真可编辑源码，不是预编译汇编。
+
+## E2E 占比
+
+| kernel | 次/step | ms/step (TP-0) | %decode step | **%E2E** |
+|---|---|---|---|---|
+| `paged_attention_ll4mi_QKV_mfma16` | 23 | 1.7119 | 5.549% | **3.146%** |
+| `paged_attention_ll4mi_reduce` | 23 | 0.1149 | 0.372% | 0.211% |
+| 合计 | | 1.8268 | 5.921% | **3.36%** |
+
+**够不到 5% 的热点线**，收进来的理由是配置罕见：**head_size = 256**（绝大多数在服务的模型是 128）、
+KV 是 **fp8_e4m3** 在 kernel 内反量化、GQA group 恰好是 8。这个模板实例受到的调优关注远少于 128 那个。
+
+## 对应模型结构的哪个部分
+
+**23 层 full_attention 层的注意力核心**。每层调用一次，每步 23 次。
+
+```
+full_attention layer[i]:
+  ├── qkv_proj   [., 8192] × [8192, 4608]      (dense GEMM，不在本 task)
+  ├── mRoPE / q-k Gemma-RMSNorm / reshape_and_cache  (不在本 task)
+  ├── ┌──────────────────────────────────────┐
+  │   │ paged_attention_ll4mi_QKV_mfma16      │  ←── 本 task
+  │   │ paged_attention_ll4mi_reduce          │
+  │   └──────────────────────────────────────┘
+  ├── 输出门 sigmoid·mul（attn_output_gate）    (不在本 task)
+  └── o_proj     [., 2048] × [8192, 2048]      (dense GEMM，不在本 task)
+```
+
+单卡几何（TP=8）：`num_attention_heads 64` → 每卡 8 个 q head；
+`num_key_value_heads 4 < tp_size 8`，`QKVParallelLinear` 会先把 kv head 补齐到 8 再切，
+所以每卡恰好 1 个 k head、1 个 v head，GQA group = 8（和 kernel 模板参数对上）。
+`head_dim 256`，`page_size 1`，`partition_size 256`。
+
+> kv head 补齐不是猜的：正因为补到 8，`qkv_proj` 的每卡输出宽度才是
+> `(64×2 + 8 + 8) × 256 / 8 = 4608`，这正是 capture trace 记录的 `aten::mm` 的 N
+> （92 次 `[64,8192]×[8192,4608]`）。不补齐会是 4352，而 4352 从未出现过。
+
+## 覆盖的 shape
+
+bs=64，三个 context 长度覆盖 session 的整个 decode 区间：
+
+| case | seq_len | 是什么 |
+|---|---|---|
+| `qwen38-pa-decode-bs64-seq8192` | 8192 | 刚进 decode，只有 ISL |
+| `qwen38-pa-decode-bs64-seq8704` | 8704 | profiler 窗口所在处，上面那两个 E2E 数字就是在这测的 |
+| `qwen38-pa-decode-bs64-seq9216` | 9216 | 生成结束，ISL 8192 + OSL 1024 |
+
+**没有 prefill case 是刻意的**：`paged_attention_ragged` 只是 decode 入口，
+chunked prefill 走同一 backend 里另一条 ragged/MHA 路径（server.log 记录 `prefill cuda_graph=disabled`），
+而那个 prefill kernel 从未被采样过——session 没有 prefill trace，它的身份和代价都不知道。
+
+## 与已有 task 的差异（细化）
+
+这个 kernel 在 `tasks/image_kernel/` 下已经被三个 task 命中，差异全在实例化：
+
+| | 已有 task | 本 task |
+|---|---|---|
+| `head_size` | 128（另有一个 64） | **256** |
+| KV cache | `"auto"` → bf16 | **fp8_e4m3**，kernel 内反量化 |
+| 模板参数 | `Fp8KVCacheDataType(0)` | **`Fp8KVCacheDataType(1)`** |
+| `block_size` | 16 | **1** |
+| context | 128 / 1024–2048 / 4097 | **8192 / 8704 / 9216** |
+| 来源 | 合成 | session 100137 trace |
+
+前三项选中的是**另一份编译产物**，所以优化工作不等价。但如果不想在这个 kernel 上挂第四个
+task，`session_cases.json` 里那三个 case 可以直接并进 `mi300x_sglang_hip_pa_ragged`。
+
+## 后端被钉死
+
+和别的 task 不同，harness 会断言 `paged_attention_ll4mi_QKV_mfma16_kernel` 确实跑了，
+并且 fp8 KV 模板参数仍是 `(vllm::Fp8KVCacheDataType)1`。换后端或把 cache 悄悄放宽成 bf16
+是换题目，不是优化。
+
+## 参考实现
+
+完全向量化的 fp32 GQA——两个 `einsum` 加一个 softmax，batch / head / partition 维都没有循环。
+因此它同时也是 ll4mi 那两个 kernel 分 partition 归约的独立实现。
+
+---
+
+# 目录结构
+
+**每个 task 目录是自包含的**——只依赖自己文件夹下的东西，不引用兄弟目录、
+也没有共享的 `_shared/`。目录之间可以单独拷走、单独跑。
+
+```
+README.md              本文件——qwen3-8 目录下唯一的 README
+<task>/
+  config.yaml          AgentKernelArena task 定义
+  session_cases.json   trace 导出的 shape/dtype + provenance
+  scripts/
+    task_runner.py     Arena harness（compile / correctness / performance）
+    forge_driver.py    forge-loop 驱动（correctness / bench / profile-run）
+```
+
+单 task 目录下**不放 README**，说明全部集中在本文件；三个 task 各占一个 section。
+
+`build/` 是运行期产物（aiter JIT `AITER_JIT_DIR`、Triton cache、
+`performance_report.json`），由 harness 在各 task 目录下自动创建，**不入库**。
+想清干净：`rm -rf tasks/qwen3-8/*/build`。
+
+`scripts/task_runner.py` 是这个 task 唯一的 harness 源文件，直接改它即可，
+没有生成步骤。CUDA-graph 计时用的那段公共 helper 逐字内联在文件里，
+夹在 `make sync-perf-helpers` 认的那对 `AKA-GENERATED` 标记之间——
+所以既能自包含运行，也能在 `src/tools/perf/vllm_cuda_graph_block.py` 更新后被重新同步。
+**不要手改标记之间的内容**，那段会被同步覆盖。
+
+---
+
+# 四条 harness 要求的落实
+
+**1 — 测试 shape 与真实 E2E session 一致，prefill/decode 都调用的就都覆盖。**
+每个 shape 都来自 session 的 CUDA-graph capture trace（`record_shapes=True`），
+或由 `config.json` 推出后与之核对，记录在 `session_cases.json` 的
+`trace_input_shapes` / `trace_input_dtypes` 里。
+
+| task | decode | prefill |
+|---|---|---|
+| MoE 2-stage | M=64 | M=8192 **和** M=16384（session 真实跑的两种 batch：429 个里的 26 和 403） |
+| GDN 线性注意力 | bs=64 | 无 —— *prefill 走的是另一个 kernel*，见上 |
+| paged attention | bs=64 × seq {8192, 8704, 9216} | 无 —— *这是 decode 专用入口*，见上 |
+
+两个「无」都写进了对应 `session_cases.json` 的 `prefill_note` 和 task README。
+这两个算子的 prefill 都派发到**不同的 kernel**，而 session 100137 **完全没有 prefill trace**
+——两个 profiler 窗口抓到的 128 步全是 `step[DECODE bs=64]`。
+造一个合成 prefill case 只会去打一个 session 无法证实的形状，所以没造。
+
+**2 — 精度测试与性能测试的 shape 覆盖一致。** 每个 harness 的两个 mode 都遍历同一个
+`CASES` 列表，没有按 mode 调整 shape、没有 `correctness_token` 缩小、
+没有 `correctness_only` / perf-only case。MoE task 还按 case 钉死了派发的 kernel 对。
+
+**3 — 性能基于 CUDA graph 测量。** 三个 task 都用逐字嵌入的
+`src/tools/perf/vllm_cuda_graph_block.py` 里的 `_benchmark_cuda_graph_or_events`。
+下面验证跑里每个 case 都报 `benchmark_method: cuda_graph`，没有回落到 event timing。
+每个 harness 还传了 `_TimedRun`，所以校验的是**被计时的那次调用**本身
+（扰动输入、NaN 毒化输出、重放图），而不是信任旁边一次调用。
+
+GDN task 在这里多花了功夫：它有状态，重放会把 cache 推进 N 次，
+harness 读 `benchmark_effective_repeats` 并把参考步进同样次数，而不是把图退化成单次调用来回避。
+
+**4 — torch 参考向量化。** 没有任何参考对 token / head / batch 做 Python 循环：
+
+| task | 参考做法 | 耗时 |
+|---|---|---|
+| MoE | 逐 expert dequant + 2 个稠密 GEMM；唯一循环是对 64 个本地 expert | ~4.5 s/case |
+| GDN | `[B,HV,V,K]` 批量外积状态更新 + 2 个 einsum，无循环 | <0.1 s |
+| paged attn | 对 dequant 后的 cache 做 2 个 einsum + softmax，无循环 | <0.1 s |
+
+---
+
+# 验证跑（本容器，1× MI355X gfx950）
+
+三个 task 都完整跑过 `compile` / `correctness` / `performance`，
+全部 case 通过且 `benchmark_method: cuda_graph`。
+
+| task | cases | correctness | perf |
+|---|---|---|---|
+| MoE 2-stage | 3 | cos 0.9886–0.9887 | 0.2295 / 0.7856 / 1.2243 ms |
+| GDN 线性注意力 | 1 | cos 0.999994（外加 cache 校验） | 0.029906 ms |
+| paged attention | 3 | cos ≈ 0.99995 | 0.0579 / 0.0629 / 0.0701 ms |
+
+两件静态分析看不出来、跑起来才确认的事：
+
+- **派发的 kernel 名与 session trace 完全一致**，包括两个 `paged_attention_ll4mi_*`
+  模板实例和三对 MoE FlyDSL kernel。
+- **MoE 的 tile 启发式是三档不是两档。** harness 的 `expected_dispatch` 不变量抓出了
+  case spec 初稿的一个错：`fused_moe.py:2251` 把 `4096 ≤ token < 16384` 送到 `tile_m=128`，
+  所以 session 的 8192-token prefill batch 跑的是**第三对** kernel（`t128x128x256`），
+  和 decode（`t32`）、16384-token prefill（`t64`）都不同。
+
+**适用于全部三个 task 的说明**：harness 的绝对耗时是**单卡孤立**测量
+（单算子、GPU 空闲、无 TP、无外围图），比同一 kernel 在 session 的 92 层 decode 图里快 1.3–1.8 倍。
+用它看**相对**提升；E2E 的权威仍是 session trace。
+
+---
+
+# 编辑生效性与耗时（已实测验证）
+
+## 编辑一定被重新编译，不会跑旧产物
+
+对每个 task 都做了同一个实验：按 `config.yaml` 的 `image_repo_path` / `repo_subdir`
+把仓库 seed 进一个干净 workspace，先跑一遍 correctness 确认基线通过，
+然后在**编辑面内**注入一个数值扰动（把 kernel 输出乘 1.5），再跑一遍。
+输出必须变化——如果仍然原样通过，就说明跑的是旧的编译产物。
+
+| task | 编辑的文件 | 基线 | 注入 ×1.5 后 |
+|---|---|---|---|
+| MoE（FlyDSL） | `aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py` 的 `silu_elem` | PASS cos 0.988737 | **FAIL** rel_err 0.5555 |
+| GDN（Triton） | `sglang/kernels/ops/attention/fla/fused_recurrent.py` 的 packed-decode kernel | PASS cos 0.999994 | **FAIL** cos 0.998465 |
+| paged attn（HIP） | `csrc/cpp_itfs/pa/pa_kernels.cuh` 的 reduce kernel | PASS rel_err 0.01020 | **FAIL** rel_err 0.50001 |
+
+三条各自依赖的机制：
+
+- **MoE**：workspace 的 `aiter/` 通过 `sys.path.insert` 覆盖镜像安装
+  （实测 `imported from: <ws>/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py`）。
+  FlyDSL 的 cache key 包含 kernel 函数源码及其依赖源码
+  （`flydsl/compiler/jit_function.py:572-598`），所以**即使 `module_name` 没变**，
+  改了 kernel body 也会重新编译——上表的扰动就没有改名字。
+  镜像里自带的 2.2 GB `aiter/jit/flydsl_cache` 因此不会喂回旧 kernel。
+- **GDN**：同样靠 `sys.path` 覆盖；Triton 按源码哈希缓存，`TRITON_CACHE_DIR` 又指向
+  workspace，天然隔离。
+- **paged attention**：靠 `AITER_META_DIR=<workspace>`，让
+  `csrc.cpp_itfs.utils.AITER_CORE_DIR` 解析到 workspace，编译时 include 的是被改过的
+  `.cuh`。**这一条原本是坏的，已修**，见下。
+
+## 修掉的一个真实缺陷：paged attention 会跑旧二进制
+
+aiter 的 ll4mi kernel 走 `compile_template_op`（`csrc/cpp_itfs/utils.py:300`）：
+
+- 缓存目录是 `$AITER_ROOT_DIR/build/<md_name>_<md5(模板参数)>`，
+  md5 只覆盖 head_size / dtype / block_size 这些**模板参数**，**不覆盖 `.cuh` 的内容**；
+- 唯一的新鲜度判断是 `not_built()`——「`lib.so` 在不在」（`utils.py:297`）；
+- `AITER_ROOT_DIR` 默认 `$HOME/.aiter`（`utils.py:68`），**全机共享**。
+
+结果：agent 改了 `pa_kernels.cuh`，文件夹名不变，`lib.so` 还在 → **直接跑旧二进制**；
+而且不同 workspace 之间还会互相串。反证做过：把 `AITER_ROOT_DIR` 指回 `/root/.aiter`
+复现修复前的行为，上面那个 ×1.5 的扰动被**完全忽略**，correctness 原样通过
+（cos 0.999948 / rel_err 0.01020）。
+
+修法在 `scripts/task_runner.py` 的 `_pin_template_op_build_dir()`：把 PA 相关源文件
+（`csrc/cpp_itfs/pa/**` 的 `.cuh/.h/.jinja/.cpp/.py` 加 `utils.py`）做 sha256，
+取前 12 位拼进 `AITER_ROOT_DIR = <workspace>/build/aiter-<hash>`。
+于是缓存既是 workspace 本地的（不串），又是内容寻址的（改了必重编，没改仍命中）。
+实测编辑后目录从 `aiter-08db1bfbc493` 变为 `aiter-9a681af165ed`，触发真实重编译。
+
+## 耗时：没有全量 aiter 编译，每个 mode 都在 1 分钟内
+
+三个 task 都不触发 aiter 全量编译——镜像里预编译的 `aiter/jit/*.so`
+（`module_aiter_core` 等约 1 GB）直接复用；只有本 task 真正用到的模块会现编：
+MoE 冷启动编 `module_moe_sorting_opus`(7.7 s) 和 `module_quant`(13.9 s)，
+PA 编一个 `pa_ragged_<md5>`(≈19 s)，GDN 一个都不编。
+
+| task | 冷启动 compile | correctness | performance | 改完源码后再跑一轮 |
+|---|---|---|---|---|
+| MoE 2-stage | 52 s | 12 s | 12 s | 8 / 19 / 12 s |
+| paged attention | 36 s | 8 s | 8 s | 5 / 8 / 8 s |
+| GDN 线性注意力 | 6 s | 6 s | 6 s | 5 / 5 / 6 s |
+
+最慢一格 53 s，离 5 分钟上限有充足余量。`config.yaml` 里的 timeout
+（900–3600 s）是保守上界，不是预期耗时。
+
+> seed 成本另说：`image_repo_path` 指的 `aiter/` 包整体约 6.3 GB，其中
+> `jit/build`(2.9 G) 已在 `image_repo_exclude` 排除，剩下 `jit/flydsl_cache`(2.2 G)
+> 和预编译 `.so`(≈1 G) **必须保留**——去掉前者会让 FlyDSL 每轮从头编，
+> 去掉后者会触发 aiter 全量重编，两者都与「不要全量编译」冲突。
+
+# Arena + KernelForge forge-loop（已实测跑通）
+
+三个 task 都用 `/shared_nfs/jqliu/run_arena/run_qwen38.sh <task> <suffix>` 端到端跑过，
+环境取自 `/shared_nfs/jqliu/set_env.sh`，logs/workspace 放 `/tmp`（NFS 上跑会把共享
+cgroup 的 page cache 顶到上限，见 `config.forge_mxfp4.yaml` 的注释）。
+
+| task | driver | prepare | forge baseline | anchor 校验 |
+|---|---|---|---|---|
+| GDN 线性注意力 | task-provided | skipped | 0.030 ms | 1 of 1 |
+| paged attention | task-provided | skipped | 0.063 ms | 3 of 3 |
+| MoE 2-stage | task-provided | skipped | 0.735 ms | 3 of 3 |
+
+`prepare = skipped` 是期望结果：prepare 是一个有预算上限的 LLM 修复循环，专门把不合规的
+driver 改写到合规；跳过意味着 forge 直接接受现成 driver，预算全花在优化上。
+`anchor` 那行是 forge 用自己的方式重跑 case 后与 harness reference 对账的结果。
+
+## 为什么每个 task 自带 `scripts/forge_driver.py`
+
+`agents/forge/launch_agent.py:822` 优先使用 task 自带的 `scripts/forge_driver.py`（逐字拷贝到
+workspace 根），没有才生成一个包 `agents/forge/drivers/arena_task_adapter` 的 shim。
+那个 shim 用 `parse_known_args`，**会把 `--profile-run` 当未知参数吞掉**、退回跑 correctness；
+而 KernelForge 的 `_check_profile_contract` 只断言 `returncode == 0`，于是 shim
+在完全没有 profiling 路径的情况下通过了闸门。1.75 h 预算下 Analysis 本来就是 `static-only`
+（`cli.py:2088`：< 2 小时一律 static-only），不会暴露；一旦 campaign 超过 2 小时，
+Analysis 切成 `profiled` 就会真正调用这条不存在的路径。kimi_k3 自带 driver 的注释记了这个坑：
+它的源 session 就是这么 `task_preparation_failed` 的。
+
+## driver 实现的契约
+
+stdout 被这两处解析：`mcp_server/tools/test.py:74-83`、`mcp_server/tools/bench.py:341-347`。
+
+| 模式 | 输出 | 说明 |
+|---|---|---|
+| `--mode <smoke\|stability\|determinism\|full>` | `SNR: <db> dB` / `allclose:` / `max_diff:` | 取全 suite 最差值 |
+| `--warmup N --iters N --bench-mode` | 每个 case 一行 `case_ms: <id> <ms>` + 一行 `mean_ms:` | 走 harness 的 `_benchmark_cuda_graph_or_events`，每个计时迭代一次 graph replay |
+| `--profile-run [--profile-case <id>]` | 无计时输出，exit 0 | 只发射目标算子：warmup 落实 JIT，几次 profiled launch，一次 synchronize |
+
+preflight 四道闸门里 **graph 这道是真查的**：`task_preparer._count_graph_replays` 通过
+`sitecustomize` 注入计数器，统计 benchmark 期间真实的 `torch.cuda.CUDAGraph.replay` 次数，
+要求 ≥ iters——不看任何打印出来的标签。三个 task 都通过，这是对「性能测试基于 CUDA graph」
+的第三方独立验证。
+
+## MoE 为什么只打 allclose、不打 SNR
+
+`test.py:85` 里 SNR 优先于 allclose，且硬卡 30 dB。MoE 这个算子是 **a4w4**——激活是 MXFP4，
+约 2 bit 尾数——**未改动的 kernel** 对着 dequant 参考也只有 rel_norm_err ≈ 0.15，
+换算 SNR ≈ 16.5 dB。打印 SNR 会让基线自己就判不合格，之后每个候选都被当成算错。
+所以 MoE 走 `allclose`，用 task 自己的容差（`min_cosine` 0.97 / `max_rel_norm_err` 0.25）判定。
+
+GDN（rel_err 0.0034 → **49.3 dB**）和 paged attention（0.0103 → **39.7 dB**）余量充足，正常打 SNR。
+paged attention 那 1% 残差是 fp8 KV 量化噪声，是 workload 属性不是实现缺陷，
+误差要涨到 3 倍才会碰线。
+
+## 环境准备
+
+KernelForge 装在 `/shared_nfs/jqliu/KernelForge`：
+
+```bash
+pip install -e . --no-deps
+pip install --no-deps plotly pymongo sqlalchemy textual dash claude-agent-sdk \
+    astunparse plotext plotille colorlover dash-bootstrap-components dash-svg \
+    textual-plotext textual-fspicker
+pip install "mcp>=1.23.0,<2.0.0"     # 见下
+```
+
+最后一行是个坑：`claude-agent-sdk` 用 `--no-deps` 装会缺 `mcp`，forge 起来后抛的却是
+`ClaudeUnavailableError: claude-agent-sdk is not installed`——**报错信息误导，真实原因是
+`ModuleNotFoundError: No module named 'mcp'`**。而直接 `pip install mcp` 会装 2.0.0，
+与 `claude-agent-sdk 0.2.139` 要求的 `mcp<2.0.0` 冲突，必须锁版本。
+
+还有一个假阳性要知道：forge 崩了之后 Arena 仍会把**未改动**的 kernel 重新打一次分并输出
+`PASS ... Speedup: 1.01x`。**只看 Arena 的 PASS/speedup 判断不了 forge 是否真跑了**，
+要看日志里有没有 `Starting autonomous iteration loop` 和 `pristine anchor agrees ...`。
+
+# 没有覆盖到的部分
+
+| | %E2E | 为什么没有 task |
+|---|---|---|
+| prefill RCCL all-reduce（bf16 256 MiB × 184/chunk） | ~15.3% | 通信算子，按要求排除 |
+| decode `cross_device_reduce_2stage`（bf16 1 MiB × 185/step） | 8.05% | 通信算子，按要求排除 |
+| `Cijk_..._MT16x16x1024`（router gate + shared gate_up + in_proj_ba） | **5.48%** | Tensile 预编译汇编，镜像内无源码 |
+| `Cijk_..._MT192x64x128`（qkv_proj / in_proj_qkvz） | 3.26% | 同上 |
+| `Cijk_..._MT64x32x128` + `PostGSU8`（shared down_proj） | 1.84% | 同上 |
+| `Cijk_..._MT224x64x128`（lm_head） | 0.20% | 同上 |
+| `_gemm_a16_w16`（o_proj / out_proj，Triton） | 1.75% | 源码可编辑，但单独权重不足以成 task |
+| MoE routing / 排序 / 量化 / 激活 / 门（7 个 kernel） | ~6.6% | **源码可编辑，是最自然的补位候选**（见下） |
+| `_gemma_fused_add_rmsnorm`（每层 2 次） | 1.56% | 源码可编辑，权重偏小 |
+| prefill 计算（无法细分到 kernel） | ~25.5% | session 没抓 prefill trace |
+
+session 的 **#5 热点算子没有 task，而且不可能有**：`Cijk_..._MT16x16x1024`
+（253 次/step、2.9837 ms/step 8 rank 均值、占 decode 9.67%、**5.48% E2E**）
+是 Tensile 生成的 GCN 汇编，预编译在 `/opt/rocm/lib/hipblaslt/library/*gfx950*.co` 里，
+镜像内没有源码。唯一的杠杆是给 `aiter/tuned_gemm.py` 加调优条目、放宽 skinny 启发式、
+或写个替代 kernel 再改派发——全是 dispatch / tuning 工作，不是 kernel 工作。
+针对这些形状的 backend-replacement task 曾经建好并验证通过，为遵守筛选标准已移除，
+policy 变了可以从 git 历史取回。
+
+**MoE 周边链路**值得单独提一句：`topkGatingSoftmax`(1.74%) + 两个 `fused_mx_quant_moe_sort`(1.78%)
++ 两个 `opus_moe_sorting`(1.56%) + `act_and_mul`(0.77%) + `_fused_gate_sigmoid_mul_add`(0.73%)
+合计约 **6.6% E2E**，7 个 kernel、每步 644 次 launch，全部是 aiter HIP C++ 和 sglang Triton，
+完全符合「源码可编辑」的标准。按 task 2 那套「整链打包、暴露融合机会」的做法可以再建一个 task。

--- a/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/config.yaml
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/config.yaml
@@ -1,0 +1,101 @@
+task_type: image_kernel
+# aiter is a source checkout in this image, not a dist-packages install; the
+# package dir is the seed, and scripts/task_runner.py symlinks the csrc/3rdparty/hsa
+# siblings the copy needs to import (aiter/utility/aiter_types.py:10 -> parents[2]).
+image_repo_path: /sgl-workspace/aiter/aiter
+repo_subdir: aiter
+image_repo_exclude:
+- __pycache__
+- jit/build
+# The compute cores are FlyDSL (mfma_moe1_* / mfma_moe2_*) and the edit surface
+# includes ops/flydsl/kernels/mixed_moe_gemm_2stage.py. Must be one of the keys
+# under `knowledge` in src/prompts/cheatsheet/default_cheatsheet.yaml
+# (flydsl/hip/triton) -- 'python' hard-fails prompt_builder.
+repository_language: flydsl
+source_file_path:
+- fused_moe.py
+- ops/flydsl/moe_kernels.py
+- ops/shuffle.py
+# Kernel source only. The tuned-config CSV is deliberately NOT an edit surface:
+# populating a lookup table is backend tuning, not kernel work, and this task set
+# is scoped to source-editable kernels.
+editable_sources:
+- ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+# NOTE ON OVERLAP with tasks/image_kernel/mi355x_vllm_aiter_mxfp4_moe_2stage_kimi_k3:
+# both tasks edit mixed_moe_gemm_2stage.py, but DIFFERENT builder functions in it.
+# K3 is a16w4 -> compile_mixed_moe_gemm1_a16w4 (:4959) / _a16w4 (:7215).
+# This task is a4w4 -> compile_mixed_moe_gemm1 (:147) / compile_mixed_moe_gemm2 (:3079).
+# The builders are listed below so the two tasks are distinguishable by target,
+# not just by name, and logical_operator carries the _a4w4 suffix for the same reason.
+target_kernel_functions:
+- compile_mixed_moe_gemm1
+- compile_mixed_moe_gemm2
+- _flydsl_stage1_wrapper
+- _flydsl_stage2_wrapper
+- fused_moe
+kernel_identity:
+  logical_operator: aiter_mxfp4_moe_2stage_a4w4
+  kernel_kind: flydsl
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: qwen38-moe-decode-m64
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+compile_timeout: 1800
+correctness_timeout: 3600
+performance_timeout: 2400
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Faithful reproduction of the Qwen3.8-2.4T-A95B routed-expert MXFP4 MoE
+    2-stage GEMM as it actually executed in Hyperloom session 100137
+    (20260814T175123Z) on MI355X/gfx950 under sglang 0.5.17. These are the
+    session's #2 and #4 hot kernels by E2E share:
+    mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32 at 11.62% E2E and
+    mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_vscale_fix3_fp4opt_v1_persist_cu256
+    at 6.25% E2E -- together 17.9% of end-to-end wall clock, the largest
+    non-communication block in the workload.
+    Config: a4w4 (fp4 activation x fp4 weight, MXFP4 group_size=32 ->
+    QuantType.per_1x32, e8m0 scales), g1u1, ActivationType.Silu, per-rank
+    (TP=8 EP=8) model_dim=8192 / inter_dim=2048 / 64 local experts of 512 /
+    topk=10. Exact shapes and dtypes are trace-recorded in session_cases.json.
+    The compute core is a FlyDSL MLIR builder and is the edit surface:
+    ops/flydsl/kernels/mixed_moe_gemm_2stage.py, compile_mixed_moe_gemm1 (:147,
+    kernel at :468) and compile_mixed_moe_gemm2 (:3079, kernel at :3275). Useful
+    levers are the MFMA pipeline, tile/block loop structure, LDS usage and the
+    ping-pong staging, the async-copy schedule, the persistent stage-2 CU
+    mapping, the CShuffle epilogue, and stage-2's atomic reduction.
+    Context worth having: this session has NO tuned FlyDSL config at all -- its
+    server.log logs "no tuned FlyDSL config" 120 times, covering all 15 M
+    buckets, so every MoE GEMM in production runs on the heuristic fallback tile
+    from aiter/fused_moe.py:2249-2255. That is why there is headroom. Note
+    though that the tuned-config CSV is NOT in the edit surface: filling in a
+    lookup table is backend tuning, not kernel work. Win by making the kernel
+    faster at the three tiles the session actually dispatches.
+    Three M buckets are covered and they dispatch three DIFFERENT kernel pairs,
+    so a tile change must be evaluated on all of them: decode M=64 (t32x128x256),
+    prefill M=8192 (t128x128x256) and prefill M=16384 (t64x128x256). The harness
+    pins the expected pair per case.
+    The harness enforces invariants a valid patch must keep. Weights must reach
+    fused_moe with .is_shuffled=True and the sglang load-time preparation
+    (e8m0_shuffle on the 2D scale view, then shuffle_weight(w, (16,16))); without
+    it aiter/fused_moe.py:2198 silently routes to the CK 2-stage path, which is
+    not the kernel the session ran. Dispatch must stay on the FlyDSL a4w4 pair.
+    Correctness and performance run the identical case list at identical shapes,
+    and correctness is the worst of 3 runs because stage2 reduces with atomics.
+    Correctness compares against an independent vectorized torch reference that
+    unpacks the MXFP4 nibbles and fake-quantizes activations the same way the
+    kernel does; observed baseline agreement is cos ~0.9887 at every M. Do not
+    edit the harness. Preserve all correctness cases and improve the CUDA-graph
+    measured performance.
+  cheatsheet: null

--- a/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/scripts/forge_driver.py
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/scripts/forge_driver.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Qwen3.8 aiter MXFP4 MoE 2-stage task.
+
+Target (optimized by forge-loop): the FlyDSL a4w4 MoE grouped GEMMs
+``compile_mixed_moe_gemm1`` / ``compile_mixed_moe_gemm2`` in
+``aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py``.
+
+Why this file exists
+--------------------
+``agents/forge/launch_agent.py:822`` prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root;
+without one it generates a shim around ``agents/forge/drivers/arena_task_adapter``.
+That shim parses ``--profile-run`` with ``parse_known_args``, i.e. it silently
+swallows the flag and runs correctness instead. KernelForge's
+``_check_profile_contract`` only asserts ``returncode == 0``, so the shim passes
+the gate without owning a profiling path at all. Campaigns longer than 2 hours
+switch Analysis to ``profiled`` (``kernel_agents/cli.py:2088``) and actually use
+that path, so the shim's gap turns into wasted prep budget or a hard
+``task_preparation_failed``. This driver implements the flag for real.
+
+Contract implemented (forge-loop runs ``python forge_driver.py <args>`` and reads
+only stdout; parsers are ``mcp_server/tools/test.py:74-83`` and
+``mcp_server/tools/bench.py:341-347``):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``allclose: True|False`` and ``max_diff: <rel_norm_err>``, worst
+        case across the suite.
+
+        It deliberately does NOT print ``SNR: <db> dB``. Both metrics are
+        parsed, but SNR takes precedence (``test.py:85``) and is gated at 30 dB,
+        while this op is **a4w4** -- the activations are MXFP4, ~2 mantissa
+        bits. The pristine kernel measures rel_norm_err ~0.15 against the
+        dequantized torch reference, i.e. ~16.5 dB. Printing SNR would fail the
+        gate on the UNMODIFIED kernel and make every candidate look broken.
+        ``allclose`` is judged against the task's own tolerance
+        (``min_cosine`` 0.97 / ``max_rel_norm_err`` 0.25 in session_cases.json),
+        which is the physically meaningful bar for fp4 activations.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` for every declared case plus one
+        ``mean_ms:`` aggregate (arithmetic mean across cases, matching Arena's
+        evaluator). Timing goes through the task harness's
+        ``_benchmark_cuda_graph_or_events``, which captures the op into a
+        CUDA/HIP graph and REPLAYS it once per timed iteration -- so
+        ``task_preparer._count_graph_replays`` observes real replays rather
+        than a printed label.
+
+  * Profiling    ``--profile-run [--profile-case <case_id>]``
+        builds one case (the most expensive by default) and launches ONLY
+        ``fused_moe``: warmups to settle the aiter JIT and the FlyDSL
+        heuristic-config lookup, a few profiled launches, one synchronize,
+        exit 0. Prints no timing.
+
+All measurement logic is REUSED from ``scripts/task_runner.py`` so the driver
+measures exactly the op Arena scores. forge-loop never edits this file.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root."""
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise SystemExit("error: task_runner.py not found next to forge_driver.py")
+
+
+def _case_cost(case: dict) -> int:
+    """Rank cases so profiling picks the one worth looking at (largest M)."""
+    return int(case["params"].get("token", 0))
+
+
+def _cases(tr) -> list[dict]:
+    cases = list(tr.CASES)
+    if not cases:
+        raise SystemExit("error: session_cases.json declares no cases")
+    return cases
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def _run_correctness(tr) -> int:
+    import torch
+
+    worst_err, worst_cos, all_ok = 0.0, 1.0, True
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        got = tr._run(inputs)
+        torch.cuda.synchronize()
+        expected = tr._reference(inputs)
+        finite = bool(torch.isfinite(got).all())
+        cos, err = tr._deviation(got, expected)
+        tol = case["params"]
+        ok = (
+            finite
+            and cos > tol.get("min_cosine", 0.97)
+            and err < tol.get("max_rel_norm_err", 0.25)
+        )
+        all_ok = all_ok and ok
+        worst_err, worst_cos = max(worst_err, err), min(worst_cos, cos)
+        print(f"# case {case['id']}: cos={cos:.6f} rel_norm_err={err:.5f} "
+              f"finite={finite} ok={ok}")
+        del inputs, expected, got
+        tr._free()
+
+    # max_diff carries the relative norm error, the same statistic the task's own
+    # tolerance is expressed in, so a human reading the log compares like with like.
+    print(f"max_diff: {worst_err:.6e}")
+    print(f"allclose: {all_ok}")
+    print(f"# worst cosine {worst_cos:.6f} across {len(_cases(tr))} case(s)")
+    return 0 if all_ok else 1
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    import torch
+
+    means: list[float] = []
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        tr._run(inputs)
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda: tr._run(inputs),
+            warmup=warmup,
+            # One graph replay per timed iteration: this is what makes
+            # _count_graph_replays see >= iters replays.
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 100),
+        )
+        if not isinstance(exec_ms, (int, float)) or exec_ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {exec_ms!r}",
+                  file=sys.stderr)
+            return 1
+        if meta.get("benchmark_method") != "cuda_graph":
+            # Fail loudly: a silent fall back to event timing would still print a
+            # number, and the graph gate would then reject the driver with a far
+            # less obvious message than this one.
+            print(f"error: case {case['id']} timed with "
+                  f"{meta.get('benchmark_method')} instead of cuda_graph "
+                  f"({meta.get('benchmark_fallback_reason')})", file=sys.stderr)
+            return 1
+        means.append(float(exec_ms))
+        print(f"case_ms: {case['id']} {exec_ms:.6f}")
+        print(f"# bench {case['id']}: {exec_ms:.6f} ms "
+              f"method={meta.get('benchmark_method')} "
+              f"chained={meta.get('benchmark_effective_repeats')}")
+        del inputs
+        tr._free()
+
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr, case_id: str | None) -> int:
+    """Launch ONLY the target op, so a profiler session captures it and nothing else."""
+    import torch
+
+    cases = _cases(tr)
+    if case_id:
+        match = [c for c in cases if c["id"] == case_id]
+        if not match:
+            print(f"error: unknown --profile-case {case_id!r}; declared: "
+                  f"{', '.join(c['id'] for c in cases)}", file=sys.stderr)
+            return 1
+        case = match[0]
+    else:
+        case = max(cases, key=_case_cost)
+
+    inputs = tr._prepare(case)
+    # Warmups settle the aiter JIT and the FlyDSL heuristic-config lookup so the
+    # profiled launches contain kernel time, not one-off compilation.
+    for _ in range(3):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(2):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    print(f"# profiled {case['id']} (M={case['params']['token']})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--mode", default="full")        # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--profile-case", default=None)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=20)
+    # Unknown flags are tolerated so a newer forge-loop can pass options this
+    # driver predates, but --profile-run above is a REAL flag, not swallowed.
+    args, _unknown = parser.parse_known_args()
+
+    tr = _import_task_runner()
+    tr._configure()
+    import torch
+
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr, args.profile_case)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/scripts/task_runner.py
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/scripts/task_runner.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the Qwen3.8-2.4T-A95B MXFP4 routed-expert MoE 2-stage GEMM.
+
+Reproduces the aiter FlyDSL MoE path behind Hyperloom session 100137
+(Qwen3.8-2.4T-A95B-Quark-MXFP4, 20260814T175123Z) on MI355X/gfx950, sglang
+0.5.17.dev20260812+gdc5f6c4883 / ROCm 7.2.0 / aiter d9e5ef7c.
+
+Hot kernels reproduced (E2E numbers measured from the session's own 8-rank
+torch trace, decode share of wall clock = 56.7%):
+
+  mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32       11.62% E2E
+  mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_vscale_fix3_
+      fp4opt_v1_persist_cu256                                        6.25% E2E
+
+Config, all read out of the session (see session_cases.json ``moe_config``):
+  a4w4 -- fp4 activation x fp4 weight, MXFP4 group_size=32 -> QuantType.per_1x32,
+  e8m0 scales, g1u1, ActivationType.Silu, per-rank (TP=8 / EP=8)
+  model_dim=8192 / inter_dim=2048 / local experts=64 (of 512) / topk=10.
+
+Two M buckets are covered because the session runs both and they dispatch
+*different* FlyDSL kernels (aiter/fused_moe.py:2249-2255):
+
+  decode  M=64      -> flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w2
+                       flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic_bnt2
+  prefill M=16384   -> flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w4_bnt0
+                       flydsl_moe2_afp4_wfp4_bf16_t64x128x256_atomic
+  prefill M=8192    -> same t64 pair (26 of the session's 429 prefill chunks)
+
+Three contract details that are easy to get wrong, each verified against the
+in-image sources rather than assumed:
+
+  * ``use_mxfp4_flydsl`` (aiter/fused_moe.py:2198) requires ``is_shuffled`` and
+    ``not doweight_stage1``. Hand a MoE call unshuffled weights and it silently
+    lands on the CK 2-stage path
+    (module_moe_ck2stages_fp4x2_fp4x2_preshuffle_off_b16_silu_per_1x32_...)
+    instead -- a completely different kernel from the one the session ran.
+    ``_assert_flydsl_dispatch`` fails closed on that.
+  * The weight/scale preparation must match what sglang's Quark MXFP4 MoE
+    scheme does at load time
+    (sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py:577-597):
+    ``e8m0_shuffle`` on the scales viewed 2D, then ``shuffle_weight(w, (16, 16))``
+    on the packed nibbles, then ``is_shuffled = True``.
+  * Unlike the Kimi-K3 sibling task, this session runs entirely on the
+    **heuristic fallback** branch -- ``no tuned FlyDSL config`` appears 120 times
+    in the session's server.log, covering all 15 M buckets. The fallback is the
+    thing being optimised here, so the harness asserts the dispatch stays FlyDSL
+    but deliberately does *not* require a tuned-CSV hit.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+MOE = SPEC["moe_config"]
+
+_IMAGE_AITER_ROOT = Path(os.environ.get("QWEN38_AITER_ROOT", "/sgl-workspace/aiter"))
+# aiter resolves csrc/include/aiter_enum.h relative to the directory *containing*
+# the package (aiter/utility/aiter_types.py:10 hardcodes parents[2]), so a
+# workspace that only seeds `aiter/` cannot import at all without these siblings.
+# They are not part of this task's edit surface, so they are linked, not copied.
+_AITER_SIBLINGS = ("csrc", "3rdparty", "hsa")
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "jit"))
+    if (WORKSPACE / "aiter").is_dir():
+        for name in _AITER_SIBLINGS:
+            link, src = WORKSPACE / name, _IMAGE_AITER_ROOT / name
+            if not link.exists() and not link.is_symlink() and src.is_dir():
+                link.symlink_to(src, target_is_directory=True)
+        sys.path.insert(0, str(WORKSPACE))
+    os.environ.setdefault("AITER_META_DIR", str(_IMAGE_AITER_ROOT))
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(fn, repetition):
+    import time
+    import torch
+
+    repetition = max(1, int(repetition))
+    if not torch.cuda.is_available():
+        times_ms = []
+        for _ in range(repetition):
+            start = time.perf_counter()
+            fn()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+        return times_ms
+
+    times_ms = []
+    for _ in range(repetition):
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        fn()
+        end_event.record()
+        torch.cuda.synchronize()
+        times_ms.append(start_event.elapsed_time(end_event))
+    return times_ms
+
+
+class _TimedRun:
+    """Handle on the exact invocation a benchmark measured.
+
+    Timing and correctness are otherwise separate invocations, so a kernel can
+    tell them apart and do less work in the one that is scored. Passing this
+    collector to the benchmark makes the scored invocation itself observable:
+    ``outputs`` aliases the buffers the timed unit last wrote, and ``rerun``
+    executes that same unit again.
+
+    Under CUDA-graph timing the buffers are captured once and every replay
+    writes to those same addresses, so ``outputs`` keeps tracking replays. Under
+    event-timing fallback the measured outputs cannot be observed reliably, so a
+    benchmark that requests this collector fails closed instead of validating a
+    separate post-timing invocation.
+    """
+
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError(
+                "timed run was never bound; the benchmark did not reach a "
+                "measurement path"
+            )
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph_or_events(
+    fn,
+    warmup=10,
+    repetition=100,
+    target_ms=1.0,
+    n_retries=5,
+    estimate_reps=5,
+    max_graph_repeats=1000,
+    use_cuda_graph=True,
+    fallback_reason=None,
+    timed_run=None,
+):
+    import torch
+
+    def _reject_unobservable_fallback(reason):
+        if timed_run is not None:
+            raise RuntimeError(
+                f"{reason}; timed_run requires an observable CUDA-graph replay "
+                "and cannot validate a separate post-timing invocation"
+            )
+
+    # A captured graph whose measured per-iteration time falls below this floor is
+    # treated as empty (it recorded no device work) and rejected in favour of
+    # per-launch event timing, so a graph that silently captured nothing is never
+    # reported as a fabricated ~0 ms cuda_graph result. Real kernels measure far
+    # above this floor; an empty-graph replay measures ~1e-5 ms.
+    empty_graph_floor_ms = 1e-4
+
+    for _ in range(max(0, int(warmup))):
+        fn()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    max_graph_repeats = max(1, int(max_graph_repeats))
+    metadata = {
+        "benchmark_target_ms": float(target_ms),
+        "benchmark_samples": int(repetition),
+        "benchmark_max_repeats": int(max_graph_repeats),
+    }
+
+    if not torch.cuda.is_available():
+        _reject_unobservable_fallback("CUDA is unavailable")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cpu_timer_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_unavailable",
+        })
+        return sum(times) / len(times), metadata
+
+    if not use_cuda_graph:
+        _reject_unobservable_fallback("CUDA-graph timing is disabled")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_graph_disabled",
+        })
+        return sum(times) / len(times), metadata
+
+    try:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            estimate_reps = max(1, int(estimate_reps))
+            estimate_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(estimate_graph):
+                for _ in range(estimate_reps):
+                    fn()
+            torch.cuda.synchronize()
+
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record(stream)
+            estimate_graph.replay()
+            end_event.record(stream)
+            torch.cuda.synchronize()
+
+            estimate_ms = start_event.elapsed_time(end_event) / estimate_reps
+            if estimate_ms == 0:
+                n_repeat = max_graph_repeats
+            else:
+                n_repeat = min(max_graph_repeats, max(1, int(float(target_ms) / estimate_ms)))
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured_outputs = None
+                for _ in range(n_repeat):
+                    captured_outputs = fn()
+            torch.cuda.synchronize()
+
+            retry_times = []
+            for _ in range(max(1, int(repetition))):
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+                start_event.record(stream)
+                graph.replay()
+                end_event.record(stream)
+                torch.cuda.synchronize()
+                retry_times.append(start_event.elapsed_time(end_event) / n_repeat)
+
+        graph_mean = sum(retry_times) / len(retry_times)
+        if graph_mean < empty_graph_floor_ms:
+            _reject_unobservable_fallback("CUDA graph captured no device work")
+            times = _measure_cuda_event_fallback(fn, repetition)
+            metadata.update({
+                "benchmark_method": "cuda_event_fallback",
+                "benchmark_effective_repeats": int(repetition),
+                "benchmark_fallback_reason": fallback_reason or "empty_cuda_graph_capture",
+            })
+            return sum(times) / len(times), metadata
+
+        metadata.update({
+            "benchmark_method": "cuda_graph",
+            "benchmark_effective_repeats": int(n_repeat),
+        })
+        if timed_run is not None:
+
+            def _replay_once():
+                # Callers stage work on their own stream before re-running (they
+                # perturb inputs and poison outputs). The capture stream must be
+                # ordered after that, or the replay races the staged writes and
+                # they land on top of the kernel's results.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
+        return graph_mean, metadata
+    except Exception as exc:
+        # Isolate the aborted capture before re-measuring so the fallback timing is
+        # not polluted by the failed attempt (a mid-capture failure can leave the
+        # first few launches abnormally slow).
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed_run cannot validate the "
+                "separate CUDA-event fallback invocation"
+            ) from exc
+        for _ in range(min(3, max(1, int(warmup)))):
+            fn()
+        torch.cuda.synchronize()
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": f"cuda_graph_failed: {type(exc).__name__}: {str(exc)[:160]}",
+        })
+        return sum(times) / len(times), metadata
+# <<< AKA-GENERATED <<<
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch capture
+#
+# aiter logs the FlyDSL pair it picked per M bucket at INFO:
+#
+#   [fused_moe] no tuned FlyDSL config for (...), using heuristic FlyDSL
+#   fallback (kn1='flydsl_moe1_...', kn2='flydsl_moe2_...')
+#
+# Two failures are silent without this check and both are fatal to the task:
+#   * weights not shuffled -> CK 2-stage path, i.e. the wrong kernel entirely;
+#   * correctness and performance running at token counts in different M
+#     buckets, so the pair being scored is never the pair being checked.
+# --------------------------------------------------------------------------- #
+_KN1_RE = re.compile(r"kn1='([^']*)'")
+_KN2_RE = re.compile(r"kn2='([^']*)'")
+_TUNED_KN1_RE = re.compile(r"kernelName1='([^']*)'")
+_TUNED_KN2_RE = re.compile(r"kernelName2='([^']*)'")
+
+
+class _LogCapture(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.messages.append(record.getMessage())
+        except Exception:  # pragma: no cover - never break a run on logging
+            pass
+
+
+@contextlib.contextmanager
+def _capture_aiter_log():
+    from aiter import logger as aiter_logger
+
+    cap = _LogCapture()
+    previous = aiter_logger.level
+    aiter_logger.addHandler(cap)
+    aiter_logger.setLevel(logging.INFO)
+    try:
+        yield cap
+    finally:
+        aiter_logger.removeHandler(cap)
+        aiter_logger.setLevel(previous)
+
+
+def _dispatch_names(inputs: dict) -> tuple[str, str, str]:
+    """Run the op once and report which FlyDSL kernel pair aiter dispatched.
+
+    ``get_2stage_cfgs`` is lru_cached, so the log line only appears on the first
+    lookup of a key; clear it so the capture is not silently empty.
+    """
+    from aiter.fused_moe import get_2stage_cfgs
+
+    get_2stage_cfgs.cache_clear()
+    with _capture_aiter_log() as cap:
+        _run(inputs)
+        _torch().cuda.synchronize()
+    blob = "\n".join(cap.messages)
+    kn1 = _KN1_RE.search(blob) or _TUNED_KN1_RE.search(blob)
+    kn2 = _KN2_RE.search(blob) or _TUNED_KN2_RE.search(blob)
+    return (kn1.group(1) if kn1 else "", kn2.group(1) if kn2 else "", blob)
+
+
+def _assert_flydsl_dispatch(label: str, kn1: str, kn2: str, blob: str) -> None:
+    if not (kn1 and kn2):
+        raise AssertionError(
+            f"{label}: aiter logged no FlyDSL kernel pair (kn1={kn1!r}, kn2={kn2!r}). "
+            f"The session's MoE runs on the FlyDSL a4w4 path; a missing pair means "
+            f"the call fell through to another backend. Captured log:\n{blob[:2000]}"
+        )
+    if not (kn1.startswith("flydsl_moe1_afp4_wfp4") and kn2.startswith("flydsl_moe2_afp4_wfp4")):
+        raise AssertionError(
+            f"{label}: dispatched pair is not the FlyDSL a4w4 pair this task "
+            f"reproduces (kn1={kn1!r}, kn2={kn2!r}). The usual cause is weights "
+            f"reaching fused_moe without .is_shuffled=True, which sends the call "
+            f"to the CK 2-stage path (aiter/fused_moe.py:2198 use_mxfp4_flydsl "
+            f"requires is_shuffled and not doweight_stage1)."
+        )
+    if "ck2stages" in blob:
+        raise AssertionError(f"{label}: a CK 2-stage module was loaded; not the session path.")
+
+
+# --------------------------------------------------------------------------- #
+# Small utilities
+# --------------------------------------------------------------------------- #
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    return torch
+
+
+def _aiter():
+    import aiter
+
+    return aiter
+
+
+def _free() -> None:
+    _torch().cuda.empty_cache()
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _assert_sglang_shuffle_contract(nlane: tuple) -> None:
+    if tuple(nlane) != (16, 16):
+        raise AssertionError(
+            f"shuffle_weight layout {tuple(nlane)}, but sglang hardcodes (16, 16) at "
+            f"quark_w4a4_mxfp4_moe.py:590,593. A kernel that needs a different "
+            f"layout cannot be reached from sglang."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+#
+# Shapes come straight out of the session's CUDA-graph capture trace
+# (record_shapes=True), aiter::fused_moe_ cpu_op at bs=64:
+#     hidden [M, 8192] bf16
+#     w1     [64, 4096, 4096] fp4x2   (= [E_local, 2*inter, hidden] MXFP4)
+#     w2     [64, 8192, 1024] fp4x2   (= [E_local, hidden, inter]   MXFP4)
+#     w1_scale [64, 4096, 256] e8m0 / w2_scale [64, 8192, 64] e8m0
+#     topk_weight [M, 10] f32 / topk_ids [M, 10] i32 / expert_mask [512] i32
+# Only M changes between cases; every weight shape is fixed by the model config.
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    torch = _torch()
+    aiter = _aiter()
+    from aiter import dtypes
+    from aiter.fused_moe import fused_topk
+    from aiter.ops.shuffle import shuffle_weight
+    from aiter.utility.fp4_utils import e8m0_shuffle
+
+    p = dict(case["params"])
+    if (p["quant_type"], p["a_dtype"], p["w_dtype"], p["use_g1u1"]) != (
+        "per_1x32", "fp4", "fp4", True
+    ):
+        raise RuntimeError(f"case {case['id']} is not the Qwen3.8 a4w4 g1u1 contract: {p}")
+
+    token = int(p["token"])
+    experts = int(p["local_experts"])
+    total_experts = int(p["total_experts"])
+    model_dim = int(p["model_dim"])
+    inter_dim = int(p["inter_dim"])
+    topk = int(p["topk"])
+
+    torch.manual_seed(int(case.get("seed", 7)))
+    hidden = torch.randn((token, model_dim), device="cuda", dtype=dtypes.bf16) * 0.1
+    w1_bf16 = torch.randn(
+        (experts, inter_dim * 2, model_dim), device="cuda", dtype=dtypes.bf16
+    ) * 0.03
+    w2_bf16 = torch.randn(
+        (experts, model_dim, inter_dim), device="cuda", dtype=dtypes.bf16
+    ) * 0.03
+
+    # aiter's own MXFP4 quantizer; rows are laid out GGUU (all gate rows then all
+    # up rows), matching torch_moe_stage1's out.split([inter, inter], -1).
+    torch_quant = aiter.get_torch_quant(aiter.QuantType.per_1x32)
+    w1_q, w1_s = torch_quant(w1_bf16, quant_dtype=dtypes.fp4x2)
+    w2_q, w2_s = torch_quant(w2_bf16, quant_dtype=dtypes.fp4x2)
+    del w1_bf16, w2_bf16
+    w1_s = w1_s.view(experts, inter_dim * 2, -1)
+    w2_s = w2_s.view(experts, model_dim, -1)
+
+    # Exactly the sglang load-time preparation, in the same order.
+    nlane = tuple(MOE.get("shuffle_layout", (16, 16)))
+    _assert_sglang_shuffle_contract(nlane)
+    w1_rt = shuffle_weight(w1_q.view(torch.uint8).contiguous(), nlane).view(dtypes.fp4x2)
+    w2_rt = shuffle_weight(w2_q.view(torch.uint8).contiguous(), nlane).view(dtypes.fp4x2)
+    w1_rt.is_shuffled = True
+    w2_rt.is_shuffled = True
+    w1_s_rt = e8m0_shuffle(w1_s.reshape(experts * inter_dim * 2, -1)).view(
+        experts, inter_dim * 2, -1
+    )
+    w2_s_rt = e8m0_shuffle(w2_s.reshape(experts * model_dim, -1)).view(
+        experts, model_dim, -1
+    )
+
+    score = torch.randn((token, total_experts), device="cuda", dtype=dtypes.bf16)
+    topk_weights, topk_ids = fused_topk(hidden, score, topk, True)
+    # EP=8: this rank owns experts [0, 64). Routing is global (512 experts), so
+    # ~7/8 of the (token, expert) pairs are dropped by the mask -- same as serving.
+    expert_mask = torch.zeros(total_experts, dtype=torch.int32, device="cuda")
+    expert_mask[:experts] = 1
+
+    return {
+        "cfg": case, "params": p, "token": token, "topk": topk,
+        "experts": experts, "model_dim": model_dim, "inter_dim": inter_dim,
+        "hidden": hidden,
+        "w1": w1_rt, "w2": w2_rt, "w1_scale": w1_s_rt, "w2_scale": w2_s_rt,
+        # Unshuffled copies drive the torch reference.
+        "w1_ref": w1_q, "w2_ref": w2_q, "w1_scale_ref": w1_s, "w2_scale_ref": w2_s,
+        "topk_weights": topk_weights, "topk_ids": topk_ids, "expert_mask": expert_mask,
+    }
+
+
+def _run(inputs: dict):
+    torch = _torch()
+    aiter = _aiter()
+    from aiter.fused_moe import fused_moe
+
+    return fused_moe(
+        inputs["hidden"],
+        inputs["w1"],
+        inputs["w2"],
+        inputs["topk_weights"],
+        inputs["topk_ids"],
+        expert_mask=inputs["expert_mask"],
+        quant_type=aiter.QuantType.per_1x32,
+        w1_scale=inputs["w1_scale"],
+        w2_scale=inputs["w2_scale"],
+        activation=aiter.ActivationType.Silu,
+        dtype=torch.bfloat16,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+#
+# aiter's own torch_moe_stage1/stage2 cannot be used here: they dequantize the
+# whole expert tensor to fp32 and materialize [token, topk, 2*inter], which at
+# the session's prefill M=16384 is 2.7 TB. This reference keeps memory bounded by
+# dequantizing one expert at a time, and stays vectorized -- the only Python loop
+# is over the 64 local experts, and each iteration is two dense GEMMs.
+#
+# It is an independent implementation, not a wrapper: it unpacks the MXFP4
+# nibbles, applies the per-1x32 e8m0 group scales, and fake-quantizes the
+# activation and the stage-1 output the same way the kernel does (the a4w4 path
+# quantizes both), so the only remaining difference is accumulation order.
+# --------------------------------------------------------------------------- #
+def _dequant_mxfp4(packed, scale_e8m0):
+    """[R, K/2] fp4x2 + [R, K/32] e8m0  ->  [R, K] bf16."""
+    torch = _torch()
+    from aiter.utility.fp4_utils import e8m0_to_f32, mxfp4_to_f32
+
+    values = mxfp4_to_f32(packed)
+    scale = e8m0_to_f32(scale_e8m0)
+    rows = values.shape[0]
+    out = (values.view(rows, -1, 32) * scale.unsqueeze(-1)).view(rows, -1)
+    return out.to(torch.bfloat16)
+
+
+def _fake_quant_mxfp4(x):
+    """Round x through MXFP4 exactly as the kernel's input quantizer does."""
+    from aiter.utility.fp4_utils import dynamic_mxfp4_quant
+
+    packed, scale = dynamic_mxfp4_quant(x)
+    return _dequant_mxfp4(packed, scale)
+
+
+def _reference(inputs: dict):
+    torch = _torch()
+    with torch.no_grad():
+        token = inputs["token"]
+        model_dim, inter_dim = inputs["model_dim"], inputs["inter_dim"]
+        topk = inputs["topk"]
+
+        x = _fake_quant_mxfp4(inputs["hidden"])                     # [M, H] bf16
+        flat_expert = inputs["topk_ids"].reshape(-1)
+        flat_token = torch.arange(token, device="cuda").repeat_interleave(topk)
+        flat_weight = inputs["topk_weights"].reshape(-1).float()
+
+        out = torch.zeros((token, model_dim), device="cuda", dtype=torch.float32)
+        for e in range(inputs["experts"]):
+            rows = (flat_expert == e).nonzero(as_tuple=True)[0]
+            if rows.numel() == 0:
+                continue
+            tok = flat_token[rows]
+            w1 = _dequant_mxfp4(inputs["w1_ref"][e], inputs["w1_scale_ref"][e])
+            gate_up = x[tok] @ w1.transpose(0, 1)                   # [n, 2*inter]
+            del w1
+            gate, up = gate_up.split([inter_dim, inter_dim], dim=-1)
+            act = (torch.nn.functional.silu(gate.float()) * up.float()).to(torch.bfloat16)
+            del gate_up, gate, up
+            act = _fake_quant_mxfp4(act)                            # stage-2 input quant
+            w2 = _dequant_mxfp4(inputs["w2_ref"][e], inputs["w2_scale_ref"][e])
+            y = (act @ w2.transpose(0, 1)).float()                  # [n, H]
+            del w2, act
+            out.index_add_(0, tok, y * flat_weight[rows].unsqueeze(-1))
+            del y
+        return out.to(torch.bfloat16)
+
+
+def _deviation(got, expected):
+    torch = _torch()
+    g, e = got.float().flatten(), expected.float().flatten()
+    cos = torch.nn.functional.cosine_similarity(g, e, dim=0).item()
+    err = ((g - e).norm() / e.norm().clamp_min(1e-8)).item()
+    return cos, err
+
+
+def _assert_within_tolerance(case: dict, cos: float, err: float, label: str) -> None:
+    tol = case["params"]
+    assert cos > tol.get("min_cosine", 0.97), (
+        case["id"], f"{label} cosine {cos:.6f} vs torch reference too low"
+    )
+    assert err < tol.get("max_rel_norm_err", 0.25), (
+        case["id"], f"{label} relative norm error {err:.4f} too high"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inputs = _prepare(CASES[0])
+    out = _run(inputs)
+    _torch().cuda.synchronize()
+    kn1, kn2, blob = _dispatch_names(inputs)
+    _assert_flydsl_dispatch("compile", kn1, kn2, blob)
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} {out.dtype}")
+    print(f"  FlyDSL dispatch OK  stage1={kn1}\n                      stage2={kn2}")
+
+
+# stage2 reduces with atomics, so the result is not bit-reproducible. Gate on the
+# worst of N rather than getting lucky once.
+_CORRECTNESS_REPEATS = 3
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        # Correctness runs at the case's own token -- identical to the shape the
+        # performance mode scores. Shrinking it would move the call into another
+        # M bucket and check a different FlyDSL kernel than the one measured.
+        inputs = _prepare(case)
+        kn1, kn2, blob = _dispatch_names(inputs)
+        _assert_flydsl_dispatch(case["id"], kn1, kn2, blob)
+        _assert_expected_pair(case, kn1, kn2)
+
+        expected = _reference(inputs)
+        worst_cos, worst_err = 1.0, 0.0
+        for _ in range(_CORRECTNESS_REPEATS):
+            got = _run(inputs)
+            torch.cuda.synchronize()
+            assert torch.isfinite(got).all(), (case["id"], "non-finite output")
+            assert tuple(got.shape) == tuple(expected.shape), (
+                case["id"], tuple(got.shape), tuple(expected.shape)
+            )
+            cos, err = _deviation(got, expected)
+            worst_cos, worst_err = min(worst_cos, cos), max(worst_err, err)
+
+        _assert_within_tolerance(case, worst_cos, worst_err, f"worst-of-{_CORRECTNESS_REPEATS}")
+        print(f"correctness PASS {case['id']:38s} M={inputs['token']:<6d} "
+              f"cos={worst_cos:.6f} rel_err={worst_err:.4f}")
+        del inputs, expected, got
+        _free()
+
+
+def _assert_expected_pair(case: dict, kn1: str, kn2: str) -> None:
+    """Pin the kernel pair the session actually ran for this M bucket."""
+    want = case.get("expected_dispatch")
+    if not want:
+        return
+    if (kn1, kn2) != (want["stage1"], want["stage2"]):
+        raise AssertionError(
+            f"{case['id']}: dispatched ({kn1}, {kn2}) but the session ran "
+            f"({want['stage1']}, {want['stage2']}) at this M. Either the tile "
+            f"heuristic moved or the case's token no longer lands in the session's "
+            f"M bucket; both make the scored kernel unrepresentative."
+        )
+
+
+def _perturb(inputs: dict) -> None:
+    """Refresh the activation in place with values no earlier launch has seen.
+
+    Only ``hidden`` is redrawn. Routing tensors are kernel inputs, not something
+    the kernel derives, so leaving them fixed keeps kernel and reference on the
+    same workload; the quantized weights have shuffled runtime copies that would
+    have to be rebuilt in lockstep, which buys nothing here.
+    """
+    torch = _torch()
+    torch.manual_seed(43)
+    inputs["hidden"].normal_(0.0, 0.1)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    run_correctness checks a separate call, which a kernel could tell apart from
+    the scored one. This re-runs the timed unit against a freshly perturbed
+    activation and checks the buffer it wrote.
+    """
+    torch = _torch()
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    got = timed.rerun()
+    expected = _reference(inputs)
+    assert torch.isfinite(got).all(), (case["id"], "timed run produced non-finite output")
+    cos, err = _deviation(got, expected)
+    _assert_within_tolerance(case, cos, err, "timed run")
+    del expected
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        # Same case list, same shapes as run_correctness -- no perf-only case and
+        # no correctness-only case, so every scored shape is a checked shape.
+        inputs = _prepare(case)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        kn1, kn2, blob = _dispatch_names(inputs)
+        _assert_flydsl_dispatch(case["id"], kn1, kn2, blob)
+        _assert_expected_pair(case, kn1, kn2)
+
+        bench = case.get("benchmark", {})
+        timed = _TimedRun()
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=bench.get("warmup", 3),
+            repetition=bench.get("repetition", 20),
+            target_ms=bench.get("target_ms", 1.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 100),
+            timed_run=timed,
+        )
+        _assert_timed_outputs(case, inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "phase": case.get("phase"),
+            "calls_per_forward": case.get("calls_per_forward"),
+            "session_e2e_pct": case.get("session_e2e_pct"),
+            "dispatched_stage1_kernel": kn1,
+            "dispatched_stage2_kernel": kn2,
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms", meta.get("benchmark_method"),
+              meta.get("benchmark_fallback_reason", ""))
+        print(f"  timed stage1={kn1}\n        stage2={kn2}")
+        del inputs
+        _free()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/session_cases.json
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_mxfp4_moe_2stage_qwen38/session_cases.json
@@ -1,0 +1,308 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950 (256 CU)",
+  "framework": "sglang 0.5.17.dev20260812+gdc5f6c4883 (ROCm 7.2.0, aiter d9e5ef7ce)",
+  "faithful_reproduction": true,
+  "run_environment_requirement": "Must run in the session's image (lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260812, i.e. sglang 0.5.17.dev20260812+gdc5f6c4883 + aiter d9e5ef7ce) on MI355X/gfx950. Verified on that image: the harness reproduces the session's own aiter dispatch lines byte-for-byte, including the tuple key and both heuristic kernel names (see dispatch_evidence).",
+  "selection": "Hot kernels #2 and #4 of session 100137 by E2E share: mfma_moe1 (11.62% E2E) and mfma_moe2 (6.25% E2E). They are the two stages of the SAME aiter fused_moe call, so one task covers both. Communication kernels are deliberately excluded from this task set.",
+  "task_name": "mi355x-qwen38-sglang-aiter-mxfp4-moe-2stage-20260814",
+  "operator": "aiter_mxfp4_moe_2stage",
+  "provenance": {
+    "session_id": "100137",
+    "session_root": "/shared_nfs/hyperloom-claw/Qwen3.8-2.4T-A95B-Quark-MXFP4/20260814T175123Z",
+    "benchmark_run": "runs/roofline/27652f24f9ee4b999c4479ca44c9bf7c/benchmark_sglang_20260815_060127",
+    "trace": "torch_trace/1786775072.0389888-TP-{0..7}.trace.json.gz",
+    "shape_source": "torch_trace/graph_capture_profile/cuda_graph_capture-DecodeCudaGraphRunner-TP-0.json.gz (record_shapes=True), aiter::fused_moe_ cpu_op in the bs=64 segment",
+    "model_config": "/shared_nfs/hyperloom/models/Qwen3.8-2.4T-A95B-Quark-MXFP4/config.json",
+    "serving_config": "TP=8 EP=8, mem_fraction_static=0.765, kv_cache_dtype=fp8_e4m3, chunked_prefill_size=16384, max_model_len=13312, ISL 8192 / OSL 1024 / conc 64",
+    "kernel_identity": {
+      "decode_stage1": "mfma_moe1_silu_mul_afp4_wfp4_bf16_t32x128x256_pm1_async_v32 -- 92 calls/step, 6.3257 ms/step (8-rank mean), 20.50% of the decode step, 11.62% E2E",
+      "decode_stage2": "mfma_moe2_afp4_wfp4_bf16_cshuffle_t32x128x256_vscale_fix3_fp4opt_v1_persist_cu256 -- 92 calls/step, 3.3994 ms/step (8-rank mean), 11.02% of the decode step, 6.25% E2E",
+      "prefill_stage1": "mfma_moe1_silu_mul_afp4_wfp4_bf16_t64x128x256_... -- identity from aiter/fused_moe.py:2249-2255 (M>=16384 -> tile_m=64); the session captured no prefill trace, so its timing is unmeasured",
+      "prefill_stage2": "mfma_moe2_afp4_wfp4_bf16_..._t64x128x... -- same"
+    },
+    "logical_dims": "Per-rank (TP=8, EP=8) routed-expert MoE. model_dim = hidden_size = 8192. inter_dim = moe_intermediate_size = 2048 (NOT TP-sharded; EP shards the expert axis). num_experts = 512 global -> 64 local per rank. topk = num_experts_per_tok = 10. MXFP4 group_size 32 -> QuantType.per_1x32. Both activation and weight are fp4 (a4w4). g1u1 = True (w1 rows = 2*inter_dim, GGUU layout).",
+    "scale_layout": "per_1x32 group scales, dtype Float8_e8m0fnu. Runtime shapes as captured: w1_scale [64, 4096, 256] = [E_local, 2*inter, model_dim/32]; w2_scale [64, 8192, 64] = [E_local, model_dim, inter_dim/32]. sglang applies e8m0_shuffle on the 2D view (E*rows, groups) then reshapes back -- quark_w4a4_mxfp4_moe.py:577-586.",
+    "weight_layout": "sglang shuffles the packed nibbles with shuffle_weight(w, (16, 16)) and sets .is_shuffled = True at load time -- quark_w4a4_mxfp4_moe.py:589-597. Without that attribute aiter/fused_moe.py:2529 sees is_shuffled=False, use_mxfp4_flydsl (:2198) is False, and the call silently lands on the CK 2-stage path instead of the FlyDSL kernels this task reproduces.",
+    "dispatch_evidence": "Re-running this harness on the session image reproduces the session's aiter log verbatim for both M buckets. server.log line (x8 ranks, 15 M buckets, 120 occurrences total): \"[fused_moe] no tuned FlyDSL config for ('gfx950', 256, <M>, 8192, 2048, 64, 9, 'ActivationType.Silu', 'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', 'QuantType.per_1x32', True, False), using heuristic FlyDSL fallback (kn1=..., kn2=...)\". Harness output for M=64 and M=16384 matches this tuple exactly.",
+    "untuned": "Unlike the Kimi-K3 sibling task, this session runs entirely on the HEURISTIC FALLBACK branch -- every one of the 15 M buckets logs 'no tuned FlyDSL config'. The fallback tile selection (aiter/fused_moe.py:2249-2255) is itself part of the optimisation surface, so the harness asserts FlyDSL dispatch but does NOT require a tuned-CSV hit."
+  },
+  "moe_config": {
+    "quant_type": "per_1x32",
+    "activation": "Silu",
+    "gate_up_layout": "GGUU (separated): w1 rows [0:inter] = gate, [inter:2*inter] = up",
+    "shuffle_layout": [
+      16,
+      16
+    ],
+    "scale_dtype": "float8_e8m0fnu",
+    "weight_dtype": "float4_e2m1fn_x2",
+    "activation_dtype": "bfloat16 in, fp4 after the kernel's own dynamic quant",
+    "doweight_stage1": false,
+    "doweight_stage2": true
+  },
+  "cases": [
+    {
+      "id": "qwen38-moe-decode-m64",
+      "phase": "decode",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 7,
+      "session_e2e_pct": {
+        "stage1": 11.62,
+        "stage2": 6.25
+      },
+      "calls_per_forward": 92,
+      "measured": "trace",
+      "note": "The profiled decode step, bs=64 (conc 64, one token per sequence). This is the only case whose session timing is directly measured: 8-rank torch trace, step[DECODE bs=64] = 30.854 ms.",
+      "trace_input_shapes": {
+        "hidden_states": [
+          64,
+          8192
+        ],
+        "w1": [
+          64,
+          4096,
+          4096
+        ],
+        "w2": [
+          64,
+          8192,
+          1024
+        ],
+        "w1_scale": [
+          64,
+          4096,
+          256
+        ],
+        "w2_scale": [
+          64,
+          8192,
+          64
+        ],
+        "topk_weight": [
+          64,
+          10
+        ],
+        "topk_ids": [
+          64,
+          10
+        ],
+        "expert_mask": [
+          512
+        ],
+        "output": [
+          64,
+          8192
+        ]
+      },
+      "trace_input_dtypes": {
+        "hidden_states": "bfloat16",
+        "w1": "float4_e2m1fn_x2",
+        "w2": "float4_e2m1fn_x2",
+        "w1_scale": "float8_e8m0fnu",
+        "w2_scale": "float8_e8m0fnu",
+        "topk_weight": "float32",
+        "topk_ids": "int32",
+        "expert_mask": "int32",
+        "output": "bfloat16"
+      },
+      "expected_dispatch": {
+        "stage1": "flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w2",
+        "stage2": "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic_bnt2"
+      },
+      "params": {
+        "token": 64,
+        "model_dim": 8192,
+        "inter_dim": 2048,
+        "local_experts": 64,
+        "total_experts": 512,
+        "topk": 10,
+        "quant_type": "per_1x32",
+        "a_dtype": "fp4",
+        "w_dtype": "fp4",
+        "use_g1u1": true,
+        "min_cosine": 0.97,
+        "max_rel_norm_err": 0.25
+      },
+      "benchmark": {
+        "warmup": 5,
+        "repetition": 20,
+        "target_ms": 2.0,
+        "max_graph_repeats": 100
+      }
+    },
+    {
+      "id": "qwen38-moe-prefill-m16384",
+      "phase": "prefill",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 11,
+      "session_e2e_pct": null,
+      "calls_per_forward": 92,
+      "measured": "shape_only",
+      "note": "chunked_prefill_size = 16384; 403 of the session's 429 prefill batches are exactly this size (6,604,752 of 6,815,744 prefill tokens). The SHAPE is certain, the E2E weight is not: the session captured no prefill trace, so session_e2e_pct is null on purpose.",
+      "trace_input_shapes": {
+        "hidden_states": [
+          16384,
+          8192
+        ],
+        "w1": [
+          64,
+          4096,
+          4096
+        ],
+        "w2": [
+          64,
+          8192,
+          1024
+        ],
+        "w1_scale": [
+          64,
+          4096,
+          256
+        ],
+        "w2_scale": [
+          64,
+          8192,
+          64
+        ],
+        "topk_weight": [
+          16384,
+          10
+        ],
+        "topk_ids": [
+          16384,
+          10
+        ],
+        "expert_mask": [
+          512
+        ],
+        "output": [
+          16384,
+          8192
+        ]
+      },
+      "trace_input_dtypes": {
+        "hidden_states": "bfloat16",
+        "w1": "float4_e2m1fn_x2",
+        "w2": "float4_e2m1fn_x2",
+        "w1_scale": "float8_e8m0fnu",
+        "w2_scale": "float8_e8m0fnu",
+        "topk_weight": "float32",
+        "topk_ids": "int32",
+        "expert_mask": "int32",
+        "output": "bfloat16"
+      },
+      "expected_dispatch": {
+        "stage1": "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w4_bnt0",
+        "stage2": "flydsl_moe2_afp4_wfp4_bf16_t64x128x256_atomic"
+      },
+      "params": {
+        "token": 16384,
+        "model_dim": 8192,
+        "inter_dim": 2048,
+        "local_experts": 64,
+        "total_experts": 512,
+        "topk": 10,
+        "quant_type": "per_1x32",
+        "a_dtype": "fp4",
+        "w_dtype": "fp4",
+        "use_g1u1": true,
+        "min_cosine": 0.97,
+        "max_rel_norm_err": 0.25
+      },
+      "benchmark": {
+        "warmup": 3,
+        "repetition": 15,
+        "target_ms": 20.0,
+        "max_graph_repeats": 20
+      }
+    },
+    {
+      "id": "qwen38-moe-prefill-m8192",
+      "phase": "prefill",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 13,
+      "session_e2e_pct": null,
+      "calls_per_forward": 92,
+      "measured": "shape_only",
+      "note": "The other prefill batch size the session actually ran: 26 of 429 batches at 8192 tokens (one un-paired ISL-8192 request). This is a THIRD kernel pair, not a duplicate of M=16384: aiter/fused_moe.py:2251 sends 4096 <= token < 16384 to tile_m=128 (_w2_bnt0), while token >= 16384 goes to tile_m=64 (_w4_bnt0). Verified by running the harness -- the expected_dispatch below is what aiter actually logs.",
+      "trace_input_shapes": {
+        "hidden_states": [
+          8192,
+          8192
+        ],
+        "w1": [
+          64,
+          4096,
+          4096
+        ],
+        "w2": [
+          64,
+          8192,
+          1024
+        ],
+        "w1_scale": [
+          64,
+          4096,
+          256
+        ],
+        "w2_scale": [
+          64,
+          8192,
+          64
+        ],
+        "topk_weight": [
+          8192,
+          10
+        ],
+        "topk_ids": [
+          8192,
+          10
+        ],
+        "expert_mask": [
+          512
+        ],
+        "output": [
+          8192,
+          8192
+        ]
+      },
+      "trace_input_dtypes": {
+        "hidden_states": "bfloat16",
+        "w1": "float4_e2m1fn_x2",
+        "w2": "float4_e2m1fn_x2",
+        "w1_scale": "float8_e8m0fnu",
+        "w2_scale": "float8_e8m0fnu",
+        "topk_weight": "float32",
+        "topk_ids": "int32",
+        "expert_mask": "int32",
+        "output": "bfloat16"
+      },
+      "expected_dispatch": {
+        "stage1": "flydsl_moe1_afp4_wfp4_bf16_t128x128x256_w2_bnt0",
+        "stage2": "flydsl_moe2_afp4_wfp4_bf16_t128x128x256_atomic"
+      },
+      "params": {
+        "token": 8192,
+        "model_dim": 8192,
+        "inter_dim": 2048,
+        "local_experts": 64,
+        "total_experts": 512,
+        "topk": 10,
+        "quant_type": "per_1x32",
+        "a_dtype": "fp4",
+        "w_dtype": "fp4",
+        "use_g1u1": true,
+        "min_cosine": 0.97,
+        "max_rel_norm_err": 0.25
+      },
+      "benchmark": {
+        "warmup": 3,
+        "repetition": 15,
+        "target_ms": 10.0,
+        "max_graph_repeats": 40
+      }
+    }
+  ]
+}

--- a/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/config.yaml
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/config.yaml
@@ -1,0 +1,80 @@
+task_type: image_kernel
+# The edit surface here is the HIP/asm tree, not the Python package. aiter's JIT
+# reads its C++ sources from AITER_META_DIR/csrc (aiter/jit/core.py:409-416), and
+# scripts/task_runner.py points that at the workspace, so edits under
+# cpp_itfs/pa/ are what actually gets compiled.
+image_repo_path: /sgl-workspace/aiter/csrc
+repo_subdir: csrc
+image_repo_exclude:
+- __pycache__
+- build
+repository_language: hip
+source_file_path:
+- cpp_itfs/pa/pa_ragged.py
+- cpp_itfs/pa/pa_ragged.cpp.jinja
+- cpp_itfs/pa/pa_common.cuh
+editable_sources:
+- cpp_itfs/pa/pa_kernels.cuh
+- cpp_itfs/pa/pa_ragged.cuh
+- cpp_itfs/pa/pa.cuh
+target_kernel_functions:
+- paged_attention_ll4mi_QKV_mfma16_kernel
+- paged_attention_ll4mi_reduce_kernel
+kernel_identity:
+  logical_operator: aiter_paged_attention_decode
+  kernel_kind: hip
+  source_owner: aiter
+  workload:
+    source: session_cases.json
+    primary_case: qwen38-pa-decode-bs64-seq8704
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+compile_timeout: 1200
+correctness_timeout: 1800
+performance_timeout: 1800
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Faithful reproduction of the Qwen3.8-2.4T-A95B full-attention decode path as
+    it actually executed in Hyperloom session 100137 (20260814T175123Z) on
+    MI355X/gfx950 under sglang 0.5.17. 23 of the model's 92 layers take this path;
+    the other 69 are Gated DeltaNet and have their own task.
+    Two kernels per call, both measured in the session's 8-rank trace:
+    paged_attention_ll4mi_QKV_mfma16_kernel<0, __hip_bfloat16, unsigned char,
+    (vllm::Fp8KVCacheDataType)1, 1, 256, 256, false, 8, 1,
+    ck_tile::ComposedAttention<...>> at 3.146% E2E, and
+    paged_attention_ll4mi_reduce_kernel<__hip_bfloat16, __hip_bfloat16, 256, 256,
+    256, 1, false> at 0.211% E2E.
+    Neither reaches the 5% hot-kernel bar on its own. The reason this exists as a
+    task is the configuration: head_size = 256, where almost every served model
+    uses 128, combined with fp8_e4m3 KV (dequantized in-kernel via k_scale /
+    v_scale) and a GQA group of exactly 8. Per rank (TP=8) there are 8 q heads
+    and 1 kv head -- num_key_value_heads is 4, below tp_size, so QKVParallelLinear
+    replicates it up to 8 before sharding. page_size is 1 and partition_size is
+    256 (_AITER_PARTITION_SIZE_ROCM). This instantiation gets far less tuning
+    attention than the head_size=128 one.
+    Three context lengths span the session's whole decode range: seq 8192 (start
+    of generation, ISL only), 8704 (where the profiler window sat, so the E2E
+    numbers above were measured there) and 9216 (ISL 8192 + OSL 1024, end of
+    generation).
+    Unlike the dense-GEMM task in this set, this is an in-place kernel
+    optimisation: the harness PINS the dispatched instantiation and fails if
+    paged_attention_ll4mi_QKV_mfma16_kernel is not the kernel that ran, or if the
+    fp8 KV template arg changes. Routing to a different backend would change the
+    subject rather than optimise it.
+    Correctness compares against a fully vectorized fp32 torch GQA reference
+    (two einsums and a softmax over the dequantized cache) that never enters
+    aiter; baseline agreement is cos ~0.99995, the residual being fp8 KV
+    quantization noise. Correctness and performance run the identical case list at
+    identical shapes. Do not edit the harness. Preserve all correctness cases and
+    improve the CUDA-graph measured performance.
+  cheatsheet: null

--- a/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/scripts/forge_driver.py
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/scripts/forge_driver.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Qwen3.8 paged GQA decode attention task.
+
+Target (optimized by forge-loop): the aiter ll4mi HIP kernels
+``paged_attention_ll4mi_QKV_mfma16_kernel`` and
+``paged_attention_ll4mi_reduce_kernel`` in ``csrc/cpp_itfs/pa/``, at this
+session's unusual instantiation -- head_size 256, fp8_e4m3 KV with in-kernel
+dequant, GQA group 8, page_size 1.
+
+Why this file exists
+--------------------
+``agents/forge/launch_agent.py:822`` prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root;
+without one it generates a shim around ``agents/forge/drivers/arena_task_adapter``.
+That shim parses ``--profile-run`` with ``parse_known_args``, i.e. it silently
+swallows the flag and runs correctness instead. KernelForge's
+``_check_profile_contract`` only asserts ``returncode == 0``, so the shim passes
+the gate without owning a profiling path. Campaigns longer than 2 hours switch
+Analysis to ``profiled`` (``kernel_agents/cli.py:2088``) and actually use that
+path. This driver implements the flag for real.
+
+Contract implemented (forge-loop reads only stdout; parsers are
+``mcp_server/tools/test.py:74-83`` and ``mcp_server/tools/bench.py:341-347``):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``SNR: <db> dB`` (worst case) against the harness's vectorized
+        fp32 GQA reference, plus ``max_diff:``. The pristine kernel measures
+        rel_norm_err ~0.0103, i.e. ~39.7 dB, clearing forge's 30 dB gate. That
+        residual is fp8 KV quantization noise -- a property of the workload, not
+        an implementation gap -- so the error would have to grow ~3x to fail.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` for every declared case plus one
+        ``mean_ms:`` aggregate. Timing goes through the harness's
+        ``_benchmark_cuda_graph_or_events``, so
+        ``task_preparer._count_graph_replays`` observes real CUDA-graph replays.
+
+  * Profiling    ``--profile-run [--profile-case <case_id>]``
+        builds one case (the longest context by default) and launches ONLY
+        ``paged_attention_ragged``: warmups to settle the aiter template-op
+        build, a few profiled launches, one synchronize, exit 0. Prints no
+        timing.
+
+All measurement logic is REUSED from ``scripts/task_runner.py``. forge-loop
+never edits this file.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root."""
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise SystemExit("error: task_runner.py not found next to forge_driver.py")
+
+
+def _cases(tr) -> list[dict]:
+    cases = list(tr.CASES)
+    if not cases:
+        raise SystemExit("error: session_cases.json declares no cases")
+    return cases
+
+
+def _snr_db(rel_norm_err: float) -> float:
+    """SNR in dB from a relative norm error: 20*log10(||ref|| / ||err||)."""
+    if rel_norm_err <= 0:
+        return 200.0
+    return -20.0 * math.log10(rel_norm_err)
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def _run_correctness(tr) -> int:
+    import torch
+
+    worst_err, worst_cos, all_ok = 0.0, 1.0, True
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        got = tr._run(inputs)
+        torch.cuda.synchronize()
+        expected = tr._reference(inputs)
+        finite = bool(torch.isfinite(got).all())
+        cos, err = tr._deviation(got, expected)
+
+        tol = case["params"]
+        ok = (
+            finite
+            and cos > tol.get("min_cosine", 0.999)
+            and err < tol.get("max_rel_norm_err", 0.05)
+        )
+        all_ok = all_ok and ok
+        worst_err, worst_cos = max(worst_err, err), min(worst_cos, cos)
+        print(f"# case {case['id']}: cos={cos:.6f} rel_norm_err={err:.5f} "
+              f"finite={finite} ok={ok}")
+        del inputs, expected, got
+        tr._free()
+
+    print(f"max_diff: {worst_err:.6e}")
+    print(f"SNR: {_snr_db(worst_err):.2f} dB")
+    print(f"allclose: {all_ok}")
+    print(f"# worst cosine {worst_cos:.6f} across {len(_cases(tr))} case(s)")
+    return 0 if all_ok else 1
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    import torch
+
+    means: list[float] = []
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        tr._run(inputs)
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        exec_ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda: tr._run(inputs),
+            warmup=warmup,
+            # One graph replay per timed iteration: this is what makes
+            # _count_graph_replays see >= iters replays.
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 100),
+        )
+        if not isinstance(exec_ms, (int, float)) or exec_ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {exec_ms!r}",
+                  file=sys.stderr)
+            return 1
+        if meta.get("benchmark_method") != "cuda_graph":
+            print(f"error: case {case['id']} timed with "
+                  f"{meta.get('benchmark_method')} instead of cuda_graph "
+                  f"({meta.get('benchmark_fallback_reason')})", file=sys.stderr)
+            return 1
+        means.append(float(exec_ms))
+        print(f"case_ms: {case['id']} {exec_ms:.6f}")
+        print(f"# bench {case['id']}: {exec_ms:.6f} ms "
+              f"method={meta.get('benchmark_method')} "
+              f"chained={meta.get('benchmark_effective_repeats')}")
+        del inputs
+        tr._free()
+
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr, case_id: str | None) -> int:
+    """Launch ONLY the target chain, so a profiler session captures it and nothing else."""
+    import torch
+
+    cases = _cases(tr)
+    if case_id:
+        match = [c for c in cases if c["id"] == case_id]
+        if not match:
+            print(f"error: unknown --profile-case {case_id!r}; declared: "
+                  f"{', '.join(c['id'] for c in cases)}", file=sys.stderr)
+            return 1
+        case = match[0]
+    else:
+        case = max(cases, key=lambda c: int(c["params"].get("seq_len", 0)))
+
+    inputs = tr._prepare(case)
+    # Warmups settle the Triton JIT so the profiled launches contain kernel time.
+    for _ in range(5):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    for _ in range(3):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    print(f"# profiled {case['id']} (bs={case['params']['batch']} "
+          f"seq={case['params']['seq_len']})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--mode", default="full")        # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--profile-case", default=None)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args, _unknown = parser.parse_known_args()
+
+    tr = _import_task_runner()
+    tr._configure()
+    import torch
+
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr, args.profile_case)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/scripts/task_runner.py
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/scripts/task_runner.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the Qwen3.8-2.4T-A95B paged GQA decode attention.
+
+Reproduces the full-attention decode path of Hyperloom session 100137
+(Qwen3.8-2.4T-A95B-Quark-MXFP4, 20260814T175123Z) on MI355X/gfx950, sglang
+0.5.17.dev20260812+gdc5f6c4883 / ROCm 7.2.0 / aiter d9e5ef7ce.
+
+23 of the model's 92 layers are ``full_attention``; the other 69 are Gated
+DeltaNet. Two kernels per call, both measured in the session's 8-rank trace:
+
+  paged_attention_ll4mi_QKV_mfma16_kernel<0, __hip_bfloat16, unsigned char,
+      (vllm::Fp8KVCacheDataType)1, 1, 256, 256, false, 8, 1,
+      ck_tile::ComposedAttention<...>>       23x/step  1.7119 ms/step  3.146% E2E
+  paged_attention_ll4mi_reduce_kernel<__hip_bfloat16, __hip_bfloat16,
+      256, 256, 256, 1, false>               23x/step  0.1149 ms/step  0.211% E2E
+
+Running this harness on the session image dispatches those two template
+instantiations byte-for-byte, at ~65 us/call against the trace's ~79 us/call.
+
+What makes this configuration worth its own task rather than another case on the
+generic paged-attention task: **head_size = 256**. Almost every served model uses
+128. Combined with fp8_e4m3 KV and a GQA group of 8, this instantiation sees far
+less tuning attention than the 128 one.
+
+Per-rank geometry (TP=8), from config.json:
+    num_attention_heads 64            -> 8 q heads/rank
+    num_key_value_heads 4             -> padded to tp_size 8 by QKVParallelLinear,
+                                         so 1 k head and 1 v head per rank
+    head_dim 256, page_size 1, partition_size 256 (_AITER_PARTITION_SIZE_ROCM)
+    kv_cache_dtype fp8_e4m3, k_scale = v_scale = 1.0, logits_soft_cap = 0.0
+    scale = head_dim ** -0.5
+
+The kv-head padding is not a guess: it is what makes qkv_proj's per-rank output
+4608 = (64*2 + 8 + 8) * 256 / 8, which is the width the capture trace records.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+PA = SPEC["pa_config"]
+
+_IMAGE_AITER_ROOT = Path(os.environ.get("QWEN38_AITER_ROOT", "/sgl-workspace/aiter"))
+# Only csrc is seeded for this task -- the edit surface is the HIP/asm tree, not
+# the Python package -- so these two are linked in beside it.
+_AITER_SIBLINGS = ("3rdparty", "hsa")
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.environ.setdefault("AITER_JIT_DIR", str(WORKSPACE / "build" / "jit"))
+    # aiter's JIT reads its C++/HIP sources from AITER_META_DIR/csrc
+    # (aiter/jit/core.py:409-416). Pointing it at the workspace is what makes the
+    # agent's edits to csrc/cpp_itfs/pa/*.cuh the code that actually gets
+    # compiled; without it the image copy is rebuilt and the patch is a no-op.
+    # core.py:412 falls back to the install root if csrc is absent, so an
+    # un-seeded workspace still runs (against unmodified sources).
+    if (WORKSPACE / "csrc").is_dir():
+        for name in _AITER_SIBLINGS:
+            link, src = WORKSPACE / name, _IMAGE_AITER_ROOT / name
+            if not link.exists() and not link.is_symlink() and src.is_dir():
+                link.symlink_to(src, target_is_directory=True)
+        os.environ.setdefault("AITER_META_DIR", str(WORKSPACE))
+    else:
+        os.environ.setdefault("AITER_META_DIR", str(_IMAGE_AITER_ROOT))
+    _pin_template_op_build_dir()
+    os.chdir(WORKSPACE)
+
+
+def _pa_source_fingerprint() -> str:
+    """sha256 over the PA sources this run will compile, truncated to 12 hex."""
+    import hashlib
+
+    root = WORKSPACE if (WORKSPACE / "csrc").is_dir() else _IMAGE_AITER_ROOT
+    pa_dir = root / "csrc" / "cpp_itfs" / "pa"
+    h = hashlib.sha256()
+    for path in sorted(pa_dir.rglob("*")):
+        if path.is_file() and path.suffix in (".cuh", ".h", ".jinja", ".cpp", ".py"):
+            h.update(path.name.encode())
+            h.update(path.read_bytes())
+    # utils.py owns the compile flags and the template-op machinery.
+    utils = root / "csrc" / "cpp_itfs" / "utils.py"
+    if utils.is_file():
+        h.update(utils.read_bytes())
+    return h.hexdigest()[:12]
+
+
+def _pin_template_op_build_dir() -> None:
+    """Make the template-op build cache workspace-local AND content-addressed.
+
+    Without this the task silently scores stale binaries. aiter compiles the
+    ll4mi kernels through ``compile_template_op``
+    (csrc/cpp_itfs/utils.py:300), whose cache folder is
+    ``$AITER_ROOT_DIR/build/<md_name>_<md5 of the TEMPLATE ARGUMENTS>`` and whose
+    only freshness check is ``not_built()`` -- "does lib.so exist"
+    (utils.py:297). Two consequences, both fatal to this task:
+
+      * the md5 covers head_size / dtype / block_size etc. but NOT the contents
+        of pa_kernels.cuh, so an agent edits the kernel, the folder name is
+        unchanged, lib.so is already there, and the OLD binary runs;
+      * AITER_ROOT_DIR defaults to ``$HOME/.aiter`` (utils.py:68), which is
+        shared across every workspace on the machine, so one run's binary leaks
+        into another's.
+
+    Folding a hash of the PA sources into AITER_ROOT_DIR fixes both: the path is
+    under the workspace, and it changes exactly when the sources change -- so an
+    edit forces a real rebuild while an unchanged rerun still hits the cache.
+    """
+    root = WORKSPACE / "build" / f"aiter-{_pa_source_fingerprint()}"
+    (root / "build").mkdir(parents=True, exist_ok=True)
+    os.environ["AITER_ROOT_DIR"] = str(root)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(fn, repetition):
+    import time
+    import torch
+
+    repetition = max(1, int(repetition))
+    if not torch.cuda.is_available():
+        times_ms = []
+        for _ in range(repetition):
+            start = time.perf_counter()
+            fn()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+        return times_ms
+
+    times_ms = []
+    for _ in range(repetition):
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        fn()
+        end_event.record()
+        torch.cuda.synchronize()
+        times_ms.append(start_event.elapsed_time(end_event))
+    return times_ms
+
+
+class _TimedRun:
+    """Handle on the exact invocation a benchmark measured.
+
+    Timing and correctness are otherwise separate invocations, so a kernel can
+    tell them apart and do less work in the one that is scored. Passing this
+    collector to the benchmark makes the scored invocation itself observable:
+    ``outputs`` aliases the buffers the timed unit last wrote, and ``rerun``
+    executes that same unit again.
+
+    Under CUDA-graph timing the buffers are captured once and every replay
+    writes to those same addresses, so ``outputs`` keeps tracking replays. Under
+    event-timing fallback the measured outputs cannot be observed reliably, so a
+    benchmark that requests this collector fails closed instead of validating a
+    separate post-timing invocation.
+    """
+
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError(
+                "timed run was never bound; the benchmark did not reach a "
+                "measurement path"
+            )
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph_or_events(
+    fn,
+    warmup=10,
+    repetition=100,
+    target_ms=1.0,
+    n_retries=5,
+    estimate_reps=5,
+    max_graph_repeats=1000,
+    use_cuda_graph=True,
+    fallback_reason=None,
+    timed_run=None,
+):
+    import torch
+
+    def _reject_unobservable_fallback(reason):
+        if timed_run is not None:
+            raise RuntimeError(
+                f"{reason}; timed_run requires an observable CUDA-graph replay "
+                "and cannot validate a separate post-timing invocation"
+            )
+
+    # A captured graph whose measured per-iteration time falls below this floor is
+    # treated as empty (it recorded no device work) and rejected in favour of
+    # per-launch event timing, so a graph that silently captured nothing is never
+    # reported as a fabricated ~0 ms cuda_graph result. Real kernels measure far
+    # above this floor; an empty-graph replay measures ~1e-5 ms.
+    empty_graph_floor_ms = 1e-4
+
+    for _ in range(max(0, int(warmup))):
+        fn()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    max_graph_repeats = max(1, int(max_graph_repeats))
+    metadata = {
+        "benchmark_target_ms": float(target_ms),
+        "benchmark_samples": int(repetition),
+        "benchmark_max_repeats": int(max_graph_repeats),
+    }
+
+    if not torch.cuda.is_available():
+        _reject_unobservable_fallback("CUDA is unavailable")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cpu_timer_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_unavailable",
+        })
+        return sum(times) / len(times), metadata
+
+    if not use_cuda_graph:
+        _reject_unobservable_fallback("CUDA-graph timing is disabled")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_graph_disabled",
+        })
+        return sum(times) / len(times), metadata
+
+    try:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            estimate_reps = max(1, int(estimate_reps))
+            estimate_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(estimate_graph):
+                for _ in range(estimate_reps):
+                    fn()
+            torch.cuda.synchronize()
+
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record(stream)
+            estimate_graph.replay()
+            end_event.record(stream)
+            torch.cuda.synchronize()
+
+            estimate_ms = start_event.elapsed_time(end_event) / estimate_reps
+            if estimate_ms == 0:
+                n_repeat = max_graph_repeats
+            else:
+                n_repeat = min(max_graph_repeats, max(1, int(float(target_ms) / estimate_ms)))
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured_outputs = None
+                for _ in range(n_repeat):
+                    captured_outputs = fn()
+            torch.cuda.synchronize()
+
+            retry_times = []
+            for _ in range(max(1, int(repetition))):
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+                start_event.record(stream)
+                graph.replay()
+                end_event.record(stream)
+                torch.cuda.synchronize()
+                retry_times.append(start_event.elapsed_time(end_event) / n_repeat)
+
+        graph_mean = sum(retry_times) / len(retry_times)
+        if graph_mean < empty_graph_floor_ms:
+            _reject_unobservable_fallback("CUDA graph captured no device work")
+            times = _measure_cuda_event_fallback(fn, repetition)
+            metadata.update({
+                "benchmark_method": "cuda_event_fallback",
+                "benchmark_effective_repeats": int(repetition),
+                "benchmark_fallback_reason": fallback_reason or "empty_cuda_graph_capture",
+            })
+            return sum(times) / len(times), metadata
+
+        metadata.update({
+            "benchmark_method": "cuda_graph",
+            "benchmark_effective_repeats": int(n_repeat),
+        })
+        if timed_run is not None:
+
+            def _replay_once():
+                # Callers stage work on their own stream before re-running (they
+                # perturb inputs and poison outputs). The capture stream must be
+                # ordered after that, or the replay races the staged writes and
+                # they land on top of the kernel's results.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
+        return graph_mean, metadata
+    except Exception as exc:
+        # Isolate the aborted capture before re-measuring so the fallback timing is
+        # not polluted by the failed attempt (a mid-capture failure can leave the
+        # first few launches abnormally slow).
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed_run cannot validate the "
+                "separate CUDA-event fallback invocation"
+            ) from exc
+        for _ in range(min(3, max(1, int(warmup)))):
+            fn()
+        torch.cuda.synchronize()
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": f"cuda_graph_failed: {type(exc).__name__}: {str(exc)[:160]}",
+        })
+        return sum(times) / len(times), metadata
+# <<< AKA-GENERATED <<<
+
+
+# --------------------------------------------------------------------------- #
+# Small utilities
+# --------------------------------------------------------------------------- #
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    torch.set_grad_enabled(False)
+    return torch
+
+
+def _free() -> None:
+    _torch().cuda.empty_cache()
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _fp8_dtype():
+    """The KV cache element type sglang uses for kv_cache_dtype=fp8_e4m3 on gfx950.
+
+    gfx950 is OCP fp8, i.e. torch.float8_e4m3fn. Older CDNA parts use the fnuz
+    variant, so resolve rather than hardcode -- but fail loudly instead of
+    silently falling back to a type the kernel would reject.
+    """
+    torch = _torch()
+    for name in PA["kv_cache_torch_dtype_candidates"]:
+        if hasattr(torch, name):
+            return getattr(torch, name)
+    raise RuntimeError(
+        f"torch has none of {PA['kv_cache_torch_dtype_candidates']}; cannot build "
+        f"an fp8_e4m3 KV cache."
+    )
+
+
+def _dispatched_kernels(inputs: dict) -> list[str]:
+    """Name the HIP kernels this call lands on, most expensive first.
+
+    Recorded and asserted: unlike the GEMM task, the session's kernel here IS the
+    thing being optimised in place, so a change that silently routes to a
+    different backend is a change of subject, not an optimisation.
+    """
+    torch = _torch()
+    from torch.profiler import ProfilerActivity, profile
+
+    _run(inputs)
+    torch.cuda.synchronize()
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        _run(inputs)
+        torch.cuda.synchronize()
+    events = [
+        (e.self_device_time_total, e.key)
+        for e in prof.key_averages()
+        if getattr(e, "self_device_time_total", 0) > 0
+    ]
+    events.sort(reverse=True)
+    return [k for _, k in events]
+
+
+def _assert_paged_attention_dispatch(label: str, kernels: list[str]) -> None:
+    blob = "\n".join(kernels)
+    if "paged_attention_ll4mi_QKV_mfma16_kernel" not in blob:
+        raise AssertionError(
+            f"{label}: paged_attention_ll4mi_QKV_mfma16_kernel did not run. "
+            f"Kernels seen: {kernels[:4]}. This task reproduces that specific "
+            f"aiter ll4mi instantiation; a different backend is a different op."
+        )
+    if "Fp8KVCacheDataType)1" not in blob:
+        raise AssertionError(
+            f"{label}: the dispatched instantiation is not the fp8 KV one. The "
+            f"session runs kv_cache_dtype=fp8_e4m3 with in-kernel dequant; a bf16 "
+            f"cache would be a different (and cheaper) kernel. Kernels: {kernels[:2]}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+#
+# Argument order and every constant below are taken from the live call site,
+# srt/layers/attention/aiter_backend.py:2638-2658:
+#     paged_attention_ragged(
+#         o.view(-1, tp_q_head_num, v_head_dim),
+#         workspace_buffer,
+#         q.view(-1, tp_q_head_num, qk_head_dim),
+#         k_cache.view(-1, 1, tp_k_head_num, qk_head_dim),
+#         v_cache.view(-1, 1, tp_v_head_num, v_head_dim),
+#         scale, kv_indptr, kv_indices, kv_last_page_len,
+#         1,                       # block_size (page_size=1)
+#         max_num_partitions, None, aiter_kv_str, "NHD", logits_soft_cap,
+#         k_scale, v_scale, None, _AITER_PARTITION_SIZE_ROCM)
+# The workspace sizing is aiter_backend.py:277-282.
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    torch = _torch()
+
+    p = dict(case["params"])
+    batch, seq_len = int(p["batch"]), int(p["seq_len"])
+    qh, kvh, hd = int(p["q_heads"]), int(p["kv_heads"]), int(p["head_dim"])
+    part = int(p["partition_size"])
+    fp8 = _fp8_dtype()
+
+    torch.manual_seed(int(case.get("seed", 17)))
+    dev = "cuda"
+    q = torch.randn((batch, qh, hd), device=dev, dtype=torch.bfloat16) * 0.1
+    # page_size = 1, so one "page" per token; the pool is exactly batch*seq_len.
+    pages = batch * seq_len
+    k_cache = (torch.randn((pages, 1, kvh, hd), device=dev, dtype=torch.bfloat16) * 0.1).to(fp8)
+    v_cache = (torch.randn((pages, 1, kvh, hd), device=dev, dtype=torch.bfloat16) * 0.1).to(fp8)
+    out = torch.empty((batch, qh, hd), device=dev, dtype=torch.bfloat16)
+
+    max_num_partitions = (seq_len + part - 1) // part
+    fp32_bytes = torch.finfo(torch.float32).bits // 8
+    workspace = torch.empty(
+        (batch * qh * max_num_partitions * hd) * fp32_bytes
+        + 2 * (batch * qh * max_num_partitions) * 4,
+        dtype=torch.uint8,
+        device=dev,
+    )
+    kv_indptr = torch.arange(0, (batch + 1) * seq_len, seq_len, device=dev, dtype=torch.int32)
+    kv_indices = torch.arange(0, pages, device=dev, dtype=torch.int32)
+    kv_last_page_len = torch.ones((batch,), device=dev, dtype=torch.int32)
+    k_scale = torch.tensor([float(p["k_scale"])], device=dev, dtype=torch.float32)
+    v_scale = torch.tensor([float(p["v_scale"])], device=dev, dtype=torch.float32)
+
+    return {
+        "cfg": case, "params": p, "batch": batch, "seq_len": seq_len,
+        "q_heads": qh, "kv_heads": kvh, "head_dim": hd,
+        "q": q, "k_cache": k_cache, "v_cache": v_cache, "out": out,
+        "workspace": workspace, "kv_indptr": kv_indptr, "kv_indices": kv_indices,
+        "kv_last_page_len": kv_last_page_len,
+        "k_scale": k_scale, "v_scale": v_scale,
+        "scale": float(hd) ** -0.5,
+        "max_num_partitions": max_num_partitions, "partition_size": part,
+    }
+
+
+def _run(inputs: dict):
+    from aiter.ops.attention import paged_attention_ragged
+
+    paged_attention_ragged(
+        inputs["out"],
+        inputs["workspace"],
+        inputs["q"],
+        inputs["k_cache"],
+        inputs["v_cache"],
+        inputs["scale"],
+        inputs["kv_indptr"],
+        inputs["kv_indices"],
+        inputs["kv_last_page_len"],
+        1,                                   # block_size / page_size
+        inputs["max_num_partitions"],
+        None,                                # alibi_slopes
+        PA["aiter_kv_cache_dtype"],
+        PA["kv_cache_layout"],
+        float(PA["logits_soft_cap"]),
+        inputs["k_scale"],
+        inputs["v_scale"],
+        None,                                # fp8_out_scale
+        inputs["partition_size"],
+    )
+    return inputs["out"]
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+#
+# Plain fp32 GQA attention over the dequantized cache. Fully vectorized: two
+# einsums and a softmax, no loop over batch, head or partition -- so it is also
+# an independent implementation of the partitioned reduction the ll4mi pair does
+# in two kernels.
+#
+# Sizes stay small because only the scores are materialized: at the session's
+# bs=64 / 8 heads / seq 8704 that is [64, 8, 8704] fp32 = 18 MiB. The
+# dequantized cache is the larger term ([64, 8704, 256] fp32 = 570 MiB), so it
+# is built per call and dropped rather than cached.
+# --------------------------------------------------------------------------- #
+def _reference(inputs: dict):
+    torch = _torch()
+    batch, seq_len = inputs["batch"], inputs["seq_len"]
+    qh, kvh, hd = inputs["q_heads"], inputs["kv_heads"], inputs["head_dim"]
+
+    # k_scale / v_scale are 1.0 in the session, but apply them anyway so the
+    # reference stays correct if a case ever carries a real scale.
+    k = inputs["k_cache"].view(batch, seq_len, kvh, hd).float() * inputs["k_scale"]
+    v = inputs["v_cache"].view(batch, seq_len, kvh, hd).float() * inputs["v_scale"]
+    q = inputs["q"].float().view(batch, kvh, qh // kvh, hd)   # GQA grouping
+
+    scores = torch.einsum("bkgd,bskd->bkgs", q, k) * inputs["scale"]
+    probs = torch.softmax(scores, dim=-1)
+    out = torch.einsum("bkgs,bskd->bkgd", probs, v)
+    del k, v, scores, probs
+    return out.reshape(batch, qh, hd)
+
+
+def _deviation(got, expected):
+    torch = _torch()
+    g, e = got.float().flatten(), expected.float().flatten()
+    cos = torch.nn.functional.cosine_similarity(g, e, dim=0).item()
+    err = ((g - e).norm() / e.norm().clamp_min(1e-8)).item()
+    return cos, err
+
+
+def _assert_within_tolerance(case: dict, cos: float, err: float, label: str) -> None:
+    tol = case["params"]
+    assert cos > tol.get("min_cosine", 0.999), (
+        case["id"], f"{label} cosine {cos:.6f} vs fp32 reference too low"
+    )
+    assert err < tol.get("max_rel_norm_err", 0.05), (
+        case["id"], f"{label} relative norm error {err:.5f} too high"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inputs = _prepare(CASES[0])
+    out = _run(inputs)
+    _torch().cuda.synchronize()
+    kernels = _dispatched_kernels(inputs)
+    _assert_paged_attention_dispatch("compile", kernels)
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} {out.dtype}")
+    for k in kernels[:2]:
+        print(f"  kernel: {k[:120]}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        # Identical case list and identical shapes to run_performance.
+        inputs = _prepare(case)
+        kernels = _dispatched_kernels(inputs)
+        _assert_paged_attention_dispatch(case["id"], kernels)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        expected = _reference(inputs)
+        assert torch.isfinite(got).all(), (case["id"], "non-finite output")
+        assert tuple(got.shape) == tuple(expected.shape), (
+            case["id"], tuple(got.shape), tuple(expected.shape)
+        )
+        cos, err = _deviation(got, expected)
+        _assert_within_tolerance(case, cos, err, "single call")
+        print(f"correctness PASS {case['id']:34s} bs={inputs['batch']:<4d} "
+              f"seq={inputs['seq_len']:<6d} cos={cos:.6f} rel_err={err:.5f}")
+        del inputs, expected, got
+        _free()
+
+
+def _perturb(inputs: dict) -> None:
+    """Redraw the query so the scored invocation sees unseen values.
+
+    The KV cache stays put: it is the paged pool, which in serving is written by
+    reshape_and_cache_flash and only appended to, and rebuilding the fp8 copy per
+    check would dominate the validation for no added coverage.
+    """
+    torch = _torch()
+    torch.manual_seed(83)
+    inputs["q"].normal_(0.0, 0.1)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed) -> None:
+    torch = _torch()
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    got = timed.rerun()
+    expected = _reference(inputs)
+    assert torch.isfinite(got).all(), (case["id"], "timed run produced non-finite output")
+    cos, err = _deviation(got, expected)
+    _assert_within_tolerance(case, cos, err, "timed run")
+    del expected
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        inputs = _prepare(case)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        kernels = _dispatched_kernels(inputs)
+        _assert_paged_attention_dispatch(case["id"], kernels)
+        bench = case.get("benchmark", {})
+        timed = _TimedRun()
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=bench.get("warmup", 10),
+            repetition=bench.get("repetition", 30),
+            target_ms=bench.get("target_ms", 2.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 100),
+            timed_run=timed,
+        )
+        _assert_timed_outputs(case, inputs, timed)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "phase": case.get("phase"),
+            "calls_per_forward": case.get("calls_per_forward"),
+            "session_e2e_pct": case.get("session_e2e_pct"),
+            "dispatched_kernels": kernels[:2],
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(f"{case['id']:34s} {exec_ms:.6f} ms  {meta.get('benchmark_method')}  "
+              f"{meta.get('benchmark_fallback_reason', '')}")
+        del inputs
+        _free()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/session_cases.json
+++ b/tasks/qwen3-8/mi355x_sglang_aiter_paged_attention_decode_qwen38/session_cases.json
@@ -1,0 +1,286 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950 (256 CU)",
+  "framework": "sglang 0.5.17.dev20260812+gdc5f6c4883 (ROCm 7.2.0, aiter d9e5ef7ce)",
+  "faithful_reproduction": true,
+  "run_environment_requirement": "Must run in the session's image (lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260812) on MI355X/gfx950. Verified on that image: the harness dispatches paged_attention_ll4mi_QKV_mfma16_kernel<0, __hip_bfloat16, unsigned char, (vllm::Fp8KVCacheDataType)1, 1, 256, 256, false, 8, 1, ck_tile::ComposedAttention<...>> and paged_attention_ll4mi_reduce_kernel<__hip_bfloat16, __hip_bfloat16, 256, 256, 256, 1, false> -- byte-identical to the two names in the session trace.",
+  "selection": "The full-attention decode path of session 100137: paged_attention_ll4mi_QKV_mfma16 (3.146% E2E) + its reduce kernel (0.211% E2E). Below the 5% hot-kernel bar, but included because head_size=256 with fp8_e4m3 KV is a rare instantiation that the generic head_size=128 paged-attention tasks do not cover. Communication kernels are deliberately excluded from this task set.",
+  "task_name": "mi355x-qwen38-sglang-aiter-paged-attention-decode-20260814",
+  "operator": "aiter_paged_attention_decode",
+  "provenance": {
+    "session_id": "100137",
+    "session_root": "/shared_nfs/hyperloom-claw/Qwen3.8-2.4T-A95B-Quark-MXFP4/20260814T175123Z",
+    "benchmark_run": "runs/roofline/27652f24f9ee4b999c4479ca44c9bf7c/benchmark_sglang_20260815_060127",
+    "trace": "torch_trace/1786775072.0389888-TP-{0..7}.trace.json.gz",
+    "model_config": "/shared_nfs/hyperloom/models/Qwen3.8-2.4T-A95B-Quark-MXFP4/config.json",
+    "serving_config": "TP=8, attention_backend=aiter, kv_cache_dtype=fp8_e4m3, page_size=1, disable_radix_cache=True, ISL 8192 / OSL 1024 / conc 64",
+    "layer_mix": "layer_types = 23 full_attention + 69 linear_attention out of 92 layers, so this kernel runs 23x per decode step.",
+    "kernel_identity": {
+      "qkv": "paged_attention_ll4mi_QKV_mfma16_kernel<0, __hip_bfloat16, unsigned char, (vllm::Fp8KVCacheDataType)1, 1, 256, 256, false, 8, 1, ck_tile::ComposedAttention<...>> -- 23 calls/step, 1.7119 ms/step (TP-0), 5.549% of the decode step, 3.146% E2E. Template args: 256 = head_dim, 256 = partition_size, 8 = GQA group (8 q heads / 1 kv head per rank), 1 = mtp.",
+      "reduce": "paged_attention_ll4mi_reduce_kernel<__hip_bfloat16, __hip_bfloat16, 256, 256, 256, 1, false> -- 23 calls/step, 0.1149 ms/step, 0.372% of the decode step, 0.211% E2E."
+    },
+    "logical_dims": "Per-rank (TP=8). num_attention_heads 64 -> 8 q heads/rank. num_key_value_heads 4 < tp_size 8, so QKVParallelLinear replicates the kv heads up to 8 and each rank gets exactly 1 k and 1 v head; the GQA group is therefore 8, matching the kernel template. head_dim 256 (unusually large -- most served models use 128). page_size 1, partition_size 256 = _AITER_PARTITION_SIZE_ROCM.",
+    "kv_head_padding_evidence": "The padding is what makes qkv_proj's per-rank output width (64*2 + 8 + 8) * 256 / 8 = 4608, which is exactly the aten::mm N the capture trace records (92 calls of [64,8192]x[8192,4608]). Without padding it would be 4352, which never appears.",
+    "call_site": "srt/layers/attention/aiter_backend.py:2638-2658; workspace sizing at :277-282; scale/k_scale/v_scale/logits_soft_cap at :286-291.",
+    "editability": "The ll4mi kernels are aiter HIP C++/asm under csrc/cpp_itfs/pa/. Unlike the dense-GEMM task this is an in-place kernel-optimisation task, so the harness DOES pin the dispatched instantiation: routing to a different backend would change the subject rather than optimise it."
+  },
+  "pa_config": {
+    "aiter_kv_cache_dtype": "fp8",
+    "kv_cache_layout": "NHD",
+    "logits_soft_cap": 0.0,
+    "block_size": 1,
+    "partition_size": 256,
+    "scale": "head_dim ** -0.5",
+    "kv_cache_torch_dtype_candidates": [
+      "float8_e4m3fn",
+      "float8_e4m3fnuz"
+    ]
+  },
+  "cases": [
+    {
+      "id": "qwen38-pa-decode-bs64-seq8192",
+      "phase": "decode",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 17,
+      "session_e2e_pct": null,
+      "calls_per_forward": 23,
+      "measured": "trace_range",
+      "note": "Start of decode: the whole ISL is cached and no output token has been appended yet. Lower bound of the session's decode context range.",
+      "trace_input_shapes": {
+        "query": [
+          64,
+          8,
+          256
+        ],
+        "k_cache": [
+          524288,
+          1,
+          1,
+          256
+        ],
+        "v_cache": [
+          524288,
+          1,
+          1,
+          256
+        ],
+        "kv_indptr": [
+          65
+        ],
+        "kv_indices": [
+          524288
+        ],
+        "kv_last_page_len": [
+          64
+        ],
+        "k_scale": [
+          1
+        ],
+        "v_scale": [
+          1
+        ],
+        "output": [
+          64,
+          8,
+          256
+        ]
+      },
+      "trace_input_dtypes": {
+        "query": "bfloat16",
+        "k_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "v_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "kv_indptr": "int32",
+        "kv_indices": "int32",
+        "kv_last_page_len": "int32",
+        "k_scale": "float32",
+        "v_scale": "float32",
+        "output": "bfloat16"
+      },
+      "params": {
+        "batch": 64,
+        "seq_len": 8192,
+        "q_heads": 8,
+        "kv_heads": 1,
+        "head_dim": 256,
+        "page_size": 1,
+        "partition_size": 256,
+        "k_scale": 1.0,
+        "v_scale": 1.0,
+        "logits_soft_cap": 0.0,
+        "min_cosine": 0.999,
+        "max_rel_norm_err": 0.05
+      },
+      "benchmark": {
+        "warmup": 10,
+        "repetition": 30,
+        "target_ms": 2.0,
+        "max_graph_repeats": 100
+      }
+    },
+    {
+      "id": "qwen38-pa-decode-bs64-seq8704",
+      "phase": "decode",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 19,
+      "session_e2e_pct": {
+        "qkv_kernel": 3.146,
+        "reduce_kernel": 0.211
+      },
+      "calls_per_forward": 23,
+      "measured": "trace",
+      "note": "Mid-generation, ~512 of OSL 1024 emitted. This is where the profiler window sits (start_step 6080 of the run), so it is the context length the 3.146% / 0.211% E2E numbers were measured at.",
+      "trace_input_shapes": {
+        "query": [
+          64,
+          8,
+          256
+        ],
+        "k_cache": [
+          557056,
+          1,
+          1,
+          256
+        ],
+        "v_cache": [
+          557056,
+          1,
+          1,
+          256
+        ],
+        "kv_indptr": [
+          65
+        ],
+        "kv_indices": [
+          557056
+        ],
+        "kv_last_page_len": [
+          64
+        ],
+        "k_scale": [
+          1
+        ],
+        "v_scale": [
+          1
+        ],
+        "output": [
+          64,
+          8,
+          256
+        ]
+      },
+      "trace_input_dtypes": {
+        "query": "bfloat16",
+        "k_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "v_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "kv_indptr": "int32",
+        "kv_indices": "int32",
+        "kv_last_page_len": "int32",
+        "k_scale": "float32",
+        "v_scale": "float32",
+        "output": "bfloat16"
+      },
+      "params": {
+        "batch": 64,
+        "seq_len": 8704,
+        "q_heads": 8,
+        "kv_heads": 1,
+        "head_dim": 256,
+        "page_size": 1,
+        "partition_size": 256,
+        "k_scale": 1.0,
+        "v_scale": 1.0,
+        "logits_soft_cap": 0.0,
+        "min_cosine": 0.999,
+        "max_rel_norm_err": 0.05
+      },
+      "benchmark": {
+        "warmup": 10,
+        "repetition": 30,
+        "target_ms": 2.0,
+        "max_graph_repeats": 100
+      }
+    },
+    {
+      "id": "qwen38-pa-decode-bs64-seq9216",
+      "phase": "decode",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 23,
+      "session_e2e_pct": null,
+      "calls_per_forward": 23,
+      "measured": "trace_range",
+      "note": "End of generation: ISL 8192 + OSL 1024. Upper bound of the session's decode context range (max_model_len 13312 / context_length 11264 are never reached by this workload).",
+      "trace_input_shapes": {
+        "query": [
+          64,
+          8,
+          256
+        ],
+        "k_cache": [
+          589824,
+          1,
+          1,
+          256
+        ],
+        "v_cache": [
+          589824,
+          1,
+          1,
+          256
+        ],
+        "kv_indptr": [
+          65
+        ],
+        "kv_indices": [
+          589824
+        ],
+        "kv_last_page_len": [
+          64
+        ],
+        "k_scale": [
+          1
+        ],
+        "v_scale": [
+          1
+        ],
+        "output": [
+          64,
+          8,
+          256
+        ]
+      },
+      "trace_input_dtypes": {
+        "query": "bfloat16",
+        "k_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "v_cache": "float8_e4m3fn (kernel sees unsigned char)",
+        "kv_indptr": "int32",
+        "kv_indices": "int32",
+        "kv_last_page_len": "int32",
+        "k_scale": "float32",
+        "v_scale": "float32",
+        "output": "bfloat16"
+      },
+      "params": {
+        "batch": 64,
+        "seq_len": 9216,
+        "q_heads": 8,
+        "kv_heads": 1,
+        "head_dim": 256,
+        "page_size": 1,
+        "partition_size": 256,
+        "k_scale": 1.0,
+        "v_scale": 1.0,
+        "logits_soft_cap": 0.0,
+        "min_cosine": 0.999,
+        "max_rel_norm_err": 0.05
+      },
+      "benchmark": {
+        "warmup": 10,
+        "repetition": 30,
+        "target_ms": 2.0,
+        "max_graph_repeats": 100
+      }
+    }
+  ],
+  "prefill_note": "There is NO prefill case in this task, and that is deliberate. paged_attention_ragged is the decode entry point only; sglang routes chunked prefill through a separate ragged/MHA path in the same backend (server.log records prefill cuda_graph=disabled for this run). That prefill kernel was never sampled: session 100137 captured no prefill trace, so neither its identity nor its cost is known -- see the session analysis note 'chunked prefill attention (aiter backend): \u5177\u4f53 kernel \u540d\u672a\u91c7\u6837'. Adding a synthetic prefill case would score a kernel the session cannot confirm ran."
+}

--- a/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/config.yaml
+++ b/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/config.yaml
@@ -1,0 +1,79 @@
+task_type: image_kernel
+image_repo_path: /sgl-workspace/sglang/python/sglang
+repo_subdir: sglang
+image_repo_exclude:
+- __pycache__
+- test
+repository_language: triton
+source_file_path:
+- srt/models/qwen3_5.py
+- srt/layers/attention/linear/gdn_backend.py
+- srt/layers/attention/linear/kernels/gdn_triton.py
+- srt/layers/attention/mamba/causal_conv1d.py
+editable_sources:
+- kernels/ops/attention/fla/fused_recurrent.py
+- kernels/ops/attention/fla/layernorm_gated.py
+- kernels/ops/mamba/causal_conv1d_triton.py
+target_kernel_functions:
+- fused_recurrent_gated_delta_rule_packed_decode_kernel
+- _causal_conv1d_update_kernel
+- _layer_norm_fwd_1pass_kernel
+kernel_identity:
+  logical_operator: gdn_linear_attn_decode
+  kernel_kind: triton
+  source_owner: sglang
+  workload:
+    source: session_cases.json
+    primary_case: qwen38-gdn-decode-bs64
+compile_command:
+- python3 scripts/task_runner.py compile
+correctness_command:
+- python3 scripts/task_runner.py correctness
+performance_command:
+- python3 scripts/task_runner.py performance
+compile_timeout: 900
+correctness_timeout: 1800
+performance_timeout: 1800
+task_result_template: null
+platform_support:
+  required_arch: gfx950
+  status: active
+  skip_reason: null
+prompt:
+  source_code: null
+  instructions: >-
+    Faithful reproduction of the Qwen3.8-2.4T-A95B Gated-DeltaNet linear-attention
+    decode core as it actually executed in Hyperloom session 100137
+    (20260814T175123Z) on MI355X/gfx950 under sglang 0.5.17. 69 of the model's 92
+    layers take this path.
+    The timed unit is the whole core -- everything the model does between the two
+    input projections and the output projection -- not a single kernel. In the
+    session's trace that unit launches five kernels per layer:
+    fused_recurrent_gated_delta_rule_packed_decode_kernel (2.278% E2E),
+    aten::copy_ via elementwise_kernel_manual_unroll (1.663%), aten::cat via
+    CatArrayBatchedCopy (0.692%), _causal_conv1d_update_kernel (0.578%) and
+    _layer_norm_fwd_1pass_kernel (0.552%) -- 5.76% E2E together.
+    Scoring the chain rather than the recurrent kernel alone is the point: 2.35 of
+    those 5.76 points are pure data movement created by the split / reshape /
+    concat around the kernels. Qwen3.8 has num_v_heads // num_k_heads = 128 // 16
+    = 8, which is NOT in (1, 2, 4), so srt/models/qwen3_5.py:640 skips the fused
+    split/cat helper and falls into the plain-torch branch -- that is where the
+    208 aten::copy_ and 69 aten::cat launches per step come from. Fusing that
+    movement into the Triton kernels is a legal and intended optimisation; so is
+    fusing conv1d, the recurrent step and the gated RMSNorm into fewer launches.
+    Per-rank geometry (TP=8): 2 k heads x 128, 16 v heads x 128, conv_dim 2560
+    with width 4, ssm state [slots, 16, 128, 128] bf16, qk L2-norm in kernel,
+    swish output gate, norm_before_gate=True.
+    Two harness details that constrain a patch. First, the operator is STATEFUL:
+    causal_conv1d_update and the recurrent kernel both update their cache in place
+    (gdn_triton.py passes ht=initial_state), so a CUDA-graph replay advances the
+    caches once per chained invocation and the harness steps its torch reference
+    the same number of times. Second, correctness checks the conv_state and
+    ssm_state as well as the output -- an implementation that returns the right
+    activations but corrupts the cache would break the next token and is rejected.
+    Correctness compares against an independent fully-vectorized torch
+    implementation transcribed from the Triton sources; observed baseline
+    agreement is cos ~0.999994. Correctness and performance run the identical case
+    list at identical shapes. Do not edit the harness. Preserve all correctness
+    cases and improve the CUDA-graph measured performance.
+  cheatsheet: null

--- a/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/scripts/forge_driver.py
+++ b/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/scripts/forge_driver.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""forge-loop measurement driver for the Qwen3.8 Gated-DeltaNet linear-attention task.
+
+Target (optimized by forge-loop): the Triton decode chain --
+``fused_recurrent_gated_delta_rule_packed_decode_kernel``,
+``_causal_conv1d_update_kernel``, ``_layer_norm_fwd_1pass_kernel`` -- plus the
+torch split/reshape/concat around them, which is where 2.35 of the chain's 5.76
+E2E points actually go.
+
+Why this file exists
+--------------------
+``agents/forge/launch_agent.py:822`` prefers a task-shipped
+``scripts/forge_driver.py`` and copies it VERBATIM to the workspace root;
+without one it generates a shim around ``agents/forge/drivers/arena_task_adapter``.
+That shim parses ``--profile-run`` with ``parse_known_args``, i.e. it silently
+swallows the flag and runs correctness instead. KernelForge's
+``_check_profile_contract`` only asserts ``returncode == 0``, so the shim passes
+the gate without owning a profiling path. Campaigns longer than 2 hours switch
+Analysis to ``profiled`` (``kernel_agents/cli.py:2088``) and actually use that
+path. This driver implements the flag for real.
+
+Contract implemented (forge-loop reads only stdout; parsers are
+``mcp_server/tools/test.py:74-83`` and ``mcp_server/tools/bench.py:341-347``):
+
+  * Correctness  ``--mode <smoke|stability|determinism|full>``
+        prints ``SNR: <db> dB`` (worst case) against the harness's independent
+        vectorized torch implementation, plus ``max_diff:``. The pristine chain
+        measures rel_norm_err ~0.0034, i.e. ~49 dB, so it clears forge's 30 dB
+        gate with ~19 dB of margin.
+
+  * Benchmark    ``--warmup <n> --iters <n> --bench-mode``
+        prints ``case_ms: <case_id> <ms>`` for every declared case plus one
+        ``mean_ms:`` aggregate. Timing goes through the harness's
+        ``_benchmark_cuda_graph_or_events``, so
+        ``task_preparer._count_graph_replays`` observes real CUDA-graph replays.
+
+  * Profiling    ``--profile-run [--profile-case <case_id>]``
+        restores the caches, warms up, then launches ONLY the chain a few times
+        and synchronizes. Prints no timing.
+
+**This operator is stateful.** ``causal_conv1d_update`` and the recurrent kernel
+update their caches in place (``gdn_triton.py`` passes ``ht=initial_state``), so
+every mode restores the pristine cache snapshot before measuring; otherwise a
+second measurement starts from a state the first one advanced and the numbers
+drift for reasons that have nothing to do with the kernel.
+
+All measurement logic is REUSED from ``scripts/task_runner.py``. forge-loop
+never edits this file.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+def _import_task_runner():
+    """Import the task's own harness, whether we run from scripts/ or the root."""
+    here = Path(__file__).resolve().parent
+    for cand in (here / "scripts", here, here.parent / "scripts"):
+        runner = cand / "task_runner.py"
+        if runner.is_file():
+            spec = importlib.util.spec_from_file_location("_forge_task_runner", runner)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["_forge_task_runner"] = module
+            spec.loader.exec_module(module)
+            return module
+    raise SystemExit("error: task_runner.py not found next to forge_driver.py")
+
+
+def _cases(tr) -> list[dict]:
+    cases = list(tr.CASES)
+    if not cases:
+        raise SystemExit("error: session_cases.json declares no cases")
+    return cases
+
+
+def _snr_db(rel_norm_err: float) -> float:
+    """SNR in dB from a relative norm error: 20*log10(||ref|| / ||err||)."""
+    if rel_norm_err <= 0:
+        return 200.0
+    return -20.0 * math.log10(rel_norm_err)
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def _run_correctness(tr) -> int:
+    import torch
+
+    worst_err, worst_cos, all_ok = 0.0, 1.0, True
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        tr._reset_state(inputs)
+        got = tr._run(inputs)
+        torch.cuda.synchronize()
+        expected = tr._reference(inputs, steps=1)
+        finite = bool(torch.isfinite(got).all())
+        cos, err = tr._deviation(got, expected)
+
+        # The caches are the point of this operator: an implementation that
+        # returns the right activations but corrupts conv_state / ssm_state
+        # breaks the next token, so check them too.
+        ref_conv = inputs["conv_state0"].clone()
+        ref_ssm = inputs["ssm_state0"].clone()
+        tr._reference_step(inputs, ref_conv, ref_ssm)
+        c_cos, c_err = tr._deviation(inputs["conv_state"], ref_conv)
+        s_cos, s_err = tr._deviation(inputs["ssm_state"], ref_ssm)
+        state_ok = c_cos > 0.999 and c_err < 0.02 and s_cos > 0.999 and s_err < 0.02
+
+        tol = case["params"]
+        ok = (
+            finite
+            and state_ok
+            and cos > tol.get("min_cosine", 0.999)
+            and err < tol.get("max_rel_norm_err", 0.03)
+        )
+        all_ok = all_ok and ok
+        worst_err, worst_cos = max(worst_err, err), min(worst_cos, cos)
+        print(f"# case {case['id']}: cos={cos:.6f} rel_norm_err={err:.5f} "
+              f"conv_state_cos={c_cos:.6f} ssm_state_cos={s_cos:.6f} "
+              f"finite={finite} ok={ok}")
+        del inputs, expected, got, ref_conv, ref_ssm
+        tr._free()
+
+    print(f"max_diff: {worst_err:.6e}")
+    print(f"SNR: {_snr_db(worst_err):.2f} dB")
+    print(f"allclose: {all_ok}")
+    print(f"# worst cosine {worst_cos:.6f} across {len(_cases(tr))} case(s)")
+    return 0 if all_ok else 1
+
+
+def _run_bench(tr, warmup: int, iters: int) -> int:
+    import torch
+
+    means: list[float] = []
+    for case in _cases(tr):
+        inputs = tr._prepare(case)
+        tr._reset_state(inputs)
+        tr._run(inputs)
+        torch.cuda.synchronize()
+        bench = case.get("benchmark", {})
+        tr._reset_state(inputs)
+        exec_ms, meta = tr._benchmark_cuda_graph_or_events(
+            lambda: tr._run(inputs),
+            warmup=warmup,
+            # One graph replay per timed iteration: this is what makes
+            # _count_graph_replays see >= iters replays.
+            repetition=max(1, iters),
+            target_ms=bench.get("target_ms", 1.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+        )
+        if not isinstance(exec_ms, (int, float)) or exec_ms <= 0:
+            print(f"error: invalid timing for case {case['id']!r}: {exec_ms!r}",
+                  file=sys.stderr)
+            return 1
+        if meta.get("benchmark_method") != "cuda_graph":
+            print(f"error: case {case['id']} timed with "
+                  f"{meta.get('benchmark_method')} instead of cuda_graph "
+                  f"({meta.get('benchmark_fallback_reason')})", file=sys.stderr)
+            return 1
+        means.append(float(exec_ms))
+        print(f"case_ms: {case['id']} {exec_ms:.6f}")
+        print(f"# bench {case['id']}: {exec_ms:.6f} ms "
+              f"method={meta.get('benchmark_method')} "
+              f"chained={meta.get('benchmark_effective_repeats')}")
+        del inputs
+        tr._free()
+
+    print(f"mean_ms: {sum(means) / len(means):.6f}")
+    return 0
+
+
+def _run_profile(tr, case_id: str | None) -> int:
+    """Launch ONLY the target chain, so a profiler session captures it and nothing else."""
+    import torch
+
+    cases = _cases(tr)
+    if case_id:
+        match = [c for c in cases if c["id"] == case_id]
+        if not match:
+            print(f"error: unknown --profile-case {case_id!r}; declared: "
+                  f"{', '.join(c['id'] for c in cases)}", file=sys.stderr)
+            return 1
+        case = match[0]
+    else:
+        case = cases[0]
+
+    inputs = tr._prepare(case)
+    tr._reset_state(inputs)
+    # Warmups settle the Triton JIT so the profiled launches contain kernel time.
+    for _ in range(5):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    tr._reset_state(inputs)
+    for _ in range(3):
+        tr._run(inputs)
+    torch.cuda.synchronize()
+    print(f"# profiled {case['id']} (bs={case['params']['batch']})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--mode", default="full")        # all modes -> task correctness
+    parser.add_argument("--bench-mode", action="store_true")
+    parser.add_argument("--profile-run", action="store_true")
+    parser.add_argument("--profile-case", default=None)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    args, _unknown = parser.parse_known_args()
+
+    tr = _import_task_runner()
+    tr._configure()
+    import torch
+
+    if not torch.cuda.is_available():
+        print("error: a ROCm GPU (gfx950) is required (torch.cuda.is_available() is False)",
+              file=sys.stderr)
+        return 1
+
+    if args.profile_run:
+        return _run_profile(tr, args.profile_case)
+    if args.bench_mode:
+        return _run_bench(tr, args.warmup, args.iters)
+    return _run_correctness(tr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/scripts/task_runner.py
+++ b/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/scripts/task_runner.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""Image-kernel harness for the Qwen3.8-2.4T-A95B Gated-DeltaNet linear-attention core.
+
+Reproduces the linear-attention decode chain of Hyperloom session 100137
+(Qwen3.8-2.4T-A95B-Quark-MXFP4, 20260814T175123Z) on MI355X/gfx950, sglang
+0.5.17.dev20260812+gdc5f6c4883 / ROCm 7.2.0.
+
+69 of the model's 92 layers are ``linear_attention`` (Gated DeltaNet); the other
+23 are full attention. The timed unit here is everything the model does between
+the two input projections and the output projection -- i.e. the whole
+``Qwen3_5GatedDeltaNet`` core, which in the session's decode trace is five
+kernels:
+
+  fused_recurrent_gated_delta_rule_packed_decode_kernel   69x/step  2.278% E2E
+  at::native::elementwise_kernel_manual_unroll (aten::copy_) 208x/step 1.663% E2E
+  at::native::CatArrayBatchedCopy (aten::cat)              69x/step  0.692% E2E
+  _causal_conv1d_update_kernel                             69x/step  0.578% E2E
+  _layer_norm_fwd_1pass_kernel (RMSNormGated)              69x/step  0.552% E2E
+                                                          -------------------
+                                                           chain     5.76% E2E
+
+The chain is timed as one unit on purpose. 2.35 of those 5.76 points are pure
+data movement (``aten::cat`` + ``aten::copy_``) produced by the split/reshape/
+concat around the kernels, so scoring the recurrent kernel alone would hide the
+single largest lever this operator has. The whole chain is inside the edit
+surface, so fusing the movement away is a legal -- and intended -- optimisation.
+
+Call chain reproduced verbatim (sglang sources, this image):
+    srt/models/qwen3_5.py:524   fix_query_key_value_ordering  (split -> reshape)
+    srt/models/qwen3_5.py:659   torch.cat((query, key, value), -1)
+      NB: the fused split/cat helper at qwen3_5.py:640 is NOT taken here --
+      it requires num_v_heads // num_k_heads in [1, 2, 4] and Qwen3.8 has
+      128 // 16 = 8, so the model falls into the plain-torch else-branch. That
+      is exactly where the 208 aten::copy_ launches per step come from.
+    srt/layers/attention/linear/gdn_backend.py:406  causal_conv1d_update
+    srt/layers/attention/linear/kernels/gdn_triton.py:121  packed_decode
+    srt/models/qwen3_5.py:684   RMSNormGated(core_attn_out, z)
+
+Per-rank geometry (TP=8), from config.json:
+    key_dim   = linear_num_key_heads(16)   * linear_key_head_dim(128)   = 2048 -> 256/rank  (2 k heads)
+    value_dim = linear_num_value_heads(128)* linear_value_head_dim(128) =16384 -> 2048/rank (16 v heads)
+    conv_dim  = 2*key_dim + value_dim = 20480 -> 2560/rank, conv width 4
+    in_proj_qkvz out = 2*key_dim + 2*value_dim = 36864 -> 4608/rank
+    in_proj_ba   out = 2*num_v_heads = 256 -> 32/rank
+    ssm state = [slots, 16, 128, 128] bf16 (--mamba-ssm-dtype bfloat16)
+
+One harness detail that matters: this operator is STATEFUL. Both
+``causal_conv1d_update`` and the recurrent kernel update their cache in place
+(gdn_triton.py passes ``ht=initial_state``). A CUDA-graph replay therefore
+advances the state ``n_repeat`` times, so the reference is stepped the same
+number of times from the same snapshot rather than being compared against a
+single step. See ``_assert_timed_outputs``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+SPEC = json.loads((WORKSPACE / "session_cases.json").read_text())
+OPERATOR = SPEC["operator"]
+CASES = SPEC["cases"]
+GDN = SPEC["gdn_config"]
+
+_IMAGE_SGLANG_PY = Path(
+    os.environ.get("QWEN38_SGLANG_PY", "/sgl-workspace/sglang/python")
+)
+
+
+def _configure() -> None:
+    for key in ("GPU_ARCHS", "PYTORCH_ROCM_ARCH", "AMDGPU_TARGETS", "GPU_TARGETS"):
+        os.environ.setdefault(key, "gfx950")
+    os.environ.setdefault("TRITON_CACHE_DIR", str(WORKSPACE / "build" / "triton"))
+    # The agent edits the workspace-seeded copy of sglang, so it must shadow the
+    # in-image install; otherwise `import sglang` resolves to the image copy and
+    # the edits are silently ignored.
+    if (WORKSPACE / "sglang").is_dir():
+        sys.path.insert(0, str(WORKSPACE))
+    os.chdir(WORKSPACE)
+
+
+# >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
+def _measure_cuda_event_fallback(fn, repetition):
+    import time
+    import torch
+
+    repetition = max(1, int(repetition))
+    if not torch.cuda.is_available():
+        times_ms = []
+        for _ in range(repetition):
+            start = time.perf_counter()
+            fn()
+            end = time.perf_counter()
+            times_ms.append((end - start) * 1000.0)
+        return times_ms
+
+    times_ms = []
+    for _ in range(repetition):
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        fn()
+        end_event.record()
+        torch.cuda.synchronize()
+        times_ms.append(start_event.elapsed_time(end_event))
+    return times_ms
+
+
+class _TimedRun:
+    """Handle on the exact invocation a benchmark measured.
+
+    Timing and correctness are otherwise separate invocations, so a kernel can
+    tell them apart and do less work in the one that is scored. Passing this
+    collector to the benchmark makes the scored invocation itself observable:
+    ``outputs`` aliases the buffers the timed unit last wrote, and ``rerun``
+    executes that same unit again.
+
+    Under CUDA-graph timing the buffers are captured once and every replay
+    writes to those same addresses, so ``outputs`` keeps tracking replays. Under
+    event-timing fallback the measured outputs cannot be observed reliably, so a
+    benchmark that requests this collector fails closed instead of validating a
+    separate post-timing invocation.
+    """
+
+    def __init__(self):
+        self._rerun = None
+        self.outputs = None
+
+    def _bind(self, rerun, outputs=None):
+        self._rerun = rerun
+        self.outputs = outputs
+
+    @property
+    def bound(self):
+        return self._rerun is not None
+
+    def rerun(self):
+        if self._rerun is None:
+            raise RuntimeError(
+                "timed run was never bound; the benchmark did not reach a "
+                "measurement path"
+            )
+        self.outputs = self._rerun()
+        return self.outputs
+
+
+def _benchmark_cuda_graph_or_events(
+    fn,
+    warmup=10,
+    repetition=100,
+    target_ms=1.0,
+    n_retries=5,
+    estimate_reps=5,
+    max_graph_repeats=1000,
+    use_cuda_graph=True,
+    fallback_reason=None,
+    timed_run=None,
+):
+    import torch
+
+    def _reject_unobservable_fallback(reason):
+        if timed_run is not None:
+            raise RuntimeError(
+                f"{reason}; timed_run requires an observable CUDA-graph replay "
+                "and cannot validate a separate post-timing invocation"
+            )
+
+    # A captured graph whose measured per-iteration time falls below this floor is
+    # treated as empty (it recorded no device work) and rejected in favour of
+    # per-launch event timing, so a graph that silently captured nothing is never
+    # reported as a fabricated ~0 ms cuda_graph result. Real kernels measure far
+    # above this floor; an empty-graph replay measures ~1e-5 ms.
+    empty_graph_floor_ms = 1e-4
+
+    for _ in range(max(0, int(warmup))):
+        fn()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    max_graph_repeats = max(1, int(max_graph_repeats))
+    metadata = {
+        "benchmark_target_ms": float(target_ms),
+        "benchmark_samples": int(repetition),
+        "benchmark_max_repeats": int(max_graph_repeats),
+    }
+
+    if not torch.cuda.is_available():
+        _reject_unobservable_fallback("CUDA is unavailable")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cpu_timer_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_unavailable",
+        })
+        return sum(times) / len(times), metadata
+
+    if not use_cuda_graph:
+        _reject_unobservable_fallback("CUDA-graph timing is disabled")
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": fallback_reason or "cuda_graph_disabled",
+        })
+        return sum(times) / len(times), metadata
+
+    try:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            estimate_reps = max(1, int(estimate_reps))
+            estimate_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(estimate_graph):
+                for _ in range(estimate_reps):
+                    fn()
+            torch.cuda.synchronize()
+
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record(stream)
+            estimate_graph.replay()
+            end_event.record(stream)
+            torch.cuda.synchronize()
+
+            estimate_ms = start_event.elapsed_time(end_event) / estimate_reps
+            if estimate_ms == 0:
+                n_repeat = max_graph_repeats
+            else:
+                n_repeat = min(max_graph_repeats, max(1, int(float(target_ms) / estimate_ms)))
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured_outputs = None
+                for _ in range(n_repeat):
+                    captured_outputs = fn()
+            torch.cuda.synchronize()
+
+            retry_times = []
+            for _ in range(max(1, int(repetition))):
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+                start_event.record(stream)
+                graph.replay()
+                end_event.record(stream)
+                torch.cuda.synchronize()
+                retry_times.append(start_event.elapsed_time(end_event) / n_repeat)
+
+        graph_mean = sum(retry_times) / len(retry_times)
+        if graph_mean < empty_graph_floor_ms:
+            _reject_unobservable_fallback("CUDA graph captured no device work")
+            times = _measure_cuda_event_fallback(fn, repetition)
+            metadata.update({
+                "benchmark_method": "cuda_event_fallback",
+                "benchmark_effective_repeats": int(repetition),
+                "benchmark_fallback_reason": fallback_reason or "empty_cuda_graph_capture",
+            })
+            return sum(times) / len(times), metadata
+
+        metadata.update({
+            "benchmark_method": "cuda_graph",
+            "benchmark_effective_repeats": int(n_repeat),
+        })
+        if timed_run is not None:
+
+            def _replay_once():
+                # Callers stage work on their own stream before re-running (they
+                # perturb inputs and poison outputs). The capture stream must be
+                # ordered after that, or the replay races the staged writes and
+                # they land on top of the kernel's results.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.synchronize()
+                return captured_outputs
+
+            timed_run._bind(_replay_once, captured_outputs)
+        return graph_mean, metadata
+    except Exception as exc:
+        # Isolate the aborted capture before re-measuring so the fallback timing is
+        # not polluted by the failed attempt (a mid-capture failure can leave the
+        # first few launches abnormally slow).
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            pass
+        if timed_run is not None:
+            raise RuntimeError(
+                "CUDA-graph capture failed; timed_run cannot validate the "
+                "separate CUDA-event fallback invocation"
+            ) from exc
+        for _ in range(min(3, max(1, int(warmup)))):
+            fn()
+        torch.cuda.synchronize()
+        times = _measure_cuda_event_fallback(fn, repetition)
+        metadata.update({
+            "benchmark_method": "cuda_event_fallback",
+            "benchmark_effective_repeats": int(repetition),
+            "benchmark_fallback_reason": f"cuda_graph_failed: {type(exc).__name__}: {str(exc)[:160]}",
+        })
+        return sum(times) / len(times), metadata
+# <<< AKA-GENERATED <<<
+
+
+# --------------------------------------------------------------------------- #
+# Small utilities
+# --------------------------------------------------------------------------- #
+def _torch():
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("ROCm GPU (gfx950) is required")
+    # Serving runs the whole forward under inference mode. RMSNormGated is a
+    # custom autograd Function whose output this harness writes into (the
+    # timed-run poison step), which grad mode forbids on a returned view; and
+    # graph capture of an autograd-tracked region is not what production does
+    # either. Disable globally rather than sprinkling no_grad().
+    torch.set_grad_enabled(False)
+    return torch
+
+
+def _free() -> None:
+    _torch().cuda.empty_cache()
+
+
+def _write_report(rows: list) -> None:
+    report_dir = WORKSPACE / "build"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "performance_report.json").write_text(json.dumps(rows, indent=2))
+
+
+def _assert_split_branch(num_v_heads: int, num_k_heads: int) -> None:
+    """Fail closed if the model would have taken the fused split/cat helper.
+
+    ``qwen3_5.py:640`` routes to ``fused_qkvzba_split_reshape_cat_contiguous``
+    when ``num_v_heads // num_k_heads in (1, 2, 4)``. Qwen3.8 is 128 // 16 = 8,
+    so it takes the plain-torch branch and pays the cat + copy_ launches this
+    task is meant to expose. If that ratio ever changes the timed unit is no
+    longer the session's unit.
+    """
+    if num_v_heads // num_k_heads in (1, 2, 4):
+        raise AssertionError(
+            f"num_v_heads // num_k_heads = {num_v_heads // num_k_heads} is in "
+            f"(1, 2, 4), so qwen3_5.py:640 would use the fused split/cat helper "
+            f"instead of the plain-torch branch this harness reproduces."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+#
+# Shapes come from the session's CUDA-graph capture trace (record_shapes=True)
+# at bs=64, cross-checked against config.json:
+#     aten::cat            [[64, 256], [64, 256], [64, 2048]] -> [64, 2560]
+#     LayerNormFn          [[1024, 128], [128], ...]   (1024 = 64 tok x 16 v heads)
+#     aten::copy_          [64, 16] x2/layer  and  [64, 16, 128] x1/layer
+#     aten::mm  in_proj_qkvz  [64, 8192] x [8192, 4608]   (feeds this unit)
+#     aten::mm  in_proj_ba    [64, 8192] x [8192,   32]   (feeds this unit)
+# --------------------------------------------------------------------------- #
+def _prepare(case: dict) -> dict:
+    torch = _torch()
+    from sglang.kernels.ops.attention.fla.layernorm_gated import RMSNorm as RMSNormGated
+
+    p = dict(case["params"])
+    batch = int(p["batch"])
+    num_k_heads, num_v_heads = int(p["num_k_heads"]), int(p["num_v_heads"])
+    head_k_dim, head_v_dim = int(p["head_k_dim"]), int(p["head_v_dim"])
+    conv_width, slots = int(p["conv_width"]), int(p["state_slots"])
+    _assert_split_branch(num_v_heads, num_k_heads)
+
+    k_tp = num_k_heads * head_k_dim          # 256
+    v_tp = num_v_heads * head_v_dim          # 2048
+    conv_dim = 2 * k_tp + v_tp               # 2560
+    qkvz_dim = 2 * k_tp + 2 * v_tp           # 4608
+    ba_dim = 2 * num_v_heads                 # 32
+
+    torch.manual_seed(int(case.get("seed", 5)))
+    dev, dt = "cuda", torch.bfloat16
+    # The two input-projection outputs; the projections themselves belong to the
+    # skinny-GEMM task, not this one.
+    qkvz = torch.randn((batch, qkvz_dim), device=dev, dtype=dt) * 0.5
+    ba = torch.randn((batch, ba_dim), device=dev, dtype=dt) * 0.5
+
+    conv_weight = torch.randn((conv_dim, conv_width), device=dev, dtype=dt) * 0.2
+    conv_bias = torch.randn((conv_dim,), device=dev, dtype=dt) * 0.1
+    # causal_conv1d_update wants state_len >= width - 1.
+    conv_state = torch.randn((slots, conv_dim, conv_width - 1), device=dev, dtype=dt) * 0.2
+    # mamba_ssm_dtype=bfloat16 in the session's launch recipe.
+    ssm_state = torch.randn(
+        (slots, num_v_heads, head_v_dim, head_k_dim), device=dev, dtype=dt
+    ) * 0.1
+    A_log = torch.randn((num_v_heads,), device=dev, dtype=torch.float32) * 0.5
+    dt_bias = torch.ones((num_v_heads,), device=dev, dtype=torch.float32)
+    # One distinct cache slot per running request, as in serving.
+    indices = torch.arange(batch, device=dev, dtype=torch.int32)
+
+    norm = RMSNormGated(
+        head_v_dim,
+        eps=float(p["rms_norm_eps"]),
+        group_size=None,
+        norm_before_gate=True,
+        device=dev,
+        dtype=dt,
+        activation=str(p["output_gate_type"]),
+    )
+    with torch.no_grad():
+        norm.weight.normal_(1.0, 0.05)
+
+    return {
+        "cfg": case, "params": p, "batch": batch,
+        "num_k_heads": num_k_heads, "num_v_heads": num_v_heads,
+        "head_k_dim": head_k_dim, "head_v_dim": head_v_dim,
+        "k_tp": k_tp, "v_tp": v_tp, "conv_dim": conv_dim, "conv_width": conv_width,
+        "qkvz": qkvz, "ba": ba,
+        "conv_weight": conv_weight, "conv_bias": conv_bias,
+        "conv_state": conv_state, "ssm_state": ssm_state,
+        "A_log": A_log, "dt_bias": dt_bias, "indices": indices,
+        "norm": norm,
+        "scale": float(head_k_dim) ** -0.5,
+        "activation": str(p["conv_activation"]),
+        # Pristine copies so a stateful op can be re-run from a known point.
+        "conv_state0": conv_state.clone(), "ssm_state0": ssm_state.clone(),
+    }
+
+
+def _split_qkvzba(inputs: dict):
+    """srt/models/qwen3_5.py:524 fix_query_key_value_ordering, verbatim."""
+    k_tp, v_tp = inputs["k_tp"], inputs["v_tp"]
+    head_v_dim, nv = inputs["head_v_dim"], inputs["num_v_heads"]
+    query, key, value, z = inputs["qkvz"].split([k_tp, k_tp, v_tp, v_tp], dim=-1)
+    b, a = inputs["ba"].split([nv, nv], dim=-1)
+    value = value.reshape(value.size(0), -1, head_v_dim)
+    z = z.reshape(z.size(0), -1, head_v_dim)
+    return query, key, value, z, b.contiguous(), a.contiguous()
+
+
+def _run(inputs: dict):
+    """One linear-attention core, exactly as the model's decode path runs it."""
+    torch = _torch()
+    from sglang.kernels.ops.attention.fla.fused_recurrent import (
+        fused_recurrent_gated_delta_rule_packed_decode,
+    )
+    from sglang.srt.layers.attention.mamba.causal_conv1d import causal_conv1d_update
+
+    query, key, value, z, b, a = _split_qkvzba(inputs)
+    query, key, value = (x.reshape(x.shape[0], -1) for x in (query, key, value))
+    mixed_qkv = torch.cat((query, key, value), dim=-1)
+
+    mixed_qkv = causal_conv1d_update(
+        mixed_qkv,
+        inputs["conv_state"],
+        inputs["conv_weight"],
+        inputs["conv_bias"],
+        inputs["activation"],
+        conv_state_indices=inputs["indices"],
+    )
+
+    batch, nv, hv = inputs["batch"], inputs["num_v_heads"], inputs["head_v_dim"]
+    out = mixed_qkv.new_empty(batch, 1, nv, hv)
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        scale=inputs["scale"],
+        initial_state=inputs["ssm_state"],
+        out=out,
+        ssm_state_indices=inputs["indices"],
+        use_qk_l2norm_in_kernel=True,
+    )
+    core_attn_out = out.transpose(0, 1).reshape(-1, hv)
+    core_attn_out = inputs["norm"](core_attn_out, z.reshape(-1, hv))
+    return core_attn_out.reshape(batch, nv * hv)
+
+
+def _reset_state(inputs: dict) -> None:
+    inputs["conv_state"].copy_(inputs["conv_state0"])
+    inputs["ssm_state"].copy_(inputs["ssm_state0"])
+
+
+# --------------------------------------------------------------------------- #
+# Reference
+#
+# Independent torch implementation of the same chain, transcribed from the
+# Triton sources rather than calling them:
+#   conv:      sglang/kernels/ops/mamba/causal_conv1d_triton.py:581
+#   recurrent: sglang/kernels/ops/attention/fla/fused_recurrent.py:184
+#   norm:      sglang/kernels/ops/attention/fla/layernorm_gated.py:75
+#
+# Fully vectorized -- no Python loop over batch or heads. The recurrent step is
+# a batched outer-product update on [B, HV, V, K], which for the session's
+# bs=64 / 16 heads / 128x128 state is 16.7 M elements, so a step costs a handful
+# of elementwise passes plus two [B*HV, V, K] contractions.
+# --------------------------------------------------------------------------- #
+def _reference_step(inputs: dict, conv_state, ssm_state):
+    """One decode step. Mutates conv_state / ssm_state in place, like the kernels."""
+    torch = _torch()
+    F = torch.nn.functional
+    with torch.no_grad():
+        batch = inputs["batch"]
+        nk, nv = inputs["num_k_heads"], inputs["num_v_heads"]
+        hk, hv = inputs["head_k_dim"], inputs["head_v_dim"]
+        k_tp, v_tp = inputs["k_tp"], inputs["v_tp"]
+
+        query, key, value, z, b, a = _split_qkvzba(inputs)
+        query, key, value = (x.reshape(x.shape[0], -1) for x in (query, key, value))
+        x = torch.cat((query, key, value), dim=-1).float()          # [B, conv_dim]
+
+        # --- depthwise causal conv, width 4, with the rolling state ------------
+        # causal_conv1d_update: window = [state, x], out = sum(window * w) + bias,
+        # then the state shifts left by one and x becomes its last column.
+        idx = inputs["indices"].long()
+        state = conv_state[idx].float()                             # [B, D, W-1]
+        window = torch.cat([state, x.unsqueeze(-1)], dim=-1)        # [B, D, W]
+        w = inputs["conv_weight"].float().unsqueeze(0)              # [1, D, W]
+        conv_out = (window * w).sum(-1) + inputs["conv_bias"].float()
+        if inputs["activation"] in ("silu", "swish"):
+            conv_out = F.silu(conv_out)
+        conv_state[idx] = window[..., 1:].to(conv_state.dtype)
+        mixed = conv_out.to(torch.bfloat16).float()                 # kernel writes bf16
+
+        # --- gated delta rule recurrent step -----------------------------------
+        q = mixed[:, : nk * hk].reshape(batch, nk, hk)
+        k = mixed[:, k_tp : k_tp + nk * hk].reshape(batch, nk, hk)
+        v = mixed[:, 2 * k_tp : 2 * k_tp + v_tp].reshape(batch, nv, hv)
+        # GQA-style head sharing: v head i reads k/q head i // (HV // H).
+        rep = nv // nk
+        q = q.repeat_interleave(rep, dim=1)                         # [B, HV, K]
+        k = k.repeat_interleave(rep, dim=1)
+        q = q / torch.sqrt((q * q).sum(-1, keepdim=True) + 1e-6)
+        k = k / torch.sqrt((k * k).sum(-1, keepdim=True) + 1e-6)
+        q = q * inputs["scale"]
+
+        xa = a.float() + inputs["dt_bias"].float()                  # [B, HV]
+        softplus = torch.where(xa <= 20.0, torch.log1p(torch.exp(xa)), xa)
+        g = -torch.exp(inputs["A_log"].float()) * softplus          # [B, HV]
+        beta = torch.sigmoid(b.float().to(torch.bfloat16).float())  # kernel casts to b.dtype
+
+        h = ssm_state[idx].float()                                  # [B, HV, V, K]
+        h = h * torch.exp(g)[:, :, None, None]
+        # v <- (v - h @ k) * beta ; h <- h + v k^T ; o <- h @ q
+        v = (v - torch.einsum("bhvk,bhk->bhv", h, k)) * beta.unsqueeze(-1)
+        h = h + v.unsqueeze(-1) * k[:, :, None, :]
+        o = torch.einsum("bhvk,bhk->bhv", h, q)                     # [B, HV, V]
+        ssm_state[idx] = h.to(ssm_state.dtype)
+
+        # --- gated RMSNorm (norm_before_gate=True, swish gate) -----------------
+        core = o.reshape(-1, hv).to(torch.bfloat16).float()
+        weight = inputs["norm"].weight.float()
+        eps = float(inputs["params"]["rms_norm_eps"])
+        core = core * torch.rsqrt((core * core).mean(-1, keepdim=True) + eps) * weight
+        gate = z.reshape(-1, hv).float()
+        core = core * (gate * torch.sigmoid(gate))
+        return core.reshape(batch, nv * hv).to(torch.bfloat16)
+
+
+def _reference(inputs: dict, steps: int = 1):
+    """Run the reference chain ``steps`` times from the pristine cache snapshot."""
+    torch = _torch()
+    conv_state = inputs["conv_state0"].clone()
+    ssm_state = inputs["ssm_state0"].clone()
+    out = None
+    for _ in range(max(1, int(steps))):
+        out = _reference_step(inputs, conv_state, ssm_state)
+    del conv_state, ssm_state
+    return out
+
+
+def _deviation(got, expected):
+    torch = _torch()
+    g, e = got.float().flatten(), expected.float().flatten()
+    cos = torch.nn.functional.cosine_similarity(g, e, dim=0).item()
+    err = ((g - e).norm() / e.norm().clamp_min(1e-8)).item()
+    return cos, err
+
+
+def _assert_within_tolerance(case: dict, cos: float, err: float, label: str) -> None:
+    tol = case["params"]
+    assert cos > tol.get("min_cosine", 0.995), (
+        case["id"], f"{label} cosine {cos:.6f} vs torch reference too low"
+    )
+    assert err < tol.get("max_rel_norm_err", 0.05), (
+        case["id"], f"{label} relative norm error {err:.5f} too high"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def run_compile() -> None:
+    inputs = _prepare(CASES[0])
+    out = _run(inputs)
+    _torch().cuda.synchronize()
+    print(f"{OPERATOR} compile smoke: PASS  out={tuple(out.shape)} {out.dtype}")
+
+
+def run_correctness() -> None:
+    torch = _torch()
+    for case in CASES:
+        # Same shapes the performance mode scores; nothing is shrunk for
+        # correctness, so every measured configuration is a checked one.
+        inputs = _prepare(case)
+        _reset_state(inputs)
+        got = _run(inputs)
+        torch.cuda.synchronize()
+        expected = _reference(inputs, steps=1)
+        assert torch.isfinite(got).all(), (case["id"], "non-finite output")
+        assert tuple(got.shape) == tuple(expected.shape), (
+            case["id"], tuple(got.shape), tuple(expected.shape)
+        )
+        cos, err = _deviation(got, expected)
+        _assert_within_tolerance(case, cos, err, "single step")
+
+        # The caches are the point of this operator, so check them too -- an
+        # implementation that produces the right output but corrupts the state
+        # would break generation on the next token.
+        ref_conv = inputs["conv_state0"].clone()
+        ref_ssm = inputs["ssm_state0"].clone()
+        _reference_step(inputs, ref_conv, ref_ssm)
+        c_cos, c_err = _deviation(inputs["conv_state"], ref_conv)
+        s_cos, s_err = _deviation(inputs["ssm_state"], ref_ssm)
+        assert c_cos > 0.999 and c_err < 0.02, (case["id"], "conv_state drift", c_cos, c_err)
+        assert s_cos > 0.999 and s_err < 0.02, (case["id"], "ssm_state drift", s_cos, s_err)
+
+        print(f"correctness PASS {case['id']:36s} bs={inputs['batch']:<5d} "
+              f"cos={cos:.6f} rel_err={err:.5f}  conv_state cos={c_cos:.6f} "
+              f"ssm_state cos={s_cos:.6f}")
+        del inputs, expected, got, ref_conv, ref_ssm
+        _free()
+
+
+def _perturb(inputs: dict) -> None:
+    """Fresh projections + a pristine cache, so a replay starts from a known point."""
+    torch = _torch()
+    torch.manual_seed(97)
+    inputs["qkvz"].normal_(0.0, 0.5)
+    inputs["ba"].normal_(0.0, 0.5)
+    _reset_state(inputs)
+
+
+def _assert_timed_outputs(case: dict, inputs: dict, timed, steps: int) -> None:
+    """Validate the invocation the benchmark actually timed.
+
+    The op is stateful and the captured graph holds ``steps`` chained
+    invocations, so one replay advances the caches ``steps`` times. The
+    reference is stepped the same number of times from the same snapshot; that
+    is what makes a graph-timed stateful kernel checkable at all.
+    """
+    torch = _torch()
+    if not timed.bound:
+        raise RuntimeError("benchmark did not expose the timed invocation")
+    _perturb(inputs)
+    if timed.outputs is not None:
+        timed.outputs.fill_(float("nan"))
+    got = timed.rerun()
+    expected = _reference(inputs, steps=steps)
+    assert torch.isfinite(got).all(), (case["id"], "timed run produced non-finite output")
+    cos, err = _deviation(got, expected)
+    _assert_within_tolerance(case, cos, err, f"timed run ({steps} chained steps)")
+    del expected
+
+
+def run_performance() -> None:
+    rows = []
+    for case in CASES:
+        inputs = _prepare(case)
+        _reset_state(inputs)
+        _run(inputs)
+        _torch().cuda.synchronize()
+        bench = case.get("benchmark", {})
+        timed = _TimedRun()
+        _reset_state(inputs)
+        exec_ms, meta = _benchmark_cuda_graph_or_events(
+            lambda: _run(inputs),
+            warmup=bench.get("warmup", 10),
+            repetition=bench.get("repetition", 30),
+            target_ms=bench.get("target_ms", 1.0),
+            max_graph_repeats=bench.get("max_graph_repeats", 50),
+            timed_run=timed,
+        )
+        steps = int(meta.get("benchmark_effective_repeats", 1))
+        _assert_timed_outputs(case, inputs, timed, steps)
+        metadata = {
+            **case["params"],
+            "model": case.get("model"),
+            "phase": case.get("phase"),
+            "calls_per_forward": case.get("calls_per_forward"),
+            "session_e2e_pct": case.get("session_e2e_pct"),
+            "chained_steps_per_replay": steps,
+        }
+        metadata.update({k: v for k, v in meta.items() if k.startswith("benchmark_")})
+        rows.append({
+            "test_case_id": case["id"],
+            "shape": case.get("trace_input_shapes"),
+            "execution_time_ms": exec_ms,
+            **{k: v for k, v in meta.items() if k.startswith("benchmark_")},
+            "metadata": metadata,
+        })
+        print(case["id"], f"{exec_ms:.6f} ms", meta.get("benchmark_method"),
+              f"chained_steps={steps}", meta.get("benchmark_fallback_reason", ""))
+        del inputs
+        _free()
+    _write_report(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["compile", "correctness", "performance", "manifest"])
+    mode = parser.parse_args().mode
+    if mode == "manifest":
+        print(json.dumps(SPEC, indent=2))
+        return
+    _configure()
+    if mode == "compile":
+        run_compile()
+    elif mode == "correctness":
+        run_correctness()
+    else:
+        run_performance()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/session_cases.json
+++ b/tasks/qwen3-8/mi355x_sglang_triton_gdn_linear_attn_qwen38/session_cases.json
@@ -1,0 +1,110 @@
+{
+  "source_day": "2026-08-14",
+  "date_field": "session_started_at",
+  "platform": "MI355X/gfx950 (256 CU)",
+  "framework": "sglang 0.5.17.dev20260812+gdc5f6c4883 (ROCm 7.2.0, triton 3.7.0+amd.rocm7.2.0)",
+  "faithful_reproduction": true,
+  "run_environment_requirement": "Must run in the session's image (lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260812) on MI355X/gfx950. The chain is pure sglang Triton plus torch, so no aiter build is needed.",
+  "selection": "The Gated-DeltaNet linear-attention decode chain of session 100137. No single kernel in it reaches 5% E2E -- the recurrent kernel is 2.278% -- but the five kernels the chain launches per layer total 5.76% E2E, and 2.35 of those points are pure data movement (aten::cat + aten::copy_) created by the split/reshape/concat around the kernels. The chain is therefore scored as one unit. Communication kernels are deliberately excluded from this task set.",
+  "task_name": "mi355x-qwen38-sglang-triton-gdn-linear-attn-20260814",
+  "operator": "gdn_linear_attn_decode",
+  "provenance": {
+    "session_id": "100137",
+    "session_root": "/shared_nfs/hyperloom-claw/Qwen3.8-2.4T-A95B-Quark-MXFP4/20260814T175123Z",
+    "benchmark_run": "runs/roofline/27652f24f9ee4b999c4479ca44c9bf7c/benchmark_sglang_20260815_060127",
+    "trace": "torch_trace/1786775072.0389888-TP-{0..7}.trace.json.gz",
+    "shape_source": "torch_trace/graph_capture_profile/cuda_graph_capture-DecodeCudaGraphRunner-TP-0.json.gz (record_shapes=True), bs=64 segment",
+    "model_config": "/shared_nfs/hyperloom/models/Qwen3.8-2.4T-A95B-Quark-MXFP4/config.json",
+    "serving_config": "TP=8, --mamba-ssm-dtype bfloat16, linear_attn_backend=triton, mamba_backend=triton, ISL 8192 / OSL 1024 / conc 64",
+    "layer_mix": "layer_types = 69 linear_attention + 23 full_attention out of 92 layers (full_attention_interval=4). Every kernel in this chain therefore runs 69x per decode step.",
+    "kernel_identity": {
+      "recurrent": "fused_recurrent_gated_delta_rule_packed_decode_kernel -- 69 calls/step, 1.2397 ms/step (TP-0), 4.018% of the decode step, 2.278% E2E. Source sglang/kernels/ops/attention/fla/fused_recurrent.py:186 (launch :374).",
+      "copy": "at::native::elementwise_kernel_manual_unroll<128,8,direct_copy_kernel_cuda> -- 208 calls/step, 0.9052 ms/step, 2.934% of the decode step, 1.663% E2E. These are aten::copy_ [64,16] x138 and [64,16,128] x69, i.e. the .contiguous() on b/a and the norm output reshape.",
+      "cat": "at::native::CatArrayBatchedCopy<OpaqueType<2u>,unsigned int,2,64,64> -- 69 calls/step, 0.3765 ms/step, 1.220% of the decode step, 0.692% E2E. torch.cat(([64,256],[64,256],[64,2048]), -1).",
+      "conv": "_causal_conv1d_update_kernel -- 69 calls/step, 0.3148 ms/step, 1.020% of the decode step, 0.578% E2E. Source sglang/kernels/ops/mamba/causal_conv1d_triton.py:581 (launch :1144).",
+      "norm": "_layer_norm_fwd_1pass_kernel -- 69 calls/step, 0.3005 ms/step, 0.974% of the decode step, 0.552% E2E. Source sglang/kernels/ops/attention/fla/layernorm_gated.py:75 (launch :273)."
+    },
+    "logical_dims": "Per-rank (TP=8) Gated DeltaNet. Global: linear_num_key_heads=16, linear_key_head_dim=128 -> key_dim 2048; linear_num_value_heads=128, linear_value_head_dim=128 -> value_dim 16384; linear_conv_kernel_dim=4 -> conv_dim = 2*key_dim + value_dim = 20480. After TP=8: 2 k heads (256), 16 v heads (2048), conv_dim 2560. in_proj_qkvz out = 4608/rank, in_proj_ba out = 32/rank.",
+    "excluded_from_unit": "The two input projections (in_proj_qkvz [64,8192]x[8192,4608] and in_proj_ba [64,8192]x[8192,32]) and the output projection (out_proj [64,2048]x[8192,2048]) are NOT part of this timed unit -- they are dense GEMMs and belong to the skinny-bf16-GEMM task. Their outputs/inputs are this unit's boundary.",
+    "split_branch_evidence": "qwen3_5.py:640 uses fused_qkvzba_split_reshape_cat_contiguous only when num_v_heads // num_k_heads is in (1, 2, 4). Qwen3.8 is 128 // 16 = 8, so the model takes the plain-torch else-branch at qwen3_5.py:658 -- which is exactly where the 208 aten::copy_ and 69 aten::cat launches per step come from. The harness asserts this ratio.",
+    "stateful": "causal_conv1d_update and the recurrent kernel both update their cache in place (gdn_triton.py passes ht=initial_state). A CUDA-graph replay advances the caches once per chained invocation, so the timed-run check steps the torch reference the same number of times from the same snapshot."
+  },
+  "gdn_config": {
+    "use_qk_l2norm_in_kernel": true,
+    "conv_activation": "silu",
+    "output_gate_type": "swish",
+    "norm_before_gate": true,
+    "scale": "head_k_dim ** -0.5",
+    "softplus_threshold": 20.0,
+    "ssm_state_dtype": "bfloat16 (--mamba-ssm-dtype bfloat16)",
+    "ssm_state_layout": "[slots, HV, V, K] = [slots, 16, 128, 128]"
+  },
+  "cases": [
+    {
+      "id": "qwen38-gdn-decode-bs64",
+      "phase": "decode",
+      "model": "Qwen3.8-2.4T-A95B-Quark-MXFP4",
+      "seed": 5,
+      "session_e2e_pct": {
+        "chain": 5.76,
+        "recurrent": 2.278,
+        "copy": 1.663,
+        "cat": 0.692,
+        "conv": 0.578,
+        "norm": 0.552
+      },
+      "calls_per_forward": 69,
+      "measured": "trace",
+      "note": "The profiled decode step: bs=64 (conc 64), one token per sequence, all 64 requests holding a distinct mamba cache slot. This is the shape the session's 8-rank trace measured directly.",
+      "trace_input_shapes": {
+        "projected_states_qkvz": [64, 4608],
+        "projected_states_ba": [64, 32],
+        "mixed_qkv_after_cat": [64, 2560],
+        "cat_parts": [[64, 256], [64, 256], [64, 2048]],
+        "conv_weight": [2560, 4],
+        "conv_bias": [2560],
+        "conv_state": [64, 2560, 3],
+        "ssm_state": [64, 16, 128, 128],
+        "A_log": [16],
+        "dt_bias": [16],
+        "ssm_state_indices": [64],
+        "recurrent_out": [64, 1, 16, 128],
+        "norm_input": [1024, 128],
+        "norm_weight": [128],
+        "output": [64, 2048]
+      },
+      "trace_input_dtypes": {
+        "projected_states_qkvz": "bfloat16",
+        "projected_states_ba": "bfloat16",
+        "mixed_qkv_after_cat": "bfloat16",
+        "conv_weight": "bfloat16",
+        "conv_bias": "bfloat16",
+        "conv_state": "bfloat16",
+        "ssm_state": "bfloat16",
+        "A_log": "float32",
+        "dt_bias": "float32",
+        "ssm_state_indices": "int32",
+        "recurrent_out": "bfloat16",
+        "norm_input": "bfloat16",
+        "norm_weight": "bfloat16",
+        "output": "bfloat16"
+      },
+      "params": {
+        "batch": 64,
+        "num_k_heads": 2,
+        "num_v_heads": 16,
+        "head_k_dim": 128,
+        "head_v_dim": 128,
+        "conv_width": 4,
+        "state_slots": 64,
+        "rms_norm_eps": 1e-06,
+        "conv_activation": "silu",
+        "output_gate_type": "swish",
+        "min_cosine": 0.999,
+        "max_rel_norm_err": 0.03
+      },
+      "benchmark": {"warmup": 10, "repetition": 30, "target_ms": 1.0, "max_graph_repeats": 50}
+    }
+  ],
+  "prefill_note": "There is NO prefill case in this task, and that is deliberate rather than an omission. The prefill path of the same operator does not run this kernel: qwen3_5 linear attention dispatches chunked prefill to sglang/kernels/ops/attention/fla/chunk.py::chunk_gated_delta_rule, a different Triton kernel with a different algorithm (chunked scan, not a single recurrent step). Covering it faithfully needs the per-request ragged chunk metadata that only a prefill trace supplies, and session 100137 captured no prefill trace (both profiler windows landed entirely on step[DECODE bs=64]). Adding a synthetic prefill case here would score a shape the session cannot confirm. The decode kernel this task does cover is decode-only by construction -- see its name."
+}

--- a/tests/test_forge_kb_producer.py
+++ b/tests/test_forge_kb_producer.py
@@ -107,7 +107,6 @@ def _command(tmp_path: Path, **overrides) -> list[str]:
         "workspace": str(tmp_path),
         "experiments_dir": tmp_path / "forge_experiments",
         "result_json": tmp_path / "forge_experiments" / "forge_result.json",
-        "program_md": tmp_path / "forge_program.md",
         "agent_config": {
             "max_iters": 1000,
             "timeout_seconds": 7200,
@@ -137,6 +136,7 @@ def test_supplied_kernel_identity_fields_are_forwarded(tmp_path):
     assert "--shapes-json" not in argv
     assert "--workload-key" not in argv
     assert "--kernel-kind" not in argv
+    assert "--program-md-file" not in argv
     assert "--resume" not in argv
 
 

--- a/tests/test_forge_kb_producer.py
+++ b/tests/test_forge_kb_producer.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import math
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +15,7 @@ import yaml
 from agents.forge.drivers import arena_task_adapter
 from agents.forge.launch_agent import (
     _build_forge_command,
+    _capture_forge_edit_baseline,
     _declared_editable_sources,
     _forge_max_hours,
     _infer_backend,
@@ -24,6 +27,7 @@ from agents.forge.launch_agent import (
     _resolve_framework,
     _resolve_gpu_type,
     _resolve_kernel_kind,
+    _verify_forge_edit_scope,
 )
 
 CK_TASK_NAMES = (
@@ -62,6 +66,17 @@ def _load_k3_forge_driver():
         / "scripts/forge_driver.py"
     )
     spec = importlib.util.spec_from_file_location("_k3_forge_driver_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_task_module(relative_path: str):
+    root = Path(__file__).resolve().parents[1]
+    path = root / relative_path
+    module_name = f"_{path.parent.parent.name}_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -214,6 +229,83 @@ def test_editable_sources_extend_complete_source_allowlist(tmp_path):
     assert resolved == [kernel.resolve(), helper.resolve()]
 
 
+def _init_scope_test_repo(tmp_path: Path) -> str:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "forge-test@local"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "forge-test"], cwd=tmp_path, check=True
+    )
+    (tmp_path / ".gitignore").write_text("build/\nforge_experiments/\n")
+    (tmp_path / "kernel.py").write_text("def kernel(): return 0\n")
+    (tmp_path / "helper.py").write_text("def helper(): return 0\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True
+    )
+    return _capture_forge_edit_baseline(str(tmp_path))
+
+
+def test_forge_edit_scope_allows_declared_source_change(tmp_path):
+    baseline = _init_scope_test_repo(tmp_path)
+    kernel = tmp_path / "kernel.py"
+    kernel.write_text("def kernel(): return 1\n")
+    subprocess.run(["git", "add", "kernel.py"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "allowed edit"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    _verify_forge_edit_scope(str(tmp_path), baseline, [kernel])
+
+
+def test_forge_edit_scope_allows_ignored_runtime_artifacts(tmp_path):
+    baseline = _init_scope_test_repo(tmp_path)
+    kernel = tmp_path / "kernel.py"
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "kernel.hsaco").write_bytes(b"runtime artifact")
+
+    _verify_forge_edit_scope(str(tmp_path), baseline, [kernel])
+
+
+def test_forge_edit_scope_discards_undeclared_untracked_file(tmp_path):
+    baseline = _init_scope_test_repo(tmp_path)
+    kernel = tmp_path / "kernel.py"
+    scratch = tmp_path / "new_helper.py"
+    scratch.write_text("def bypass(): return 1\n")
+
+    _verify_forge_edit_scope(str(tmp_path), baseline, [kernel])
+
+    assert not scratch.exists()
+
+
+@pytest.mark.parametrize("change_kind", ["tracked", "rename"])
+def test_forge_edit_scope_rejects_undeclared_changes(tmp_path, change_kind):
+    baseline = _init_scope_test_repo(tmp_path)
+    kernel = tmp_path / "kernel.py"
+    helper = tmp_path / "helper.py"
+    if change_kind == "tracked":
+        helper.write_text("def helper(): return 1\n")
+        subprocess.run(["git", "add", "helper.py"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "undeclared edit"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+    else:
+        helper.rename(tmp_path / "renamed_helper.py")
+
+    with pytest.raises(RuntimeError, match="outside source_file_path/editable_sources"):
+        _verify_forge_edit_scope(str(tmp_path), baseline, [kernel])
+
+
 def test_explicit_source_owner_wins_for_wrapper_anchor():
     config = {
         "image_repo_path": "/workspace/vllm/model_executor/attention.py",
@@ -266,9 +358,87 @@ def test_forge_budget_reserves_internal_shutdown_margin():
 
 def test_gpu_type_uses_normalized_arena_hardware_model():
     assert _resolve_gpu_type({"target_gpu_model": "MI355X"}) == "mi355x"
-    assert _resolve_gpu_type({"target_gpu_model": "mi300"}) == "mi300"
+    assert _resolve_gpu_type({"target_gpu_model": "mi300"}) == "mi300x"
+    assert _resolve_gpu_type({"target_gpu_model": "MI300X"}) == "mi300x"
+    assert _resolve_gpu_type({"target_gpu_model": "mi325"}) == "mi325x"
+    assert _resolve_gpu_type({"target_gpu_model": "MI325X"}) == "mi325x"
     with pytest.raises(ValueError, match="target_gpu_model"):
         _resolve_gpu_type({"target_gpu_model": ""})
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "tasks/kimi-k3/mi355x_sglang_flydsl_hgemm_small_m_kimi_k3/scripts/forge_driver.py",
+        "tasks/kimi-k3/mi355x_sglang_triton_attn_residual_kimi_k3/scripts/forge_driver.py",
+        "tasks/kimi-k3/mi355x_sglang_triton_mla_decode_grouped_kimi_k3/scripts/forge_driver.py",
+    ],
+)
+def test_kimi_forge_driver_snr_fails_closed_on_non_finite_output(
+    monkeypatch,
+    relative_path,
+):
+    driver = _load_task_module(relative_path)
+
+    class _Scalar:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+    class _Vector:
+        def __init__(self, norm, noise=0.0):
+            self.norm_value = norm
+            self.noise = noise
+
+        def flatten(self):
+            return self
+
+        def norm(self):
+            return _Scalar(self.norm_value)
+
+        def __sub__(self, _other):
+            return _Vector(self.noise)
+
+    class _Output:
+        def __init__(self, finite, noise):
+            self.finite = finite
+            self.noise = noise
+
+        def double(self):
+            return _Vector(1.0, self.noise)
+
+    class _Reference:
+        def flatten(self):
+            return _Vector(1.0)
+
+    class _TaskRunner:
+        CASES = [{"id": "case0"}]
+
+        def __init__(self, finite, noise):
+            self.finite = finite
+            self.noise = noise
+
+        @staticmethod
+        def _prepare(_case):
+            return {}
+
+        def _run(self, _inputs):
+            return _Output(self.finite, self.noise)
+
+        @staticmethod
+        def _golden(_inputs):
+            return _Reference()
+
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(synchronize=lambda: None, empty_cache=lambda: None),
+        isfinite=lambda output: SimpleNamespace(all=lambda: output.finite),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    assert driver._run_correctness(_TaskRunner(False, math.nan)) == 1
+    assert driver._run_correctness(_TaskRunner(True, 0.001)) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forge_kb_producer.py
+++ b/tests/test_forge_kb_producer.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+from agents.forge.drivers import arena_task_adapter
 from agents.forge.launch_agent import (
     _build_forge_command,
     _declared_editable_sources,
@@ -21,10 +22,9 @@ from agents.forge.launch_agent import (
     _resolve_all_source_files,
     _resolve_fellow,
     _resolve_framework,
+    _resolve_gpu_type,
     _resolve_kernel_kind,
 )
-from agents.forge.drivers import arena_task_adapter
-
 
 CK_TASK_NAMES = (
     "mi355x_vllm_ck_a8w8_blockscale_gemm",
@@ -112,6 +112,7 @@ def _command(tmp_path: Path, **overrides) -> list[str]:
             "timeout_seconds": 7200,
         },
         "gpu_arch": "gfx950",
+        "gpu_type": "mi355x",
         "fellow": "triton-fellow",
         "task_type": "image_kernel",
         "source_files": [tmp_path / "wrapper.py", tmp_path / "kernel.py"],
@@ -126,6 +127,8 @@ def _command(tmp_path: Path, **overrides) -> list[str]:
 def test_supplied_kernel_identity_fields_are_forwarded(tmp_path):
     argv = _command(tmp_path)
 
+    assert _value(argv, "--gpu-target") == "gfx950"
+    assert _value(argv, "--gpu-type") == "mi355x"
     assert _value(argv, "--operator-name") == "unified_attention"
     assert _value(argv, "--framework") == "aiter"
     assert _value(argv, "--target-functions") == "dispatch,_device_kernel"
@@ -261,6 +264,13 @@ def test_forge_budget_reserves_internal_shutdown_margin():
     assert _forge_max_hours({"timeout_seconds": 600}) == 1.0
 
 
+def test_gpu_type_uses_normalized_arena_hardware_model():
+    assert _resolve_gpu_type({"target_gpu_model": "MI355X"}) == "mi355x"
+    assert _resolve_gpu_type({"target_gpu_model": "mi300"}) == "mi300"
+    with pytest.raises(ValueError, match="target_gpu_model"):
+        _resolve_gpu_type({"target_gpu_model": ""})
+
+
 @pytest.mark.parametrize(
     ("task_name", "logical_operator", "kernel_kind", "source_owner"),
     [
@@ -303,7 +313,7 @@ def test_forge_budget_reserves_internal_shutdown_margin():
         ),
         (
             "mi355x_vllm_triton_paged_attention_2d",
-            "unified_attention_with_output",
+            "paged_attention_2d",
             "triton",
             "vllm",
         ),


### PR DESCRIPTION
## Summary
- stop generating `forge_program.md` in the AgentKernelArena Forge launcher
- omit `--program-md-file` so KernelForge owns its agent rules and safety constraints
- preserve structured kernel, source, function, framework, operator, GPU, and fellow metadata

## Test plan
- [x] `python3 -m py_compile agents/forge/launch_agent.py tests/test_forge_kb_producer.py`
- [x] focused Forge command regression tests (`3 passed`)


Made with [Cursor](https://cursor.com)