### PR TITLE
docs: restore header options dropped in docs/0.2.0 reconcile

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,12 @@ version_number = "0.2.0"
 html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "hyperloom",
+    "header_title": f"AgentKernelArena {version_number}",
+    "header_link": False,
     "use_repository_button": True,
     "use_issues_button": True,
+    "version_list_link": False,
+    "link_main_doc": False,
 }
 
 # This section turns on/off article info


### PR DESCRIPTION
Follow-up to #85. The reconcile merge kept `flavor: hyperloom` but dropped `header_title`, `header_link`, `version_list_link`, and `link_main_doc` that were present on `docs/0.2.0`. Restores those (skips `nav_secondary_items`, which duplicated the Hyperloom/GitHub/etc. links already covered by the TOC and theme flavor). No TOC change needed — Hyperloom is already listed under Reference in `_toc.yml.in`.