### PR TITLE
Update ROCm version for AMD Instinct GPUs

### DIFF
--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -15,9 +15,9 @@ The following hardware configurations are supported and tested.
 
 | AMD Instinct GPU | ROCm version | Notes |
 | --- | --- | --- |
-| MI300X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI300X` |
-| MI325X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI325X` |
-| MI355X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI355X` |
+| MI300X | 10.0 (Bundled in the selected SGLang image) | `target_gpu_model: MI300X` |
+| MI325X | 10.0 (Bundled in the selected SGLang image) | `target_gpu_model: MI325X` |
+| MI355X | 10.0 (Bundled in the selected SGLang image) | `target_gpu_model: MI355X` |
 
 ## Software requirements
 


### PR DESCRIPTION
Updated ROCm version for AMD Instinct GPUs from 7.2 to 10.0 in the compatibility matrix.