### PR TITLE
Add a non-root RDNA4 runtime and correct agent guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,14 @@ Thanks for your interest in AgentKernelArena! This guide explains how to contrib
 
 - Read `README.md` to understand the project scope: controlled A/B experiments and RL-ready feedback for GPU kernel agents.
 - Skim the files under `example_configs/` for run-level agent/task/GPU selection and the relevant `agents/<name>/agent_config.yaml` for agent-specific model and runtime settings.
-- Ensure you have an AMD GPU with ROCm-compatible Docker access; the supported workflow uses the pinned ROCm/SGLang images documented in the compatibility matrix.
+- Ensure you have an AMD GPU with ROCm-compatible Docker access; use the architecture-specific runtime documented in the compatibility matrix.
 - Confirm that the selected agent integration and its authentication/dependencies are available.
 
 ## Development Setup
 
-Docker is the only supported path. All runs happen inside the pinned ROCm/SGLang
-container; see `docs/install/install.md`.
+Docker is the only supported path. All runs happen inside the selected GPU
+runtime container; see `docs/install/install.md` for image selection and the
+RDNA4 build step.
 
 ```bash
 # Verify the container can see Python, ROCm tools, and the GPU

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in AgentKernelArena! This guide explains how to contrib
 
 Docker is the only supported path. All runs happen inside the selected GPU
 runtime container; see `docs/install/install.md` for image selection and the
-RDNA4 build step.
+RDNA4 image preparation.
 
 ```bash
 # Verify the container can see Python, ROCm tools, and the GPU

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo "                         Use CONFIG=... for another config; AGENTS=... overrides it"
 	@echo "                         AGENTS=all explicitly checks all three first-class CLIs"
 	@echo "make docker-smoke        - Verify Docker Python, ROCm tools, imports, and GPU access"
-	@echo "make docker-build-rdna4  - Build the pinned gfx1201 runtime for the host UID"
+	@echo "make docker-build-rdna4  - Prebuild/rebuild gfx1201 runtime (also builds on first use)"
 	@echo "make docker-run CONFIG=example_configs/quickstart_claude_mi300.yaml RUN_ARGS=\"--run-suffix test\" - Run an experiment in Docker"
 	@echo "make docker-parallel-run CONFIG=example_configs/benchmark_cursor_mi355x.yaml GPU_IDS=0,1 - Run an experiment across one worker container per GPU"
 	@echo "                         Default CONFIG is the MI300/MI300X Claude quickstart"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help docker-shell docker-check-agents docker-smoke docker-run docker-parallel-run docker-quality-loop docker-setup-flydsl docker-setup-geak \
+.PHONY: help docker-shell docker-check-agents docker-smoke docker-build-rdna4 docker-run docker-parallel-run docker-quality-loop docker-setup-flydsl docker-setup-geak \
         slurm-shell slurm-smoke slurm-parallel-smoke slurm-check-agents slurm-run slurm-parallel-run slurm-submit slurm-parallel-submit \
         check-docker-runner check-slurm-runner check-evaluator check-held-out check-visualization \
         visualization-build visualization-serve visualization-run \
@@ -22,11 +22,12 @@ help:
 	@echo "                         Use CONFIG=... for another config; AGENTS=... overrides it"
 	@echo "                         AGENTS=all explicitly checks all three first-class CLIs"
 	@echo "make docker-smoke        - Verify Docker Python, ROCm tools, imports, and GPU access"
+	@echo "make docker-build-rdna4  - Build the pinned gfx1201 runtime for the host UID"
 	@echo "make docker-run CONFIG=example_configs/quickstart_claude_mi300.yaml RUN_ARGS=\"--run-suffix test\" - Run an experiment in Docker"
 	@echo "make docker-parallel-run CONFIG=example_configs/benchmark_cursor_mi355x.yaml GPU_IDS=0,1 - Run an experiment across one worker container per GPU"
 	@echo "                         Default CONFIG is the MI300/MI300X Claude quickstart"
 	@echo "                         On other GPUs, pass a matching CONFIG explicitly"
-	@echo "                         Images: gfx942->mi30x, gfx950->mi35x; override with AKA_DOCKER_IMAGE=..."
+	@echo "                         Images: gfx942->mi30x, gfx950->mi35x, gfx1201->local RDNA4 build"
 	@echo "make docker-quality-loop CONFIG=example_configs/quality_loop_mi300.yaml - Audit and harden config-selected tasks, then open at most one draft PR"
 	@echo "                         Default quality-loop CONFIG is agents/quality_loop/agent_config.yaml"
 	@echo "make docker-setup-flydsl - Install FlyDSL when absent (for flydsl2flydsl, torch2flydsl, and triton2flydsl)"
@@ -113,6 +114,9 @@ docker-check-agents:
 
 docker-smoke:
 	@$(DOCKER_RUNNER) smoke
+
+docker-build-rdna4:
+	@$(DOCKER_RUNNER) build-rdna4-image
 
 docker-run:
 	@$(DOCKER_RUNNER) run --config_name $(CONFIG) $(RUN_ARGS)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The prompt system also recognizes `cuda2hip`; the current bundled task tree does
 - Node.js 22+ and npm when using the alternative npm installation of Claude Code
   (or another npm-installed agent CLI)
 - For MI300/MI355X, use the GPU-specific SGLang image: `gfx942` uses `lmsysorg/sglang:v0.5.12-rocm720-mi30x`; `gfx950` uses `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705`
-- For RDNA4 `gfx1201`, build the [pinned RDNA4 runtime](docker/rdna4/README.md) with `make docker-build-rdna4`.
+- For RDNA4 `gfx1201`, the runner automatically builds the default [pinned RDNA4 runtime](docker/rdna4/README.md) on first use if it is missing.
 - A supported agent CLI installed and logged in on the host, or the dependencies required by a specialized agent
 
 ### Setup
@@ -196,7 +196,7 @@ The following configurations provide starting points for supported runtimes:
 | --- | --- |
 | `example_configs/quickstart_claude_mi300.yaml` | One Claude Code GELU task on MI300/MI300X (`gfx942`); use this for a first run on MI300-series hardware. |
 | `example_configs/quickstart_claude_mi355x.yaml` | One Claude Code GELU task on MI355X (`gfx950`); use this for a first run on MI355X. |
-| `example_configs/quickstart_claude_rdna4.yaml` | One Claude Code GELU task on RDNA4 (`gfx1201`); run `make docker-build-rdna4` first. |
+| `example_configs/quickstart_claude_rdna4.yaml` | One Claude Code GELU task on RDNA4 (`gfx1201`); builds the default runtime on first use if missing. |
 | `example_configs/benchmark_cursor_mi355x.yaml` | Curated 60-task Cursor Agent benchmark on MI355X; use this for a longer benchmark only after installing and authenticating Cursor Agent. |
 
 Running `make docker-run` without `CONFIG` uses the MI300/MI300X Claude

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ The prompt system also recognizes `cuda2hip`; the current bundled task tree does
 - Git
 - Node.js 22+ and npm when using the alternative npm installation of Claude Code
   (or another npm-installed agent CLI)
-- The GPU-specific SGLang image: `gfx942` uses `lmsysorg/sglang:v0.5.12-rocm720-mi30x`; `gfx950` uses `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705`
+- For MI300/MI355X, use the GPU-specific SGLang image: `gfx942` uses `lmsysorg/sglang:v0.5.12-rocm720-mi30x`; `gfx950` uses `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705`
+- For RDNA4 `gfx1201`, build the [pinned RDNA4 runtime](docker/rdna4/README.md) with `make docker-build-rdna4`.
 - A supported agent CLI installed and logged in on the host, or the dependencies required by a specialized agent
 
 ### Setup
@@ -189,12 +190,13 @@ installation. The npm path requires Node.js 22+ and npm. See the
 [official Claude Code setup guide](https://code.claude.com/docs/en/installation)
 for the current alternatives.
 
-The repository provides three ready-to-use run configurations:
+The following configurations provide starting points for supported runtimes:
 
 | Configuration | Purpose |
 | --- | --- |
 | `example_configs/quickstart_claude_mi300.yaml` | One Claude Code GELU task on MI300/MI300X (`gfx942`); use this for a first run on MI300-series hardware. |
 | `example_configs/quickstart_claude_mi355x.yaml` | One Claude Code GELU task on MI355X (`gfx950`); use this for a first run on MI355X. |
+| `example_configs/quickstart_claude_rdna4.yaml` | One Claude Code GELU task on RDNA4 (`gfx1201`); run `make docker-build-rdna4` first. |
 | `example_configs/benchmark_cursor_mi355x.yaml` | Curated 60-task Cursor Agent benchmark on MI355X; use this for a longer benchmark only after installing and authenticating Cursor Agent. |
 
 Running `make docker-run` without `CONFIG` uses the MI300/MI300X Claude

--- a/docker/rdna4/.dockerignore
+++ b/docker/rdna4/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Dockerfile
+!prepare_runtime.py
+!requirements.lock

--- a/docker/rdna4/Dockerfile
+++ b/docker/rdna4/Dockerfile
@@ -1,0 +1,19 @@
+# rocm/vllm:rocm10.0.0_ubuntu24.04_py3.14_pytorch_2.12.0_vllm_0.27.0
+# Keep the GPU stack fixed; add only the missing report dependencies below.
+FROM rocm/vllm@sha256:b8a082f346d069376d35784250e38b23a043efe979408ae3a33d7c6b62ee3276
+
+USER root
+COPY prepare_runtime.py /tmp/aka-prepare-runtime.py
+RUN python /tmp/aka-prepare-runtime.py && rm /tmp/aka-prepare-runtime.py
+
+COPY requirements.lock /tmp/aka-rdna4-requirements.lock
+RUN PIP_CONFIG_FILE=/dev/null PIP_EXTRA_INDEX_URL= \
+    /opt/venv/bin/python -m pip install --no-cache-dir --no-deps \
+    --only-binary=:all: --require-hashes --index-url https://pypi.org/simple \
+    -r /tmp/aka-rdna4-requirements.lock && rm /tmp/aka-rdna4-requirements.lock
+
+# Verify the same public paths the runner uses, without a GPU or host mounts.
+# /root remains private; neither execution nor extension builds should need it.
+RUN setpriv --reuid=65534 --regid=65534 --clear-groups env HOME=/tmp \
+    /opt/venv/bin/python -c \
+    "import os, torch, triton, pytest, yaml, numpy, matplotlib.pyplot; assert not os.access('/root', os.X_OK); assert os.access('/opt/rocm/bin/hipcc', os.X_OK); assert os.access('/opt/rocm/bin/rocprofv3', os.X_OK)"

--- a/docker/rdna4/README.md
+++ b/docker/rdna4/README.md
@@ -73,9 +73,13 @@ checks also do not replace a framework-finalized `task_validator` report.
 
 Known limits of existing tasks with this image include:
 
-- Device capacity: HIP Transpose's original correctness cases can exceed VRAM;
-  vLLM persistent matmul can request 96 KiB shared memory against the device's
-  64 KiB per-workgroup limit.
+- Device capacity (16 GB tested): HIP Transpose's original correctness cases
+  exceeded VRAM on the tested board. `gfx1201` covers boards with different
+  memory capacities; see [AMD GPU specifications](https://rocm.docs.amd.com/en/docs-10.0.0/reference/gpu-specs.html).
+  Larger-memory boards, including 32 GB models, have not been validated here.
+- Per-workgroup LDS (`gfx1201`): vLLM persistent matmul can request 96 KiB of
+  shared memory against the 64 KiB per-workgroup limit. Increasing board VRAM
+  does not increase this separate LDS limit.
 - Native FlyDSL tasks: some use APIs absent from the bundled FlyDSL version;
   others explicitly require a CDNA architecture in `platform_support`.
 - Image-bound tasks: existing `image_kernel` contracts can refer to source

--- a/docker/rdna4/README.md
+++ b/docker/rdna4/README.md
@@ -37,6 +37,12 @@ through the runner's existing PATH. The build checks Python imports and compiler
 and profiler accessibility as an unprivileged UID, without exposing `/root`.
 Experiments still run as the invoking host UID; no runtime root initialization
 or host permission changes are required.
+The runner supplies `USER` and `LOGNAME` for Python libraries that resolve a
+username, since the host UID may have no entry in the image's passwd database.
+On `gfx1201`, `AITER_ROOT_DIR` and `AITER_JIT_DIR` point to separate
+container-local `/tmp` caches, with the runner's worker suffix when set, so
+repository and installed-package builds do not write under the unmounted host
+home directory.
 
 The `gfx1201` smoke check requires `hipcc` and `rocprofv3`. Other architectures
 retain the existing `hipcc` and `rocprof-compute` checks. Finding a profiler does
@@ -44,17 +50,31 @@ not imply that a task or candidate was profiled.
 
 ## Validation and limits
 
-Runtime checks have exercised existing HIP GELU, Triton RMSNorm, and BF16 GEMM
-tasks on a 16 GB `gfx1201` GPU. This is not a guarantee that every Arena task fits
-the device. In particular, the current vLLM persistent-matmul task can request
-96 KiB shared memory against the device's 64 KiB per-workgroup limit. Keep task
-shapes, correctness tolerances, and timing policy intact when investigating such
-failures; any tuning belongs in the permitted kernel implementation.
+Runtime checks have exercised existing HIP and Triton kernels and PyTorch
+baselines on a 16 GB `gfx1201` GPU. A passing baseline for a generation or
+conversion task does not validate a generated target kernel. Runtime command
+checks also do not replace a framework-finalized `task_validator` report.
 
-Only `gfx1201` is configured here. Other Radeon architectures, optional FlyDSL
-and AITER task dependencies, full vLLM serving, and evaluation-tool sidecars need
-separate qualification. Existing task contracts and benchmark helpers are
-unchanged. Agent availability and authentication are separate preflight checks.
+Known limits of existing tasks with this image include:
+
+- Device capacity: HIP Transpose's original correctness cases can exceed VRAM;
+  vLLM persistent matmul can request 96 KiB shared memory against the device's
+  64 KiB per-workgroup limit.
+- Native FlyDSL tasks: some use APIs absent from the bundled FlyDSL version;
+  others explicitly require a CDNA architecture in `platform_support`.
+- Image-bound tasks: existing `image_kernel` contracts can refer to source
+  trees and Python package paths from a different image. Those paths are not
+  interchangeable with this image's packages.
+- Repository tasks: some rocPRIM test instantiations require wave64 operations
+  unavailable on this wave32 device.
+
+Keep task shapes, correctness tolerances, and timing policy intact when
+investigating failures. Honor architecture restrictions, and qualify task or
+harness changes with the [task validator](../../docs/how-to/task-validator.md).
+Only `gfx1201` is configured here; this does not establish support for every task
+category, other Radeon architectures, full vLLM serving, or evaluation-tool
+sidecars. Existing task contracts and benchmark helpers are unchanged. Agent
+availability and authentication are separate preflight checks.
 
 ## Security and reproducibility review
 

--- a/docker/rdna4/README.md
+++ b/docker/rdna4/README.md
@@ -7,7 +7,6 @@ This recipe supports `gfx1201`. The base image and immutable digest live in
 From the repository root on the GPU host:
 
 ```bash
-make docker-build-rdna4
 make docker-smoke
 make docker-check-agents CONFIG=example_configs/quickstart_claude_rdna4.yaml
 make docker-run CONFIG=example_configs/quickstart_claude_rdna4.yaml
@@ -17,8 +16,20 @@ Install and authenticate the selected agent separately as described in the
 [installation guide](../../docs/install/install.md). The build and smoke steps
 do not need an agent or its credentials. `AKA_DOCKER_IMAGE_GFX1201` overrides
 both the build output tag and the architecture-specific runtime selection;
-`AKA_DOCKER_IMAGE` remains the global run override. Build the image on each
-Docker host before selecting it. There is no automatic image build on a run.
+`AKA_DOCKER_IMAGE` remains the global run override.
+
+The runner automatically builds the default image when it is absent from the
+Docker daemon, before launching the first container. This applies to smoke,
+shell, agent checks, and task runs; parallel runs complete this step during
+preflight before starting workers. The first build may download the base image
+and locked packages. Later invocations reuse the existing image without checking
+for recipe updates. Use `make docker-build-rdna4` to prebuild it or rebuild after
+recipe changes. A build failure stops the command before the experiment starts.
+
+Setting either image override disables automatic builds, even when its value
+equals the default tag. Custom images use Docker's normal run/pull behavior;
+build or publish them separately. To build this recipe under a custom tag, use
+`AKA_DOCKER_IMAGE_GFX1201=<tag> make docker-build-rdna4`.
 
 ## Runtime layout
 
@@ -99,8 +110,8 @@ availability and authentication are separate preflight checks.
 ## Security and reproducibility review
 
 External inputs are the digest-pinned upstream image and the hash-locked PyPI
-wheels. The explicit build sends only the Dockerfile, normalizer, and package
-lock from `docker/rdna4/` as its context. It installs only the locked wheels,
+wheels. Both automatic and explicit builds send only the Dockerfile, normalizer,
+and package lock from `docker/rdna4/` as their context. They install only the locked wheels,
 with no source builds, dependency resolution, or agent credentials. The normalizer
 refuses to replace existing runtime aliases and leaves `/root` private. The runner
 retains its existing host-UID execution, device mounts, privileged-container

--- a/docker/rdna4/README.md
+++ b/docker/rdna4/README.md
@@ -1,0 +1,70 @@
+# RDNA4 runtime image
+
+This recipe supports `gfx1201`. The base image and immutable digest live in
+[Dockerfile](Dockerfile); the default local output tag lives in
+[`docker_benchmark.sh`](../../src/scripts/docker_benchmark.sh).
+
+From the repository root on the GPU host:
+
+```bash
+make docker-build-rdna4
+make docker-smoke
+make docker-check-agents CONFIG=example_configs/quickstart_claude_rdna4.yaml
+make docker-run CONFIG=example_configs/quickstart_claude_rdna4.yaml
+```
+
+Install and authenticate the selected agent separately as described in the
+[installation guide](../../docs/install/install.md). The build and smoke steps
+do not need an agent or its credentials. `AKA_DOCKER_IMAGE_GFX1201` overrides
+both the build output tag and the architecture-specific runtime selection;
+`AKA_DOCKER_IMAGE` remains the global run override. Build the image on each
+Docker host before selecting it. There is no automatic image build on a run.
+
+## Runtime layout
+
+The upstream image puts a uv-managed Python virtual environment in
+`/opt/python`, with its base interpreter under `/root`. The recipe copies only
+that base interpreter and standard library to `/opt/aka-python-runtime` and
+updates the virtual environment's interpreter links and `pyvenv.cfg`. Installed
+PyTorch, Triton, and ROCm SDK packages remain in their original locations.
+The recipe also installs the missing plotting packages from
+[`requirements.lock`](requirements.lock), using exact versions and wheel hashes
+without dependency upgrades. Other plotting dependencies come from the pinned
+base image. Refresh this lock when changing the base or Python version.
+
+Aliases `/opt/venv` and `/opt/rocm` expose the virtual environment and ROCm SDK
+through the runner's existing PATH. The build checks Python imports and compiler
+and profiler accessibility as an unprivileged UID, without exposing `/root`.
+Experiments still run as the invoking host UID; no runtime root initialization
+or host permission changes are required.
+
+The `gfx1201` smoke check requires `hipcc` and `rocprofv3`. Other architectures
+retain the existing `hipcc` and `rocprof-compute` checks. Finding a profiler does
+not imply that a task or candidate was profiled.
+
+## Validation and limits
+
+Runtime checks have exercised existing HIP GELU, Triton RMSNorm, and BF16 GEMM
+tasks on a 16 GB `gfx1201` GPU. This is not a guarantee that every Arena task fits
+the device. In particular, the current vLLM persistent-matmul task can request
+96 KiB shared memory against the device's 64 KiB per-workgroup limit. Keep task
+shapes, correctness tolerances, and timing policy intact when investigating such
+failures; any tuning belongs in the permitted kernel implementation.
+
+Only `gfx1201` is configured here. Other Radeon architectures, optional FlyDSL
+and AITER task dependencies, full vLLM serving, and evaluation-tool sidecars need
+separate qualification. Existing task contracts and benchmark helpers are
+unchanged. Agent availability and authentication are separate preflight checks.
+
+## Security and reproducibility review
+
+External inputs are the digest-pinned upstream image and the hash-locked PyPI
+wheels. The explicit build sends only the Dockerfile, normalizer, and package
+lock from `docker/rdna4/` as its context. It installs only the locked wheels,
+with no source builds, dependency resolution, or agent credentials. The normalizer
+refuses to replace existing runtime aliases and leaves `/root` private. The runner
+retains its existing host-UID execution, device mounts, privileged-container
+policy, and opt-in evaluation-tool policy. These containers remain
+reproducibility boundaries, not security sandboxes. Record the derived local
+image ID with run evidence; the base digest alone does not identify changes to
+this recipe.

--- a/docker/rdna4/README.md
+++ b/docker/rdna4/README.md
@@ -48,6 +48,22 @@ The `gfx1201` smoke check requires `hipcc` and `rocprofv3`. Other architectures
 retain the existing `hipcc` and `rocprof-compute` checks. Finding a profiler does
 not imply that a task or candidate was profiled.
 
+## Agent architecture guidance
+
+`target_gpu_model: RDNA4` selects the
+[gfx1201 architecture context](../../src/prompts/cheatsheet/RDNA4_architecture.md)
+and the existing HIP/Triton `knowledge_override` entries in
+[the cheatsheet map](../../src/prompts/cheatsheet/default_cheatsheet.yaml).
+This shared prompt route does not require a GEAK workflow. Other target
+languages retain their default guides; selecting one does not qualify its
+runtime dependencies on RDNA4.
+
+The guides distinguish hardware WMMA formats from installed compiler support,
+SIMD residency from CU/WGP totals, and tracing from hardware counters. Board
+capacity and launch limits must come from the actual device. The guide commands
+are for diagnostics inside this runtime; use the task's unchanged harness for
+scored timing. These prompt corrections do not establish a performance gain.
+
 ## Validation and limits
 
 Runtime checks have exercised existing HIP and Triton kernels and PyTorch

--- a/docker/rdna4/prepare_runtime.py
+++ b/docker/rdna4/prepare_runtime.py
@@ -1,0 +1,52 @@
+"""Normalize the pinned image's uv Python and ROCm SDK layout at build time."""
+from pathlib import Path
+import shutil
+import sys
+import sysconfig
+
+
+def prepare_runtime(venv: Path, base: Path, sdk: Path, prefix: Path) -> None:
+    """Relocate only the base interpreter; keep installed packages in the venv."""
+    base = base.resolve()
+    destination = prefix / "aka-python-runtime"
+    aliases = {prefix / "venv": venv, prefix / "rocm": sdk}
+    for path in (destination, *aliases):
+        if path.exists() or path.is_symlink():
+            raise FileExistsError(f"Refusing to replace existing runtime path: {path}")
+    if not sdk.is_dir() or not (sdk / "bin/hipcc").is_file():
+        raise ValueError(f"Missing ROCm SDK: {sdk}")
+
+    config_path = venv / "pyvenv.cfg"
+    config = config_path.read_text().splitlines()
+    if sum(line.partition("=")[0].strip() == "home" for line in config) != 1:
+        raise ValueError("Expected exactly one Python home in pyvenv.cfg")
+
+    # Resolve links before changing any of them (python3 may point to python).
+    links = {
+        link: link.resolve().relative_to(base)
+        for link in (venv / "bin").glob("python*")
+        if link.is_symlink()
+    }
+    if venv / "bin/python" not in links:
+        raise ValueError("Expected the pinned image's Python interpreter symlink")
+
+    shutil.copytree(base, destination, symlinks=True)
+    for link, relative_target in links.items():
+        link.unlink()
+        link.symlink_to(destination / relative_target)
+    config_path.write_text("\n".join(
+        f"home = {destination / 'bin'}"
+        if line.partition("=")[0].strip() == "home" else line
+        for line in config
+    ) + "\n")
+    for alias, target in aliases.items():
+        alias.symlink_to(target, target_is_directory=True)
+
+
+if __name__ == "__main__":
+    prepare_runtime(
+        Path(sys.prefix),
+        Path(sys.base_prefix),
+        Path(sysconfig.get_path("purelib")) / "_rocm_sdk_devel",
+        Path("/opt"),
+    )

--- a/docker/rdna4/requirements.lock
+++ b/docker/rdna4/requirements.lock
@@ -1,0 +1,9 @@
+# Missing AKA plotting dependencies for the digest-pinned base in Dockerfile.
+# Wheel hashes target Linux x86_64 / CPython 3.14. Install with --no-deps:
+# numpy, packaging, pillow, python-dateutil and six come from the pinned base.
+contourpy==1.3.3 --hash=sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3
+cycler==0.12.1 --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+fonttools==4.64.0 --hash=sha256:b4a7af455ffed980925bc0ebf5b8d6239e6c3e797d9d755b6db192fb3080d614
+kiwisolver==1.5.1 --hash=sha256:18a0cfb124546a4c2e6087c5f3029c7f44b37c85b142e0ced71f73a7599ac208
+matplotlib==3.11.1 --hash=sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be
+pyparsing==3.3.2 --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -9,7 +9,7 @@ myst:
 
 AgentKernelArena runs controlled agent experiments against GPU kernel tasks on
 an AMD GPU. Docker is the supported workflow: each experiment runs inside the
-GPU-architecture-specific SGLang image and bind-mounts the required local agent
+GPU-architecture-specific runtime image and bind-mounts the required local agent
 CLI plus its login state.
 
 ## Prerequisites
@@ -20,11 +20,13 @@ The following prerequisites are required before running AgentKernelArena.
   `/dev/dri` must be present. The runner also mounts `/dev/mem` when present.
 - **Docker Engine:** the current user must be able to access the Docker daemon
   without `sudo`.
-- **SGLang runtime image:** `gfx942` uses
+- **Runtime image:** `gfx942` uses
   `lmsysorg/sglang:v0.5.12-rocm720-mi30x`; `gfx950` uses
   `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705`. The runner selects from
   `target_gpu_model` for experiment runs and from the visible host GPU for shell
   and smoke commands.
+  For `gfx1201`, build the [RDNA4 runtime](../../docker/rdna4/README.md) with
+  `make docker-build-rdna4` before running smoke or experiments.
 - **Git**
 - **Node.js 22+ and npm**, when using the alternative npm installation of Claude
   Code or another npm-installed agent CLI.
@@ -58,6 +60,30 @@ same Docker runtime. See [Run on Slurm/Spur GPU nodes](../how-to/slurm-run.md).
 
 Install and authenticate the agent selected by your configuration before
 starting an experiment; the next section covers the first-class host CLIs.
+
+### RDNA4 (`gfx1201`)
+
+The RDNA4 image normalizes the upstream Python and ROCm SDK paths so the same
+runner can execute as the host user. Build it explicitly on the GPU host:
+
+```bash
+make docker-build-rdna4
+make docker-smoke
+```
+
+After installing and authenticating Claude Code, use:
+
+```bash
+CONFIG_PATH=example_configs/quickstart_claude_rdna4.yaml
+make docker-check-agents CONFIG="$CONFIG_PATH"
+make docker-run CONFIG="$CONFIG_PATH"
+```
+
+The smoke check requires `rocprofv3` on `gfx1201`; the CDNA profiler requirement
+is unchanged. See the [image recipe and limitations](../../docker/rdna4/README.md)
+for its pinned base, non-root runtime layout, and task coverage. A successful
+smoke establishes runtime availability, not support for every task or profiler
+analysis of an optimized candidate.
 
 ## Install agent CLIs
 
@@ -97,13 +123,14 @@ their own runtime dependencies. Review the corresponding directory under
 ## Choose an example configuration
 
 Choose the configuration that matches the physical GPU and installed agent.
-The two quickstart configurations each run one GELU task; the benchmark
+The quickstart configurations each run one GELU task; the benchmark
 configuration is a longer 60-task Cursor Agent run.
 
 | Configuration | Purpose |
 | --- | --- |
 | `example_configs/quickstart_claude_mi300.yaml` | First Claude Code run on MI300/MI300X (`gfx942`). |
 | `example_configs/quickstart_claude_mi355x.yaml` | First Claude Code run on MI355X (`gfx950`). |
+| `example_configs/quickstart_claude_rdna4.yaml` | First Claude Code run on RDNA4 (`gfx1201`); build its runtime first. |
 | `example_configs/benchmark_cursor_mi355x.yaml` | Curated 60-task Cursor Agent benchmark on MI355X; requires an installed and authenticated Cursor Agent CLI. |
 
 The default `make docker-run` configuration is the MI300/MI300X quickstart.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -25,8 +25,8 @@ The following prerequisites are required before running AgentKernelArena.
   `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705`. The runner selects from
   `target_gpu_model` for experiment runs and from the visible host GPU for shell
   and smoke commands.
-  For `gfx1201`, build the [RDNA4 runtime](../../docker/rdna4/README.md) with
-  `make docker-build-rdna4` before running smoke or experiments.
+  For `gfx1201`, the runner automatically builds the default
+  [RDNA4 runtime](../../docker/rdna4/README.md) on first use if it is missing.
 - **Git**
 - **Node.js 22+ and npm**, when using the alternative npm installation of Claude
   Code or another npm-installed agent CLI.
@@ -64,13 +64,14 @@ starting an experiment; the next section covers the first-class host CLIs.
 ### RDNA4 (`gfx1201`)
 
 The RDNA4 image normalizes the upstream Python and ROCm SDK paths so the same
-runner can execute as the host user. Build it explicitly on the GPU host:
+runner can execute as the host user. On the GPU host, the first command builds
+the default image if it is missing, then checks the runtime:
 
 ```bash
-make docker-build-rdna4
 make docker-smoke
 ```
 
+You can also start a task directly; its preflight prepares the same image.
 After installing and authenticating Claude Code, use:
 
 ```bash
@@ -78,6 +79,10 @@ CONFIG_PATH=example_configs/quickstart_claude_rdna4.yaml
 make docker-check-agents CONFIG="$CONFIG_PATH"
 make docker-run CONFIG="$CONFIG_PATH"
 ```
+
+Existing images are reused. `make docker-build-rdna4` remains available for
+prebuilding or rebuilding after recipe changes. Explicit image overrides disable
+automatic builds; see the runtime guide for custom image handling.
 
 The smoke check requires `rocprofv3` on `gfx1201`; the CDNA profiler requirement
 is unchanged. See the [image recipe and limitations](../../docker/rdna4/README.md)
@@ -130,7 +135,7 @@ configuration is a longer 60-task Cursor Agent run.
 | --- | --- |
 | `example_configs/quickstart_claude_mi300.yaml` | First Claude Code run on MI300/MI300X (`gfx942`). |
 | `example_configs/quickstart_claude_mi355x.yaml` | First Claude Code run on MI355X (`gfx950`). |
-| `example_configs/quickstart_claude_rdna4.yaml` | First Claude Code run on RDNA4 (`gfx1201`); build its runtime first. |
+| `example_configs/quickstart_claude_rdna4.yaml` | First Claude Code run on RDNA4 (`gfx1201`); builds the default runtime on first use if missing. |
 | `example_configs/benchmark_cursor_mi355x.yaml` | Curated 60-task Cursor Agent benchmark on MI355X; requires an installed and authenticated Cursor Agent CLI. |
 
 The default `make docker-run` configuration is the MI300/MI300X quickstart.

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -13,11 +13,12 @@ Supported and tested hardware, Docker images, software versions, agent CLIs, and
 
 The following hardware configurations are supported and tested.
 
-| AMD Instinct GPU | ROCm version | Notes |
+| AMD GPU | ROCm version | Notes |
 | --- | --- | --- |
 | MI300X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI300X` |
 | MI325X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI325X` |
 | MI355X | 7.2 (Bundled in the selected SGLang image.) | `target_gpu_model: MI355X` |
+| RDNA4 (`gfx1201`, 16 GB tested) | Pinned in the [RDNA4 recipe](../../docker/rdna4/Dockerfile) | `target_gpu_model: RDNA4`; HIP/Triton task runtime checks, with limits in the [recipe guide](../../docker/rdna4/README.md). |
 
 ## Software requirements
 
@@ -27,12 +28,13 @@ The following software versions are required or verified.
 | --- | --- | --- |
 | Linux | Ubuntu 22.04, Ubuntu 24.04 | |
 | hipcc | Matches ROCm image | Required for HIP tasks. |
-| rocprof-compute | Matches ROCm image | Required for HIP performance profiling. |
+| Profiler tools | Match runtime image | Smoke requires `rocprof-compute` on CDNA and `rocprofv3` on `gfx1201`. Tool availability does not establish candidate analysis. |
 | Docker | Current stable release | Required; serial experiments run through `make docker-run`; multi-GPU experiments run through `make docker-parallel-run`. |
 | SGLang runtime image | `lmsysorg/sglang:v0.5.12-rocm720-mi30x` for `gfx942`; `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705` for `gfx950` | The verified `gfx950` digest is `sha256:b435b508b5aa696abb25c909341ce73e41574c4271cf716bed72418dcea86b78`. Override with `AKA_DOCKER_IMAGE`, `AKA_DOCKER_IMAGE_GFX942`, or `AKA_DOCKER_IMAGE_GFX950`. |
-| Python | Provided by the image (for example, 3.10) | Bundled in the SGLang image. |
+| RDNA4 runtime image | [Digest-pinned base and layout adapter](../../docker/rdna4/Dockerfile) | Build with `make docker-build-rdna4`. Override the local build/run tag with `AKA_DOCKER_IMAGE_GFX1201`. |
+| Python | Provided by the image | Bundled in the selected runtime image. |
 | Node.js and npm | Node.js 22 with a current npm | Required on the host only for the alternative npm installation of Claude Code or another npm-installed agent CLI. |
-| PyTorch | ROCm build bundled in the image | Provided by the SGLang Docker image. |
+| PyTorch | ROCm build bundled in the image | Provided by the selected runtime image. |
 | Triton | Bundled with the image's ROCm PyTorch | Required for Triton task categories. |
 | AITER | `0.1.17.dev110+g9127c94a1` in the verified `gfx950` image | Required by AITER-backed task oracles and kernels. |
 | FlyDSL | `0.2.2` in the verified `gfx950` image (or `make docker-setup-flydsl` when absent) | Required for `flydsl2flydsl`, `torch2flydsl`, and `triton2flydsl` tasks. |
@@ -48,6 +50,7 @@ FlyDSL, and AITER versions in the preceding table remain unchanged.
 | --- | --- | --- |
 | `gfx950` (MI355X) | Runtime-qualified, candidate-dependent | Pinned image/build locks and all six integrated startup controls pass on the current hardware. End-to-end readiness still depends on language, artifact, adapter, and candidate attestation. Waitcheck and ConSan are qualified only for explicitly configured advisory pilots. Trusted single-dispatch Triton/FlyDSL rocJITsu capsule replay is implemented, but automatic evaluator-owned capsule capture and binding to the correctness run remain advisory-only gaps. |
 | `gfx942` (MI300X/MI325X) | Unverified | No equivalent image/adapter/positive-control qualification has completed; the host runner currently rejects evaluation-tool sidecars. |
+| `gfx1201` (RDNA4) | Unverified | Runtime task checks do not qualify evaluation-tool sidecars; the host runner rejects them. |
 
 The runtime base digest and per-tool package/source locks are recorded in
 `docker/eval-tools/images.lock.yaml`. See [Check kernels with evaluation

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -89,4 +89,4 @@ configure a provider.
 | OpenAI | Use a selected integration or CLI configured for OpenAI. |
 | Anthropic | Use a selected integration or CLI configured for Anthropic. |
 | OpenRouter or another OpenAI-compatible service | Supported when the selected integration accepts a custom provider/base URL. |
-| Local vLLM | `make vllm` starts an OpenAI-compatible endpoint on port `30001`; configure the selected integration to use it. |
+| Local vLLM | `make vllm` uses a separate serving image to launch an OpenAI-compatible endpoint on port `30001`; configure the selected integration to use it. This serving path is unverified on RDNA4; the [RDNA4 kernel-runtime checks](../../docker/rdna4/README.md#validation-and-limits) do not establish full vLLM serving support. |

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -31,7 +31,7 @@ The following software versions are required or verified.
 | Profiler tools | Match runtime image | Smoke requires `rocprof-compute` on CDNA and `rocprofv3` on `gfx1201`. Tool availability does not establish candidate analysis. |
 | Docker | Current stable release | Required; serial experiments run through `make docker-run`; multi-GPU experiments run through `make docker-parallel-run`. |
 | SGLang runtime image | `lmsysorg/sglang:v0.5.12-rocm720-mi30x` for `gfx942`; `lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705` for `gfx950` | The verified `gfx950` digest is `sha256:b435b508b5aa696abb25c909341ce73e41574c4271cf716bed72418dcea86b78`. Override with `AKA_DOCKER_IMAGE`, `AKA_DOCKER_IMAGE_GFX942`, or `AKA_DOCKER_IMAGE_GFX950`. |
-| RDNA4 runtime image | [Digest-pinned base and layout adapter](../../docker/rdna4/Dockerfile) | Build with `make docker-build-rdna4`. Override the local build/run tag with `AKA_DOCKER_IMAGE_GFX1201`. |
+| RDNA4 runtime image | [Digest-pinned base and layout adapter](../../docker/rdna4/Dockerfile) | Default image builds on first use if missing; `make docker-build-rdna4` prebuilds or rebuilds it. Image overrides disable automatic builds; see the [runtime guide](../../docker/rdna4/README.md). |
 | Python | Provided by the image | Bundled in the selected runtime image. |
 | Node.js and npm | Node.js 22 with a current npm | Required on the host only for the alternative npm installation of Claude Code or another npm-installed agent CLI. |
 | PyTorch | ROCm build bundled in the image | Provided by the selected runtime image. |

--- a/example_configs/quickstart_claude_rdna4.yaml
+++ b/example_configs/quickstart_claude_rdna4.yaml
@@ -1,0 +1,10 @@
+# First run on RDNA4 gfx1201. Build the runtime with make docker-build-rdna4.
+agent:
+  template: claude_code
+
+tasks:
+  - hip2hip/gpumode/GELU
+
+target_gpu_model: RDNA4
+log_directory: logs
+workspace_directory_prefix: workspace

--- a/example_configs/quickstart_claude_rdna4.yaml
+++ b/example_configs/quickstart_claude_rdna4.yaml
@@ -1,4 +1,4 @@
-# First run on RDNA4 gfx1201. Build the runtime with make docker-build-rdna4.
+# First run on RDNA4 gfx1201. The default runtime builds on first use if missing.
 agent:
   template: claude_code
 

--- a/src/prompts/cheatsheet/RDNA4_architecture.md
+++ b/src/prompts/cheatsheet/RDNA4_architecture.md
@@ -1,86 +1,70 @@
-# AMD RDNA 4 (gfx1201) Kernel Optimization Context & Directives
+# AMD RDNA 4 (gfx1201) Kernel Optimization Context
 
-## 1. Role & Objective
-You are an expert AMD GPU Kernel Engineer. Your objective is to generate, optimize, and debug HIP/ROCm C++ kernels for AMD RDNA 4 GPUs (gfx1201 architecture, e.g. Radeon RX 9070 series). Your optimizations must adhere to the execution models, memory hierarchies, and hardware limits detailed below.
+This guide targets AKA's `RDNA4` configuration (`gfx1201`). The architecture
+token identifies an instruction set, not a board's VRAM capacity, clock rate,
+cache capacity, or enabled compute-unit count. Read the actual device properties;
+do not assume that every gfx1201 device has the specifications of an RX 9070 XT
+or a Radeon AI PRO R9700.
 
-**Critical difference from CDNA (MI300/MI350):** RDNA is a fundamentally different architecture from CDNA. Do NOT assume CDNA behaviors (XCDs, MFMA, Wave64-default, unified CPU-GPU memory, multi-chiplet NUMA). RDNA uses a different wavefront size, cache hierarchy, and compute model.
+## Execution and resource limits
 
-## 2. Execution Model & Compute Topology
+- The normal HIP/Triton configuration here uses **wave32**. LLVM also supports
+  wave64 for this target. Use the compiled wave size and HIP `warpSize` when
+  reasoning about lane operations; do not transplant wave64 reductions or masks.
+- A WGP contains two CUs, each with two SIMD32 units. Occupancy is accounted for
+  **per SIMD**, with up to 16 resident wave32 waves per SIMD. Keep SIMD, CU, and
+  WGP units explicit when comparing compiler reports and device APIs.
+- VGPR allocation, LDS allocation, block size, and wave size jointly constrain
+  residency. Use compiler resource reports and occupancy APIs for the actual
+  kernel. A universal threshold such as "fewer than 96 VGPRs" is not a reliable
+  optimization rule; higher occupancy is not always faster.
+- WGP LDS capacity is not a single workgroup's allocation budget. The tested
+  gfx1201 runtime exposes **64 KiB per workgroup**. Query `sharedMemPerBlock`
+  and account for both static and dynamic allocations before choosing tiles.
+- Check available VRAM before experiments. An allocation failure does not
+  authorize reducing the task's required shapes or skipping correctness cases.
 
-* **Wavefront:** RDNA uses **Wave32** by default (32 work-items per wavefront). Wave64 is available as a compatibility mode but runs as two Wave32 operations internally. When using cross-lane operations, assume a size of 32 unless explicitly using Wave64 mode.
-* **Workgroup:** Composed of multiple Wave32s. Maximum workgroup size is 1024 work-items.
-* **Work Group Processor (WGP):** The fundamental compute block in RDNA, replacing the CU concept from CDNA. Each WGP contains 2 compute units sharing resources.
-* **Compute Unit (CU):** Each CU within a WGP has 2 SIMD32 units. The full GPU has 32 WGPs (64 CUs).
-* **No XCDs:** RDNA 4 is a monolithic die — there is no multi-chiplet topology, no inter-XCD concerns, no NUMA partitioning.
+The [LLVM target guide](https://llvm.org/docs/AMDGPUUsage.html#processors)
+documents wave-size target features. AMD's
+[occupancy guide](https://gpuopen.com/learn/occupancy-explained/) explains SIMD
+residency and the distinction between occupancy and performance.
 
-## 3. Memory Hierarchy & Locality Rules
+## Matrix instructions and numeric formats
 
-### 3.1 Memory Specifications
-* **LDS (Local Data Share):** **128 KB per WGP** (shared between the 2 CUs in a WGP, effectively 64 KB per CU).
-  * *Rule:* LDS has 32 banks. Pad shared arrays to avoid bank conflicts, same as CDNA.
-  * *Difference:* LDS is shared at the WGP level, not CU level. Two workgroups on the same WGP share the 128 KB pool.
-* **L0 Cache (Vector Cache):** 32 KB per CU. This is the closest cache to the SIMD units.
-* **L1 Cache:** 256 KB per WGP (shared instruction + data cache). Significantly larger than CDNA's per-CU L1.
-* **L2 Cache:** 4 MB shared across the entire GPU (not per-XCD as in CDNA).
-* **Infinity Cache (L3):** 32 MB. Much smaller than CDNA's 256 MB — do not rely on it for large working sets.
-* **GDDR6 (Global Memory):** 16 GB capacity, ~640 GB/s peak bandwidth (256-bit bus with 20 Gbps GDDR6).
-  * *Critical:* RDNA4 has ~8x less memory bandwidth than MI300X (5.3 TB/s). Kernels that were compute-bound on MI300X may be memory-bound on RDNA4. Minimize global memory traffic aggressively.
+RDNA4 uses **WMMA**, not the CDNA MFMA instruction family. Its hardware matrix
+capabilities include FP16, BF16, FP8/BF8, and integer formats including INT8 and
+INT4. INT4 support does not imply native FP4 or arbitrary mixed-format support.
+See AMD's [RDNA4 WMMA guide](https://gpuopen.com/learn/accelerating_generative_ai_on_amd_radeon_gpus/)
+for instruction rates and examples.
 
-### 3.2 Memory Optimization Directives
-1. **Memory bandwidth is precious:** With ~640 GB/s vs MI300X's 5.3 TB/s, reducing memory traffic is the #1 optimization priority. Fuse operations, use LDS aggressively, and minimize global memory round-trips.
-2. **Coalesced Access:** Global memory accesses must be coalesced. Ensure adjacent work-items in a Wave32 access contiguous memory. Align buffers to 128 bytes.
-3. **Vector Loads:** Use `float4`, `uint4`, `half2` to widen memory transactions. This is even more critical on RDNA due to limited bandwidth.
-4. **Infinity Cache is small:** At 32 MB, the L3 cache cannot hold large working sets. Design tile sizes to fit in L2 (4 MB) or LDS (128 KB per WGP).
+Hardware support and compiler/library support are separate. Validate the exact
+input format, accumulator type, layout, and shape with the installed toolchain;
+inspect generated code before claiming a WMMA path. RDNA4 HIP WMMA intrinsics
+use gfx12-specific signatures and layouts. Do not copy RDNA3 intrinsics or
+CDNA FP8/MFMA code unchanged. Floating-point reassociation, lower precision, and
+fast-math options must still satisfy the task's original correctness contract.
 
-## 4. Compute Units — No Matrix Cores (MFMA)
+## Memory and launch tuning
 
-**RDNA 4 does NOT have MFMA (Matrix Fused Multiply-Add) instructions.** Do not use `__builtin_amdgcn_mfma_*` intrinsics — they will fail to compile.
+Coalesce neighboring lanes' accesses and preserve alignment and tail handling
+when vectorizing. Stage reused data through LDS only when the saved traffic
+outweighs synchronization and occupancy costs. Cache sizes and bandwidth vary
+by product; measure locality benefits rather than assuming a fixed cache-line
+size or a universal cache-resident working-set limit.
 
-* **WMMA (Wave Matrix Multiply-Accumulate):** RDNA 4 supports WMMA instructions for matrix operations, which operate at the Wave32 level. Use `__builtin_amdgcn_wmma_*` intrinsics or rocWMMA wrappers.
-* **Supported WMMA data types:** FP16, BF16, INT8.
-* **No FP8/FP6/FP4 matrix acceleration:** Unlike CDNA 4 (MI355X), RDNA 4 does not support sub-byte matrix types in hardware.
-* **For non-matrix workloads:** Use standard VALU (vector ALU) operations. RDNA 4 has strong FP32 and FP16 throughput through its SIMD32 units.
+Check whether a device API's multiprocessor count denotes CUs or WGPs for the
+installed runtime. Do not blindly multiply that count or hardcode a full-chip
+CU count into a persistent grid. Sweep launch geometry under the task's
+unchanged benchmark policy.
 
-## 5. RDNA-Specific Optimizations
+## Profiling and task integrity
 
-### Wavefront size
-* Default is **Wave32**. This means:
-  - Shuffle/permute operations span 32 lanes, not 64
-  - `__ballot()` returns a 32-bit mask
-  - Reductions need fewer steps (5 vs 6 for power-of-2 reduction)
-  - Better occupancy potential: more wavefronts fit per CU with smaller wavefronts
+Use `rocprofv3` for HIP/kernel tracing in the configured runtime. Tracing
+provides dispatch durations and API activity; it does not by itself collect
+occupancy, cache-hit, or matrix-utilization counters. Counter availability
+depends on the GPU and installed profiler. See the language guides for commands.
+The presence of a profiler does not qualify AKA evaluation-tool sidecars.
 
-### Occupancy
-| Resource per CU | RDNA 4 limit |
-|-----------------|--------------|
-| Wavefronts      | 16 (Wave32)  |
-| VGPRs           | 1536 total   |
-| SGPRs           | 512 total    |
-| LDS             | 64 KB (128 KB per WGP) |
-
-* Target VGPR usage < 96 per thread for good occupancy.
-* Use `__attribute__((amdgpu_waves_per_eu(4, 8)))` to hint occupancy.
-
-### Scalar ALU
-RDNA has a more capable scalar unit than CDNA. Uniform operations (loop counters, base pointers, conditions that are the same across all lanes) run on the SALU for free. Structure code to keep uniform work in scalar registers.
-
-## 6. Strict Kernel Generation Constraints
-1. **Wave32 default:** Write kernels assuming Wave32 unless explicitly targeting Wave64 compatibility mode.
-2. **No MFMA:** Never use MFMA intrinsics. Use WMMA or standard vector ALU.
-3. **Register pressure:** Keep VGPR usage bounded. RDNA 4 has 1536 VGPRs per CU — spilling is expensive.
-4. **`__launch_bounds__`:** Use to control occupancy. Prefer `__launch_bounds__(256, 4)` as a starting point.
-5. **LDS bank conflicts:** Same 32-bank structure as CDNA. Pad shared arrays with +1 technique.
-6. **No unified CPU-GPU memory:** Unlike MI300X, there is no unified memory pool. Explicit `hipMemcpy` or `hipMallocManaged` with prefetch is required.
-7. **PCIe bandwidth:** Host-device transfer goes over PCIe (not Infinity Fabric). Use pinned memory and async copies.
-
-## 7. Compilation
-
-```bash
-hipcc -O3 \
-      --offload-arch=gfx1201 \
-      -ffast-math \
-      kernel.cpp -o kernel
-```
-
-* `--offload-arch=gfx1201` is required for RDNA 4.
-* Do NOT use `gfx942` (MI300X) or `gfx950` (MI355X) — wrong architecture.
+Keep profiling separate from scoreable timing. Honor `platform_support` and
+protected harness boundaries; a conflicting architecture requirement or
+unsupported API is a compatibility issue to report, not a guard to bypass.

--- a/src/prompts/cheatsheet/hip_rdna_cheatsheet.md
+++ b/src/prompts/cheatsheet/hip_rdna_cheatsheet.md
@@ -1,247 +1,82 @@
-# HIP Kernel Best Practices for RDNA GPUs
+# HIP Kernel Best Practices for RDNA4 (gfx1201)
 
-Reference: [HIP documentation](https://rocm.docs.amd.com/projects/HIP/en/latest/) | [RDNA ISA](https://gpuopen.com/amd-isa-documentation/)
+Use the accompanying architecture context for device limits. These are tuning
+directions to measure, not guarantees of speedup.
 
----
+## Wave operations and launch geometry
 
-## 1. Memory Access — Coalescing
+Use HIP `warpSize` for lane arithmetic. The normal configuration is wave32;
+block sizes such as 64, 128, and 256 are starting points to benchmark, not
+mandatory choices. Tail lanes must participate correctly in barriers and
+collectives.
 
-RDNA GPUs access global memory in 64-byte cache lines. A wavefront of 32 threads fetches optimally when consecutive threads access consecutive addresses.
+HIP `__ballot()` and `__activemask()` return **64-bit** values even on wave32.
+Keep their declared mask types instead of inferring a 32-bit C++ return type
+from the number of active lanes. `_sync` operations require consistent masks
+and participation. See the
+[HIP warp-function contract](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_cpp_language_extensions.html#warp-cross-lane-functions).
 
-**Good — coalesced:**
-```cpp
-float val = a[blockDim.x * blockIdx.x + threadIdx.x];
-```
+Use `hipOccupancyMaxActiveBlocksPerMultiprocessor` or
+`hipOccupancyMaxPotentialBlockSize` to explore the compiled kernel's resource
+limits. Tune block size and work per thread together. Register counts reported
+per thread, physical registers per SIMD, and waves per CU are different units;
+do not insert them into the same occupancy formula.
 
-**Bad — strided:**
-```cpp
-float val = a[threadIdx.x * N];
-```
+## Memory, LDS, and register pressure
 
-Rules:
-- Prefer Structure-of-Arrays (SoA) over Array-of-Structures (AoS).
-- Device allocations from `hipMalloc` already satisfy device-allocation alignment requirements. Use `hipMallocPitch` for pitch-aware 2D layouts, and explicit alignment attributes only for host/static objects when needed.
-- Use vector loads (`float4`, `half2`, `uint4`) to widen memory transactions. This is critical on RDNA due to lower bandwidth (~640 GB/s GDDR6).
+- Make adjacent lanes access adjacent elements where the task layout permits.
+  Vector loads can reduce instruction count, but require valid alignment,
+  in-bounds tails, and enough registers. They are not automatically faster.
+- Reuse data in registers or LDS when useful. Include static and dynamic LDS
+  in the device's per-workgroup limit. Padding or swizzling can reduce bank
+  conflicts, but the extra storage can reduce occupancy.
+- Inspect compiler resource metadata and scratch usage when changing tile
+  sizes or unrolling. An `s_load_dword` or `v_readlane` instruction alone is
+  not evidence of spilling. Compare the full compiled resource report.
+- Uniform control flow can reduce divergence; scalar instructions still have
+  cost. Do not assume predicated arithmetic always beats a branch.
+- Block-local aggregation can reduce global atomic contention when it preserves
+  the required semantics. Reordered floating-point sums must pass the original
+  tolerances. Do not change output dtype merely to save bandwidth.
 
----
+Pinned host buffers and asynchronous copies can help transfer-heavy workloads.
+They do not improve a device-only score unless those transfers are inside the
+declared measurement boundary. Preserve that boundary for both implementations.
 
-## 2. Occupancy and Wavefront Management
+## Matrix operations and compilation
 
-RDNA defaults to **Wave32** (32 threads per wavefront). Each CU can schedule up to 16 Wave32 wavefronts. High occupancy hides memory latency.
+Use WMMA-capable implementations for supported matrix shapes and types. RDNA4
+has FP8/BF8 and INT4 hardware matrix operations as well as FP16/BF16/INT8;
+actual availability through HIP wrappers depends on the installed stack.
+AMD's [WMMA examples](https://gpuopen.com/learn/accelerating_generative_ai_on_amd_radeon_gpus/)
+show the gfx12 intrinsic suffix and changed fragment layout. Do not substitute
+MFMA intrinsics or assume an RDNA3 fragment layout is compatible.
 
-### Controlling occupancy
-```cpp
-__attribute__((amdgpu_waves_per_eu(4, 8)))
-__global__ void myKernel(...) { ... }
-
-__attribute__((amdgpu_flat_work_group_size(64, 256)))
-__global__ void myKernel(...) { ... }
-```
-
-### Key occupancy limits (RDNA 4, gfx1201)
-| Resource per CU | Limit |
-|-----------------|-------|
-| Wavefronts      | 16 (Wave32) |
-| VGPRs           | 1536 total |
-| SGPRs           | 512 total |
-| LDS             | 64 KB (128 KB per WGP) |
-
-- Block size should be a multiple of 32 (wavefront width). 64 or 128 are good starting points.
-- Prefer 128–256 threads/block; tune with `hipOccupancyMaxPotentialBlockSize`.
-- Target VGPR usage < 96 per thread for good occupancy.
-
----
-
-## 3. LDS (Local Data Share / Shared Memory)
-
-LDS provides ~100x faster bandwidth than global memory. Each WGP has 128 KB (64 KB per CU).
-
-```cpp
-__global__ void tiled_gemm(const float* A, const float* B, float* C,
-                            int M, int N, int K) {
-    constexpr int TILE = 16;
-    __shared__ float As[TILE][TILE];
-    __shared__ float Bs[TILE][TILE];
-
-    int tx = threadIdx.x, ty = threadIdx.y;
-    float acc = 0.f;
-
-    for (int t = 0; t < K / TILE; ++t) {
-        As[ty][tx] = A[(blockIdx.y * TILE + ty) * K + t * TILE + tx];
-        Bs[ty][tx] = B[(t * TILE + ty) * N + blockIdx.x * TILE + tx];
-        __syncthreads();
-
-        for (int k = 0; k < TILE; ++k)
-            acc += As[ty][k] * Bs[k][tx];
-        __syncthreads();
-    }
-    C[(blockIdx.y * TILE + ty) * N + blockIdx.x * TILE + tx] = acc;
-}
-```
-
-**Avoid bank conflicts:** LDS has 32 banks (4-byte each). Threads within a wavefront that map to the same bank serialize. Pad shared arrays:
-```cpp
-__shared__ float tile[TILE][TILE + 1]; // +1 avoids 32-way conflict
-```
-
----
-
-## 4. Register Pressure and Spilling
-
-Each CU has 1536 VGPRs total. High register usage per thread reduces maximum wavefronts. Register spilling to scratch memory adds ~500 cycle latency.
-
-**Check register usage:**
-```bash
-hipcc -O3 --save-temps --offload-arch=gfx1201 kernel.cpp
-# Read the .s assembly for v_readlane / s_load_dword (spill indicators)
-```
-
-**Reduce registers:**
-- Break large kernels into smaller ones.
-- Use `__attribute__((noinline))` on helper functions to prevent excessive inlining.
-- Replace temporary arrays with reduction trees.
-- Accumulate in `float` but store in `half` when precision allows.
-
----
-
-## 5. Divergent Branching
-
-Within a Wave32, divergent branches cause both paths to execute serially with masking.
-
-```cpp
-// Bad: half the wavefront idles each branch
-if (threadIdx.x % 2 == 0)
-    doA();
-else
-    doB();
-
-// Better: use predicated arithmetic
-float result = cond ? a : b;    // compiles to v_cndmask
-```
-
-- Hoist loop-invariant conditionals above the loop.
-- RDNA has a strong scalar ALU — uniform conditions (e.g., `blockIdx.x == 0`) run on the SALU for free. Only per-thread vector conditions cause divergence.
-
----
-
-## 6. Atomic Operations
-
-Global atomics stall the wavefront. Prefer LDS-local atomics, then reduce to global.
-
-```cpp
-__shared__ int local_sum;
-if (threadIdx.x == 0) local_sum = 0;
-__syncthreads();
-
-atomicAdd(&local_sum, thread_val);    // fast LDS atomic
-__syncthreads();
-
-if (threadIdx.x == 0)
-    atomicAdd(global_sum, local_sum); // one global atomic per block
-```
-
-Use `__hip_atomic_fetch_add` with `__HIP_MEMORY_SCOPE_WORKGROUP` for workgroup-scoped atomics.
-
----
-
-## 7. Async Copies and Streams
-
-Overlap host-device transfers with kernel execution using multiple streams:
-
-```cpp
-hipStream_t stream[2];
-hipStreamCreate(&stream[0]);
-hipStreamCreate(&stream[1]);
-
-for (int i = 0; i < N; i += CHUNK) {
-    int s = i / CHUNK % 2;
-    hipMemcpyAsync(d_in + i, h_in + i, CHUNK * sizeof(float),
-                   hipMemcpyHostToDevice, stream[s]);
-    myKernel<<<grid, block, 0, stream[s]>>>(d_in + i, d_out + i, CHUNK);
-    hipMemcpyAsync(h_out + i, d_out + i, CHUNK * sizeof(float),
-                   hipMemcpyDeviceToHost, stream[s]);
-}
-hipDeviceSynchronize();
-```
-
-Use pinned host memory (`hipHostMalloc`) for maximum PCIe transfer bandwidth.
-
----
-
-## 8. RDNA-Specific Optimizations
-
-### Wave32 advantages
-- Shuffle/permute operations span 32 lanes (fewer steps for reductions)
-- `__ballot()` returns a 32-bit mask
-- More wavefronts fit per CU, improving latency hiding
-- Cross-lane operations are faster (smaller wavefront)
-
-### No MFMA — use WMMA or vector ALU
-- **Do NOT** use `__builtin_amdgcn_mfma_*` intrinsics — they do not exist on RDNA.
-- RDNA 4 supports **WMMA** (Wave Matrix Multiply-Accumulate) via `__builtin_amdgcn_wmma_*` or rocWMMA.
-- For non-matrix workloads, use standard vector ALU operations. RDNA 4 has strong FP32/FP16 throughput.
-
-### Memory bandwidth is the bottleneck
-- RDNA 4 has ~640 GB/s GDDR6 (vs 5.3 TB/s HBM3 on MI300X).
-- Kernels that were compute-bound on CDNA may become memory-bound on RDNA.
-- Minimize global memory traffic: fuse operations, use LDS aggressively, use vector loads.
-
-### No unified CPU-GPU memory
-- Use explicit `hipMemcpy` or `hipMallocManaged` with prefetch.
-- Host-device transfer goes over PCIe, not Infinity Fabric.
-
-### Smaller Infinity Cache
-- 32 MB L3 (vs 256 MB on MI300X). Do not rely on it for large working sets.
-- Size tiles to fit in L2 (4 MB) or LDS (128 KB per WGP).
-
----
-
-## 9. Profiling
+For a standalone diagnostic kernel, compile for the actual target:
 
 ```bash
-# Basic counter collection
-rocprof --stats --hip-trace my_app
-
-# rocprofv3 counter collection
-rocprofv3 --hip-trace --kernel-trace -- ./my_app
+hipcc -O3 --offload-arch=gfx1201 --save-temps -c kernel.hip -o kernel.o
 ```
 
-Key metrics to watch:
-| Metric | Healthy range |
-|--------|--------------|
-| Wavefront occupancy | > 50% of max |
-| L2 cache hit rate | > 80% for reuse-heavy kernels |
-| Memory bandwidth utilization | > 70% of peak for bandwidth-bound kernels |
-| VGPR usage | < 96 per thread (for good occupancy) |
-| LDS bank conflicts | 0 |
+Use the task's declared build commands for evaluation. Add fast-math, launch
+bounds, or unrolling only after checking their effect on correctness and
+resource usage. Do not rewrite protected build/test files to force a result.
 
----
+## Profiling
 
-## 10. Compilation Flags
+Inside the AKA runtime, use a separate diagnostic run of your application:
 
 ```bash
-hipcc -O3 \
-      --offload-arch=gfx1201 \
-      -mllvm -amdgpu-function-calls=0 \  # inline device functions
-      -ffast-math \
-      kernel.cpp -o kernel
+rocprofv3 --hip-trace --kernel-trace --output-format csv -- ./my_app
 ```
 
-- `--offload-arch=gfx1201` is required for RDNA 4. Do NOT use `gfx942` (MI300X) or `gfx950` (MI355X).
-- `-O3` enables loop unrolling and vectorization.
-- Avoid `-g` in production; it disables many optimizations.
+This collects HIP API and kernel traces, **not hardware counters**. Inspect
+kernel durations and dispatch counts first. Query available counters with
+`rocprofv3 --list-avail`; support and prerequisites are version/device dependent.
+Do not assume `rocprof-compute`/Omniperf support from the executable's presence,
+or infer cache hit rate or WMMA utilization from timing alone. The
+[rocprofv3 guide](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/docs-7.14.0/how-to/using-rocprofv3.html)
+describes tracing versus counter collection and RDNA counter prerequisites.
 
----
-
-## 11. Quick Checklist
-
-- [ ] Access pattern is coalesced (SoA layout, 128-byte alignment)
-- [ ] Block size is a multiple of 32 (Wave32 width)
-- [ ] Shared memory tile avoids bank conflicts (pad by 1)
-- [ ] Register count < 96 VGPRs/thread (verify with `--save-temps`)
-- [ ] No divergent branches in inner loops
-- [ ] Atomics use LDS-local reduction before global write
-- [ ] Streams overlap compute and data transfer
-- [ ] WMMA used for matrix workloads (not MFMA)
-- [ ] Global memory traffic minimized (fuse ops, vector loads)
-- [ ] Kernels profiled with rocprof/rocprofv3 to identify bottleneck
+Profiling can perturb execution. Collect scored performance separately with
+the original harness, warmups, samples, synchronization, and state resets.

--- a/src/prompts/cheatsheet/triton_rdna_cheatsheet.md
+++ b/src/prompts/cheatsheet/triton_rdna_cheatsheet.md
@@ -1,246 +1,88 @@
-# Triton Kernel Best Practices for RDNA GPUs
+# Triton Kernel Best Practices for RDNA4 (gfx1201)
 
-Reference: [Triton documentation](https://triton-lang.org/main/) | [Python API](https://triton-lang.org/main/python-api/triton.language.html) | [ROCm Triton](https://github.com/ROCm/triton)
-
----
-
-## 1. Block / Tile Size Selection and Autotuning
-
-On RDNA, Triton's `num_warps` multiplies by **32 threads per warp** (Wave32), not 64 as on CDNA. A kernel with `num_warps=4` dispatches 128 threads per program instance; the same value on MI300 dispatches 256 threads. Expect different occupancy trade-offs.
+Use the accompanying architecture context for hardware limits. Check the
+installed backend before tuning; compiler support evolves independently of
+the hardware instruction set.
 
 ```python
 import triton
-import triton.language as tl
-
-@triton.autotune(
-    configs=[
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32}, num_warps=8, num_stages=2),
-        triton.Config({'BLOCK_M': 64,  'BLOCK_N': 128, 'BLOCK_K': 32}, num_warps=4, num_stages=2),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64,  'BLOCK_K': 32}, num_warps=4, num_stages=2),
-        triton.Config({'BLOCK_M': 64,  'BLOCK_N': 64,  'BLOCK_K': 64}, num_warps=4, num_stages=1),
-    ],
-    key=['M', 'N', 'K'],
-)
-@triton.jit
-def matmul_kernel(A, B, C, M, N, K, ...):
-    ...
+target = triton.runtime.driver.active.get_current_target()
+print(target)  # Confirm arch='gfx1201' and warp_size=32 for this configuration.
 ```
 
-Guidelines:
-- Start with `BLOCK_M = BLOCK_N = 128`, `BLOCK_K = 32`. `BLOCK_K = 64` may spill on RDNA due to the smaller VGPR budget per CU.
-- Prefer `num_warps ∈ {2, 4, 8}`. Wave32 means even small `num_warps` values dispatch full wavefronts cleanly.
-- `num_stages = 1` or `2` on RDNA. Deeper pipelines rarely help because RDNA's L1/L0 caches are smaller than CDNA's L2.
-- Keep BLOCK sizes powers of 2 and divisible by 16 (required by WMMA instruction tiling).
+## Launch geometry and resource usage
 
----
+On the wave32 configuration, `num_warps=4` represents 128 threads per program,
+rather than the 256 threads of a wave64 configuration. Re-tune `num_warps`, tile
+shape, and pipeline stages together when moving a kernel from CDNA.
 
-## 2. Memory Access Patterns and Vectorization
+For matrix kernels, tiles with M/N dimensions of 32 or 64 and `num_warps` of 4
+or 8 are useful initial candidates; expand the search as the workload warrants.
+These are not universal optima. Larger tiles may improve reuse while consuming
+more accumulator registers or LDS. A reduction in `num_warps` does not by
+itself guarantee more resident programs or better performance.
 
-RDNA 4 has ~640 GB/s GDDR6 bandwidth vs MI300X's 5.3 TB/s HBM3 — memory bandwidth is the primary bottleneck. Squeeze every byte.
+Inspect generated kernel metadata, including registers, spills, and shared
+memory. Keep shared memory within the actual per-workgroup limit; the WGP's
+aggregate LDS capacity is not the launch budget. Choose pipeline depth based
+on generated code and measured performance rather than importing a CDNA preset.
 
-```python
-@triton.jit
-def kernel(X, Y, N: tl.constexpr, BLOCK: tl.constexpr):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
+## Matrix lowering and numeric formats
 
-    # Masked load: safe for non-power-of-2 N
-    mask = offs < N
-    x = tl.load(X + offs, mask=mask, other=0.0)
+RDNA4 uses WMMA for supported matrix operations. Hardware supports FP8/BF8 as
+well as FP16/BF16 and integer matrix types; it is incorrect to declare FP8
+universally unavailable on gfx1201. See AMD's
+[RDNA4 WMMA overview](https://gpuopen.com/learn/accelerating_generative_ai_on_amd_radeon_gpus/).
 
-    tl.store(Y + offs, x, mask=mask)
-```
+`tl.dot` support depends on the exact dtype pair, accumulator, shape, layout,
+and installed compiler. Compile and validate that combination, then inspect
+the generated AMD assembly for the expected instructions. Unsupported cases
+can fail compilation; do not assume a silent or correct scalar fallback.
+Hardware INT4 support alone also does not establish support for a mixed-format
+or block-scaled Triton operation.
 
-- Use `tl.multiple_of(ptr, 16)` and `tl.max_contiguous(ptr, 16)` so Triton emits 128-bit (`dwordx4`) loads.
-- Prefer `float16` / `bfloat16` for compute to double effective bandwidth; accumulate in `float32` via `tl.dot(..., out_dtype=tl.float32)`.
-- Use `eviction_policy="evict_last"` for streaming data (read-once) so you don't pollute the small L2 (4 MB on gfx1201).
-- Fuse elementwise ops into the same kernel whenever possible — every round-trip to GDDR6 is expensive.
+Do not force CDNA MFMA layouts or carry over MFMA tuning controls such as
+`matrix_instr_nonkdim` without checking their meaning in the installed AMD
+backend. Follow the compiler's shape constraints, mask problem tails, and
+retain the task's input/output dtypes and numerical tolerances. See the
+[Triton dot API](https://triton-lang.org/main/python-api/generated/triton.language.dot.html).
 
----
+## Memory and reductions
 
-## 3. `tl.dot` on RDNA: WMMA, not MFMA
+- Coalesce lanes' accesses. Use `tl.multiple_of` and `tl.max_contiguous` only
+  when the asserted alignment and contiguity are true for every relevant case;
+  false compiler hints can produce incorrect code.
+- Mask out-of-bounds loads and stores. For reductions, use neutral values for
+  masked lanes, such as negative infinity for a maximum before softmax.
+- Fuse work when it saves traffic without excessive registers, synchronization,
+  or recomputation. Do not change precision to manufacture bandwidth gains.
+- Leave cache policy at its default until measurements justify a change. Do
+  not prescribe `evict_last` for all read-once data; eviction hints are backend
+  dependent and must match actual reuse. See the
+  [Triton load API](https://triton-lang.org/main/python-api/generated/triton.language.load.html).
+- A row that fits comfortably in registers may suit a single-program reduction.
+  Large rows can spill; compare appropriate decompositions rather than assuming
+  that all reductions should remain in registers. Preserve stable softmax
+  math, including max subtraction and safe handling of task-defined edge cases.
+- Autotuning candidates must preserve state between trials for mutating kernels.
+  Follow the existing harness's reset and timing policy.
 
-On RDNA 4, `tl.dot` lowers to **WMMA** (Wave Matrix Multiply-Accumulate) instructions, not MFMA. The instruction tiling and dtype support differ from CDNA.
+## Profiling and measurement
 
-```python
-# Tiled GEMM inner loop (works on both CDNA and RDNA)
-a = tl.load(A + ...)                              # [BLOCK_M, BLOCK_K], float16 or bf16
-b = tl.load(B + ...)                              # [BLOCK_K, BLOCK_N], float16 or bf16
-acc = tl.dot(a, b, acc, out_dtype=tl.float32)     # accumulate in fp32
-```
-
-Rules and differences vs MI300:
-- **Supported dtypes**: `tl.dot` on gfx1201 supports `fp16 × fp16 → fp32`, `bf16 × bf16 → fp32`, and `int8 × int8 → int32`. FP8 `tl.dot` is **not** supported on gfx1201 (MI300/MI350 only).
-- **Tile shapes**: WMMA uses 16×16×16 tiles. Both inputs must have shapes divisible by 16 in all dimensions.
-- **Throughput**: WMMA on a single RDNA WGP is lower than MFMA on a CDNA CU. Do not expect MI300-class matmul TFLOPS.
-- **Fallback**: If a dtype combination is unsupported, Triton emits scalar FMA code silently — expect orders-of-magnitude slowdown. Verify with `MLIR_ENABLE_DUMP=1`.
-
-Always guard with `tl.static_assert`:
-```python
-tl.static_assert(BLOCK_M % 16 == 0, "BLOCK_M must be divisible by 16 for WMMA")
-tl.static_assert(BLOCK_N % 16 == 0, "BLOCK_N must be divisible by 16 for WMMA")
-tl.static_assert(BLOCK_K % 16 == 0, "BLOCK_K must be divisible by 16 for WMMA")
-```
-
----
-
-## 4. Reductions
-
-Wave32 reductions finish in 5 cross-lane steps (log2(32)) vs 6 on Wave64. `tl.sum` / `tl.max` / `tl.min` / `tl.argmax` compile to the optimal tree.
-
-```python
-@triton.jit
-def softmax_kernel(X, Y, stride, N: tl.constexpr, BLOCK: tl.constexpr):
-    row = tl.program_id(0)
-    offs = tl.arange(0, BLOCK)
-    mask = offs < N
-
-    x = tl.load(X + row * stride + offs, mask=mask, other=-float('inf'))
-
-    x_max = tl.max(x, axis=0)
-    x = x - x_max
-    num = tl.exp(x)
-    denom = tl.sum(num, axis=0)
-    y = num / denom
-
-    tl.store(Y + row * stride + offs, y, mask=mask)
-```
-
-- For multi-pass reductions (softmax, layer-norm), keep the entire row in registers — the LDS round-trip is wasted on RDNA.
-- `tl.associative_scan` is supported but the RDNA backend may lower some primitives less efficiently than CDNA; measure before committing to scan-heavy designs.
-
----
-
-## 5. `num_warps` and Occupancy
-
-Each RDNA 4 CU supports up to 16 Wave32 wavefronts (1536 VGPRs total, 512 SGPRs). Lower `num_warps` per program → more concurrent programs per CU, better latency hiding.
-
-Tuning heuristics:
-| Problem shape | Suggested `num_warps` |
-|---|---|
-| Elementwise / reduction, BLOCK ≤ 1024 | 2 or 4 |
-| Matmul, BLOCK_M×BLOCK_N ≤ 64×64 | 2 or 4 |
-| Matmul, BLOCK_M×BLOCK_N ≤ 128×128 | 4 |
-| Matmul, BLOCK_M×BLOCK_N ≥ 128×256 | 8 |
-| Attention (flash-style) | 4 (kv tiling in inner loop) |
-
-- Start at `num_warps=4`. Increase only if occupancy analysis shows you are latency-bound.
-- Check VGPR usage in compiled kernel (`MLIR_ENABLE_DUMP=1` then read `.amdgcn` output). Target < 96 VGPRs per thread for good occupancy.
-- RDNA has twice as many programs per CU as Wave64 CDNA at the same `num_warps` — keep BLOCK sizes modest to avoid over-subscribing the register file.
-
----
-
-## 6. LDS (Shared Memory)
-
-Triton manages LDS automatically for `tl.dot` tiles and `tl.load` with explicit reuse. RDNA 4 has **128 KB LDS per WGP** (shared between 2 CUs). Effective budget per workgroup is the same 64 KB as CDNA's per-CU LDS.
-
-- Triton's autotuner respects the LDS budget; oversized configs are rejected with `OutOfResources`.
-- For manual shared-memory patterns (e.g., persistent kernels), write explicit tile loads and keep each workgroup's LDS usage ≤ 32 KB to allow two programs per WGP.
-- Avoid bank conflicts: LDS on RDNA has 32 banks (4 bytes each). Triton emits layout transforms to avoid them, but user-placed intermediate tiles (e.g., via `tl.zeros`) may still conflict for awkward shapes.
-
----
-
-## 7. Register Pressure and Spilling
-
-RDNA 4 has 1536 VGPRs per CU total; >96 VGPRs per thread cuts occupancy in half.
+In the AKA runtime, trace a separate diagnostic execution:
 
 ```bash
-MLIR_ENABLE_DUMP=1 python my_kernel.py 2>&1 | grep -A2 "; NumVgprs"
+rocprofv3 --hip-trace --kernel-trace --output-format csv -- python my_kernel.py
 ```
 
-Reduce pressure:
-- Lower `BLOCK_K` (shrinks the accumulator intermediate).
-- Split large fused kernels into two; use one global memory write between them if it avoids spills.
-- Reuse `acc` accumulator across `tl.dot` calls — don't allocate fresh `tl.zeros` per K-iteration.
-- For elementwise kernels, prefer broadcasting scalars (`tl.full((), value)`) over `tl.full([BLOCK], value)` — the latter materializes a full tile in registers.
+Tracing reports dispatch/API activity, not occupancy or cache-hit counters.
+`rocprofv3 --list-avail` lists the installed tool's available counters; requesting
+or collecting them requires separate capability checks. Consult the
+[rocprofv3 guide](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/docs-7.14.0/how-to/using-rocprofv3.html)
+for the distinction and device-specific prerequisites.
 
----
-
-## 8. AMD/ROCm Backend for RDNA
-
-### Verify the target
-```python
-import triton
-print(triton.runtime.driver.active.get_current_target())
-# → HIPBackend(arch='gfx1201', warp_size=32)   # RDNA 4
-```
-
-If `warp_size` is 64 or `arch` is `gfx942`/`gfx950`, you are not running on RDNA. Check `HIP_VISIBLE_DEVICES` and `PYTORCH_ROCM_ARCH`.
-
-### Triton version
-- Minimum: **Triton 3.2** (first release with usable gfx1201 support).
-- Recommended: **Triton 3.4+** or ROCm-triton main, which includes WMMA code-gen and `tl.dot` dtype fixes for gfx1201.
-
-### Autotuner config space
-```python
-# RDNA-friendly starting configs
-configs = [
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32}, num_warps=4, num_stages=1),
-    triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32}, num_warps=8, num_stages=2),
-    triton.Config({'BLOCK_M': 64,  'BLOCK_N': 128, 'BLOCK_K': 64}, num_warps=4, num_stages=2),
-    triton.Config({'BLOCK_M': 64,  'BLOCK_N': 64,  'BLOCK_K': 64}, num_warps=2, num_stages=1),
-]
-```
-
-### `libdevice` math
-RDNA uses the same `__ocml_*` math library as CDNA. Call them via `tl.math.exp`, `tl.math.log`, etc. — unchanged from MI300 code.
-
-### Persistent kernels
-Launch overhead is higher relative to kernel time on RDNA (smaller GPU). Persistent kernels with a work-queue pattern pay off sooner than on MI300 for small problem sizes.
-
----
-
-## 9. Profiling
-
-```bash
-# Basic counter collection
-rocprofv3 --hip-trace --kernel-trace -- python my_kernel.py
-
-# Show Triton autotuning results
-TRITON_PRINT_AUTOTUNING=1 python my_kernel.py
-```
-
-Key metrics for RDNA Triton kernels:
-| Metric | Healthy range (RDNA 4) |
-|---|---|
-| Wave32 occupancy | > 50% of peak (at least 8 waves/CU) |
-| Memory bandwidth utilization | > 70% of 640 GB/s for bandwidth-bound kernels |
-| L2 cache hit rate | > 70% (smaller 4 MB L2) |
-| VGPR usage | < 96 per thread |
-| LDS bank conflicts | 0 |
-| WMMA instruction throughput | verify MFMA is NOT emitted |
-
-Inspect the generated assembly:
-```bash
-MLIR_ENABLE_DUMP=1 AMDGCN_ENABLE_DUMP=1 python my_kernel.py 2>&1 | \
-    grep -E "v_wmma|v_mfma"
-# Should see v_wmma_* on gfx1201; v_mfma_* indicates wrong target or fallback
-```
-
----
-
-## 10. Common RDNA-vs-MI300 Gotchas
-
-- **FP8 `tl.dot`** doesn't compile on gfx1201 — silently falls back to scalar FMA. Use fp16/bf16 on RDNA and gate FP8 paths with `tl.constexpr` flags keyed off target arch.
-- **`num_warps=1` workloads**: Wave32 means a single warp is 32 threads. Existing MI300 code that assumes `num_warps=1` gives 64 threads will under-dispatch by 2x. Re-tune small block sizes.
-- **Softmax / layer-norm inner reductions**: Wave32 cross-lane is faster, but there are fewer threads per warp, so multi-row SRAM layouts that relied on Wave64 broadcast need `tl.broadcast_to` adjustments.
-- **Infinity Cache (L3)**: 32 MB on gfx1201 vs 256 MB on MI300X. Large working sets that fit in MI300's L3 will spill to GDDR6 on RDNA. Shrink tile sizes or re-stream.
-- **Multi-GPU**: RDNA has no XGMI/Infinity Fabric — multi-GPU collectives go over PCIe. NCCL Triton overlap patterns tuned for MI300 won't map directly.
-
----
-
-## 11. Quick Checklist
-
-- [ ] Target verified: `arch='gfx1201'`, `warp_size=32`
-- [ ] Triton version ≥ 3.4 (or ROCm-triton main)
-- [ ] BLOCK_{M,N,K} all divisible by 16 (WMMA requirement, enforced with `tl.static_assert`)
-- [ ] `num_warps` tuned for Wave32 (start at 4; do not blindly reuse MI300 values)
-- [ ] `num_stages` ∈ {1, 2}
-- [ ] `tl.dot` accumulates in `float32`, dtypes limited to fp16/bf16/int8 on gfx1201 (no FP8)
-- [ ] VGPR usage < 96/thread (verify with `MLIR_ENABLE_DUMP=1`)
-- [ ] LDS usage ≤ 32 KB per workgroup for 2-programs-per-WGP occupancy
-- [ ] Memory access hinted with `tl.multiple_of` / `tl.max_contiguous` for 128-bit loads
-- [ ] Streaming data uses `eviction_policy="evict_last"`
-- [ ] Global memory traffic minimized (small L2 + lower GDDR6 bandwidth)
-- [ ] Profiling confirms `v_wmma_*` instructions emitted (not `v_mfma_*` or scalar FMA)
-- [ ] Correctness validated against PyTorch reference with `torch.testing.assert_close`
+Separate first-use JIT/autotuning and profiling from the harness's scored
+measurement as required by its contract. Keep baseline and candidate timing
+methods, allocations, state resets, warmups, and cases equivalent. Report
+unsupported task dependencies or architecture restrictions without bypassing
+guards or editing protected harness files.

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -927,6 +927,10 @@ build_docker_args() {
     local codex_home="${AKA_CODEX_HOME:-$container_home/.codex}"
     local cache_suffix="${AKA_CACHE_SUFFIX:-}"
     local cache_postfix=""
+    local container_username
+    # Arbitrary host UIDs need not exist in the image's passwd database.
+    # Python getpass (used by TorchInductor/AITER) also accepts USER/LOGNAME.
+    container_username="$(id -un 2>/dev/null)" || container_username="aka-$HOST_UID"
 
     if [[ -n "$cache_suffix" ]]; then
         cache_suffix="${cache_suffix//[^A-Za-z0-9_.-]/_}"
@@ -951,6 +955,8 @@ build_docker_args() {
         --security-opt=seccomp=unconfined
         --user "${HOST_UID}:${HOST_GID}"
         -e "HOME=${container_home}"
+        -e "USER=${container_username}"
+        -e "LOGNAME=${container_username}"
         -e "CODEX_HOME=${codex_home}"
         -e "XDG_CACHE_HOME=/tmp/agent-cache${cache_postfix}"
         -e "MPLCONFIGDIR=/tmp/matplotlib${cache_postfix}"
@@ -986,6 +992,15 @@ build_docker_args() {
             -e "AITER_JIT_DIR=/tmp/aiter-jit${cache_postfix}"
             -e "FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl-runtime-cache${cache_postfix}"
             --tmpfs "/tmp/aiter_configs:rw,uid=${HOST_UID},gid=${HOST_GID},mode=1777"
+        )
+    fi
+
+    if [[ "$SELECTED_GPU_ARCH" == "gfx1201" ]]; then
+        # AITER's repository and installed-package builds use separate caches.
+        # The host-UID container does not have a writable host-home mount.
+        docker_args+=(
+            -e "AITER_ROOT_DIR=/tmp/aiter-root${cache_postfix}"
+            -e "AITER_JIT_DIR=/tmp/aiter-jit${cache_postfix}"
         )
     fi
 

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -6,7 +6,7 @@ GFX950_V0514_DOCKER_IMAGE="lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705"
 GFX950_V0514_MANIFEST_DIGEST="sha256:b435b508b5aa696abb25c909341ce73e41574c4271cf716bed72418dcea86b78"
 GFX950_V0514_IMMUTABLE_IMAGE="lmsysorg/sglang-rocm@${GFX950_V0514_MANIFEST_DIGEST}"
 DEFAULT_DOCKER_IMAGE_GFX950="${AKA_DOCKER_IMAGE_GFX950:-$GFX950_V0514_DOCKER_IMAGE}"
-# Built explicitly with `make docker-build-rdna4`; its Dockerfile pins the base.
+# Built on first use when absent; its Dockerfile pins the base.
 DEFAULT_DOCKER_IMAGE_GFX1201="${AKA_DOCKER_IMAGE_GFX1201:-agent-kernel-arena:rdna4-rocm10-v1}"
 CONTAINER_WORKDIR="${AKA_DOCKER_WORKDIR:-/workspace}"
 HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -234,6 +234,31 @@ select_runtime_for_config() {
 
 select_runtime_for_host() {
     select_runtime "$(detect_host_gpu_arch)"
+}
+
+build_rdna4_image() {
+    # Send only the recipe, normalizer, and package lock as build context.
+    docker build --pull=false \
+        --file "$HOST_ROOT/docker/rdna4/Dockerfile" \
+        --tag "$DEFAULT_DOCKER_IMAGE_GFX1201" \
+        "$HOST_ROOT/docker/rdna4"
+}
+
+ensure_runtime_image() {
+    # Custom images retain Docker's normal pull/run behavior, even if an
+    # override happens to equal our default tag. Never build over an override.
+    [[ "$SELECTED_GPU_ARCH" == "gfx1201" \
+        && -z "${AKA_DOCKER_IMAGE:-}" \
+        && -z "${AKA_DOCKER_IMAGE_GFX1201:-}" ]] || return 0
+    if docker image inspect "$SELECTED_IMAGE" >/dev/null 2>&1; then
+        return 0
+    fi
+    # An unavailable daemon is not evidence that the image is missing.
+    docker info >/dev/null \
+        || die "Cannot access Docker; check daemon access before building the RDNA4 runtime."
+    echo "RDNA4 image '$SELECTED_IMAGE' is missing; building the pinned runtime before launch. The first build may download the base image and locked packages." >&2
+    build_rdna4_image >&2 \
+        || die "RDNA4 runtime build failed; no experiment was started. Retry the command or run make docker-build-rdna4."
 }
 
 detect_node_prefix() {
@@ -938,6 +963,9 @@ build_docker_args() {
     fi
 
     [[ -n "$SELECTED_IMAGE" ]] || select_runtime_for_host
+    # Parallel runs finish their preflight before starting any workers, so the
+    # first container builds a missing default and subsequent containers reuse it.
+    ensure_runtime_image
 
     docker_args=(run --rm --entrypoint bash)
     unset _MOUNTED_TARGETS
@@ -1764,11 +1792,7 @@ case "${1:-}" in
         docker_exec 0 bash src/scripts/docker_benchmark.sh _container_check_agents $REQUIRED_AGENTS
         ;;
     build-rdna4-image)
-        # Build context contains only the recipe, normalizer, and package lock.
-        docker build --pull=false \
-            --file "$HOST_ROOT/docker/rdna4/Dockerfile" \
-            --tag "$DEFAULT_DOCKER_IMAGE_GFX1201" \
-            "$HOST_ROOT/docker/rdna4"
+        build_rdna4_image
         ;;
     smoke)
         select_runtime_for_host

--- a/src/scripts/docker_benchmark.sh
+++ b/src/scripts/docker_benchmark.sh
@@ -6,6 +6,8 @@ GFX950_V0514_DOCKER_IMAGE="lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260705"
 GFX950_V0514_MANIFEST_DIGEST="sha256:b435b508b5aa696abb25c909341ce73e41574c4271cf716bed72418dcea86b78"
 GFX950_V0514_IMMUTABLE_IMAGE="lmsysorg/sglang-rocm@${GFX950_V0514_MANIFEST_DIGEST}"
 DEFAULT_DOCKER_IMAGE_GFX950="${AKA_DOCKER_IMAGE_GFX950:-$GFX950_V0514_DOCKER_IMAGE}"
+# Built explicitly with `make docker-build-rdna4`; its Dockerfile pins the base.
+DEFAULT_DOCKER_IMAGE_GFX1201="${AKA_DOCKER_IMAGE_GFX1201:-agent-kernel-arena:rdna4-rocm10-v1}"
 CONTAINER_WORKDIR="${AKA_DOCKER_WORKDIR:-/workspace}"
 HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOST_HOME="${HOME:?HOME must be set}"
@@ -53,6 +55,7 @@ Usage:
   src/scripts/docker_benchmark.sh check-agents [--config_name <run-config.yaml>]
   src/scripts/docker_benchmark.sh quality-loop [--config <quality-loop-config.yaml>] [quality_loop args...]
   src/scripts/docker_benchmark.sh smoke
+  src/scripts/docker_benchmark.sh build-rdna4-image
   src/scripts/docker_benchmark.sh eval-tools-smoke
   src/scripts/docker_benchmark.sh build-eval-tool-images
 
@@ -68,6 +71,7 @@ Environment overrides:
   AKA_DOCKER_IMAGE_<ARCH> Per-arch image override, e.g. AKA_DOCKER_IMAGE_GFX950=...
   AKA_DOCKER_IMAGE_GFX942 Default image for gfx942.
   AKA_DOCKER_IMAGE_GFX950 Default image for gfx950.
+  AKA_DOCKER_IMAGE_GFX1201 RDNA4 image (also the build-rdna4-image output tag).
   AKA_NODE_PREFIX         Host Node prefix containing bin/node and npm-installed agent CLI(s).
   AKA_AGENTS              Agent CLI(s) to check, comma/space separated; use all for all three.
   AKA_EVAL_TOOLS          Override evaluation_tools.enabled (comma/space separated).
@@ -115,6 +119,7 @@ docker_image_for_arch() {
     case "$arch" in
         gfx942) printf '%s\n' "$DEFAULT_DOCKER_IMAGE_GFX942" ;;
         gfx950) printf '%s\n' "$DEFAULT_DOCKER_IMAGE_GFX950" ;;
+        gfx1201) printf '%s\n' "$DEFAULT_DOCKER_IMAGE_GFX1201" ;;
         *)
             die "No Docker image mapping for GPU arch '$arch'. Set AKA_DOCKER_IMAGE or ${env_name}."
             ;;
@@ -211,7 +216,7 @@ detect_host_gpu_arch() {
 
 select_runtime() {
     local arch="$1"
-    [[ -n "$arch" ]] || die "Could not infer GPU arch; set AKA_GPU_ARCH=gfx942 or AKA_GPU_ARCH=gfx950"
+    [[ -n "$arch" ]] || die "Could not infer GPU arch; set AKA_GPU_ARCH (for example gfx942, gfx950, or gfx1201)"
 
     SELECTED_GPU_ARCH="$(normalize_gpu_arch "$arch")"
     if [[ -n "${AKA_DOCKER_IMAGE:-}" ]]; then
@@ -1229,7 +1234,9 @@ import sys
 print(f"python={sys.executable}")
 print(f"version={sys.version.split()[0]}")
 
-for cmd in ("hipcc", "rocprof-compute"):
+selected_arch = os.environ.get("AGENT_KERNEL_ARENA_GPU_ARCH")
+profiler = "rocprofv3" if selected_arch == "gfx1201" else "rocprof-compute"
+for cmd in ("hipcc", profiler):
     path = shutil.which(cmd)
     if not path:
         raise SystemExit(f"missing command: {cmd}")
@@ -1250,7 +1257,6 @@ print(f"torch_cuda_available={torch.cuda.is_available()}")
 if not torch.cuda.is_available():
     raise SystemExit("torch.cuda.is_available() is False")
 print(f"torch_cuda_device={torch.cuda.get_device_name(0)}")
-selected_arch = os.environ.get("AGENT_KERNEL_ARENA_GPU_ARCH")
 actual_arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
 if actual_arch:
     print(f"torch_cuda_arch={actual_arch}")
@@ -1741,6 +1747,13 @@ case "${1:-}" in
         REQUIRED_AGENTS="$(normalize_check_agents "$(resolve_required_agents "$config_name")")"
         AGENTS_STRICT=1
         docker_exec 0 bash src/scripts/docker_benchmark.sh _container_check_agents $REQUIRED_AGENTS
+        ;;
+    build-rdna4-image)
+        # Build context contains only the recipe, normalizer, and package lock.
+        docker build --pull=false \
+            --file "$HOST_ROOT/docker/rdna4/Dockerfile" \
+            --tag "$DEFAULT_DOCKER_IMAGE_GFX1201" \
+            "$HOST_ROOT/docker/rdna4"
         ;;
     smoke)
         select_runtime_for_host

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -232,6 +232,7 @@ forwarded_agents="$(PATH="$FAKE_BIN:$PATH" bash "$RUNNER" _container_check_agent
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx950)
 assert_has "$PINNED_GFX950_IMAGE" "${args[@]}"
 assert_cache_args_present "" "${args[@]}"
+assert_not_has "AITER_ROOT_DIR=/tmp/aiter-root" "${args[@]}"
 
 # A worker suffix must isolate both runtime cache directories.
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx950 AKA_CACHE_SUFFIX=worker/3)
@@ -251,15 +252,36 @@ assert_cache_args_absent "${args[@]}"
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx942)
 assert_has "lmsysorg/sglang:v0.5.12-rocm720-mi30x" "${args[@]}"
 assert_cache_args_absent "${args[@]}"
+assert_not_has "AITER_ROOT_DIR=/tmp/aiter-root" "${args[@]}"
 
 # RDNA4 selects its explicitly built image, keeps the host UID and standard
-# runtime paths, and receives no gfx950-specific cache or sidecar changes.
+# runtime paths, and receives no gfx950-specific FlyDSL cache or tmpfs mount.
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201)
 assert_has "agent-kernel-arena:rdna4-rocm10-v1" "${args[@]}"
 assert_has "$(id -u):$(id -g)" "${args[@]}"
+expected_username="$(id -un 2>/dev/null)" || expected_username="aka-$(id -u)"
+assert_has "USER=$expected_username" "${args[@]}"
+assert_has "LOGNAME=$expected_username" "${args[@]}"
+assert_has "AITER_ROOT_DIR=/tmp/aiter-root" "${args[@]}"
+assert_has "AITER_JIT_DIR=/tmp/aiter-jit" "${args[@]}"
 assert_has "AGENT_KERNEL_ARENA_GPU_ARCH=gfx1201" "${args[@]}"
 assert_has "PYTORCH_ROCM_ARCH=gfx1201" "${args[@]}"
-assert_cache_args_absent "${args[@]}"
+assert_not_has "FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl-runtime-cache" "${args[@]}"
+assert_not_has "/tmp/aiter_configs:rw,uid=$(id -u),gid=$(id -g),mode=1777" "${args[@]}"
+mapfile -t args < <(
+    id() {
+        # GNU id prints a numeric UID and exits nonzero when passwd has no name.
+        if [[ "$*" == "-un" ]]; then command id -u; return 1; fi
+        command id "$@"
+    }
+    export -f id
+    run_shell_args AKA_GPU_ARCH=gfx1201
+)
+assert_has "USER=aka-$(id -u)" "${args[@]}"
+assert_has "LOGNAME=aka-$(id -u)" "${args[@]}"
+mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201 AKA_CACHE_SUFFIX=worker-0)
+assert_has "AITER_ROOT_DIR=/tmp/aiter-root-worker-0" "${args[@]}"
+assert_has "AITER_JIT_DIR=/tmp/aiter-jit-worker-0" "${args[@]}"
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201 \
     AKA_DOCKER_IMAGE_GFX1201=example.invalid/rdna:custom)
 assert_has "example.invalid/rdna:custom" "${args[@]}"

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -252,6 +252,33 @@ mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx942)
 assert_has "lmsysorg/sglang:v0.5.12-rocm720-mi30x" "${args[@]}"
 assert_cache_args_absent "${args[@]}"
 
+# RDNA4 selects its explicitly built image, keeps the host UID and standard
+# runtime paths, and receives no gfx950-specific cache or sidecar changes.
+mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201)
+assert_has "agent-kernel-arena:rdna4-rocm10-v1" "${args[@]}"
+assert_has "$(id -u):$(id -g)" "${args[@]}"
+assert_has "AGENT_KERNEL_ARENA_GPU_ARCH=gfx1201" "${args[@]}"
+assert_has "PYTORCH_ROCM_ARCH=gfx1201" "${args[@]}"
+assert_cache_args_absent "${args[@]}"
+mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201 \
+    AKA_DOCKER_IMAGE_GFX1201=example.invalid/rdna:custom)
+assert_has "example.invalid/rdna:custom" "${args[@]}"
+mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201 \
+    AKA_DOCKER_IMAGE_GFX1201=example.invalid/rdna:custom \
+    AKA_DOCKER_IMAGE=example.invalid/global:override)
+assert_has "example.invalid/global:override" "${args[@]}"
+
+# Building is explicit, GPU-independent, and sends only docker/rdna4 as context.
+mapfile -t args < <(bash "$RUNNER" build-rdna4-image)
+assert_has "build" "${args[@]}"
+assert_has "--pull=false" "${args[@]}"
+assert_has "$ROOT/docker/rdna4/Dockerfile" "${args[@]}"
+assert_has "$ROOT/docker/rdna4" "${args[@]}"
+assert_not_has "$ROOT" "${args[@]}"
+mapfile -t args < <(AKA_DOCKER_IMAGE_GFX1201=example.invalid/rdna:build \
+    bash "$RUNNER" build-rdna4-image)
+assert_has "example.invalid/rdna:build" "${args[@]}"
+
 # Image equality alone is insufficient: the selected architecture must be gfx950.
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx942 AKA_DOCKER_IMAGE="$PINNED_GFX950_IMAGE")
 assert_cache_args_absent "${args[@]}"

--- a/tests/test_docker_benchmark.sh
+++ b/tests/test_docker_benchmark.sh
@@ -51,6 +51,18 @@ assert_before() {
 # Capture the exact argv that the runner would pass to Docker without requiring
 # a daemon, GPU devices, or the benchmark images on this host.
 docker() {
+    if [[ -n "${FAKE_RUNTIME_DIR:-}" ]]; then
+        printf '%s\n' "$1" >> "$FAKE_RUNTIME_DIR/events"
+        case "$1" in
+            info) return "${FAKE_DOCKER_INFO_STATUS:-0}" ;;
+            build)
+                printf '%s\n' "$@" > "$FAKE_RUNTIME_DIR/build-args"
+                [[ "${FAKE_DOCKER_BUILD_STATUS:-0}" == "0" ]] || return 42
+                touch "$FAKE_RUNTIME_DIR/image-present"
+                ;;
+            image) [[ -f "$FAKE_RUNTIME_DIR/image-present" ]] || return 1 ;;
+        esac
+    fi
     if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
         local reference="${!#}"
         if [[ "$reference" == "$PINNED_GFX950_IMMUTABLE_IMAGE" ]]; then
@@ -254,7 +266,7 @@ assert_has "lmsysorg/sglang:v0.5.12-rocm720-mi30x" "${args[@]}"
 assert_cache_args_absent "${args[@]}"
 assert_not_has "AITER_ROOT_DIR=/tmp/aiter-root" "${args[@]}"
 
-# RDNA4 selects its explicitly built image, keeps the host UID and standard
+# RDNA4 selects its derived image, keeps the host UID and standard
 # runtime paths, and receives no gfx950-specific FlyDSL cache or tmpfs mount.
 mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201)
 assert_has "agent-kernel-arena:rdna4-rocm10-v1" "${args[@]}"
@@ -290,7 +302,7 @@ mapfile -t args < <(run_shell_args AKA_GPU_ARCH=gfx1201 \
     AKA_DOCKER_IMAGE=example.invalid/global:override)
 assert_has "example.invalid/global:override" "${args[@]}"
 
-# Building is explicit, GPU-independent, and sends only docker/rdna4 as context.
+# Explicit prebuild/rebuild is GPU-independent and uses only docker/rdna4 as context.
 mapfile -t args < <(bash "$RUNNER" build-rdna4-image)
 assert_has "build" "${args[@]}"
 assert_has "--pull=false" "${args[@]}"
@@ -557,6 +569,83 @@ assert_has "_container_check_agents" "${args[@]}"
 assert_has "claude_code" "${args[@]}"
 assert_not_has "$CLAUDE_HOME/.local/share/claude:$CLAUDE_HOME/.local/share/claude:ro" "${args[@]}"
 assert_not_has "$CLAUDE_HOME/.codex:$CLAUDE_HOME/.codex" "${args[@]}"
+
+# First-use builds happen before any container, then reuse the image across
+# preflight, workers, and subsequent invocations. These are daemon-free tests.
+run_runtime_command() {
+    local mode="$1"
+    shift
+    env HOME="$CLAUDE_HOME" AKA_NODE_PREFIX="$CLAUDE_PREFIX" \
+        AKA_GPU_ARCH=gfx1201 GPU_IDS=0,1 AKA_EVAL_TOOLS= \
+        FAKE_RUNTIME_DIR="$RUNTIME_DIR" "$@" \
+        bash "$RUNNER" "$mode" \
+        --config_name example_configs/quickstart_claude_rdna4.yaml \
+        > "$RUNTIME_DIR/stdout" 2> "$RUNTIME_DIR/stderr"
+}
+
+for runtime_mode in shell smoke check-agents preflight run parallel-run; do
+    RUNTIME_DIR="$TEST_HOME/runtime-$runtime_mode"
+    mkdir -p "$RUNTIME_DIR"
+    run_runtime_command "$runtime_mode" || {
+        cat "$RUNTIME_DIR/stderr" >&2
+        fail "$runtime_mode failed on first use"
+    }
+    mapfile -t events < "$RUNTIME_DIR/events"
+    assert_before build run "${events[@]}"
+    [[ "$(awk '$0 == "build" {n++} END {print n+0}' "$RUNTIME_DIR/events")" == 1 ]] \
+        || fail "$runtime_mode built more than once"
+    mapfile -t args < "$RUNTIME_DIR/build-args"
+    assert_has "--pull=false" "${args[@]}"
+    assert_has "$ROOT/docker/rdna4/Dockerfile" "${args[@]}"
+    assert_has "$ROOT/docker/rdna4" "${args[@]}"
+    assert_has "agent-kernel-arena:rdna4-rocm10-v1" "${args[@]}"
+    assert_not_has "$ROOT" "${args[@]}"
+    assert_not_has "$CLAUDE_HOME" "${args[@]}"
+    if [[ "$runtime_mode" == parallel-run ]]; then
+        [[ "$(awk '$0 == "run" {n++} END {print n+0}' "$RUNTIME_DIR/events")" == 5 ]] \
+            || fail "parallel run did not launch preflight, init, two workers, and postprocess"
+    fi
+    : > "$RUNTIME_DIR/events"
+    run_runtime_command "$runtime_mode" || fail "$runtime_mode failed with a cached image"
+    mapfile -t events < "$RUNTIME_DIR/events"
+    assert_has run "${events[@]}"
+    assert_not_has build "${events[@]}"
+    assert_not_has info "${events[@]}"
+done
+
+# Build/daemon failures must propagate instead of launching a container.
+for failure in FAKE_DOCKER_BUILD_STATUS=42 FAKE_DOCKER_INFO_STATUS=1; do
+    RUNTIME_DIR="$TEST_HOME/runtime-failure-$failure"
+    mkdir -p "$RUNTIME_DIR"
+    if run_runtime_command run "$failure"; then
+        fail "$failure did not stop the run"
+    fi
+    mapfile -t events < "$RUNTIME_DIR/events"
+    assert_not_has run "${events[@]}"
+    [[ ! -f "$RUNTIME_DIR/image-present" ]] || fail "failed setup cached an image"
+    if [[ "$failure" == FAKE_DOCKER_INFO_STATUS=* ]]; then
+        assert_not_has build "${events[@]}"
+    else
+        assert_has build "${events[@]}"
+    fi
+    # A later invocation can recover without a stale success flag.
+    run_runtime_command run || fail "retry after $failure did not recover"
+done
+
+# Missing custom images and CDNA defaults keep the ordinary Docker run/pull
+# path. Even an explicit override equal to the default tag opts out of builds.
+for override in \
+    AKA_DOCKER_IMAGE=example.invalid/rdna:custom \
+    AKA_DOCKER_IMAGE_GFX1201=example.invalid/rdna:custom \
+    AKA_DOCKER_IMAGE=agent-kernel-arena:rdna4-rocm10-v1 \
+    AKA_DOCKER_IMAGE_GFX1201=agent-kernel-arena:rdna4-rocm10-v1 \
+    AKA_GPU_ARCH=gfx942 AKA_GPU_ARCH=gfx950; do
+    RUNTIME_DIR="$TEST_HOME/runtime-override-${override//\//_}"
+    mkdir -p "$RUNTIME_DIR"
+    run_runtime_command shell "$override" || fail "override failed: $override"
+    mapfile -t events < "$RUNTIME_DIR/events"
+    [[ "${events[*]}" == run ]] || fail "override attempted automatic image setup: $override"
+done
 
 # AGENTS=all is an explicit override and expands to all three first-class CLIs.
 ALL_HOME="$TEST_HOME/all-home"

--- a/tests/test_rdna4_prompt_routing.py
+++ b/tests/test_rdna4_prompt_routing.py
@@ -1,0 +1,113 @@
+"""Exercise architecture/language selection through the real prompt builder."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from src.prompt_builder import _load_cheatsheet, prompt_builder
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDES = ROOT / "src/prompts/cheatsheet"
+LOGGER = logging.getLogger(__name__)
+
+
+def expected_guides(*names):
+    return "\n\n---\n\n".join((GUIDES / name).read_text() for name in names)
+
+
+@pytest.mark.parametrize("model", ["RDNA4", "rdna4"])
+@pytest.mark.parametrize("task_type,language", [
+    ("hip2hip", "hip"),
+    ("torch2hip", "hip"),
+    ("cuda2hip", "hip"),
+    ("triton2triton", "triton"),
+    ("instruction2triton", "triton"),
+])
+def test_rdna4_selects_destination_language_guide(model, task_type, language):
+    text, arch = _load_cheatsheet(task_type, model, ROOT, {}, LOGGER)
+
+    assert arch == "gfx1201"
+    assert text == expected_guides(
+        "RDNA4_architecture.md", f"{language}_rdna_cheatsheet.md"
+    )
+
+
+@pytest.mark.parametrize("model,arch,architecture_file", [
+    ("MI300", "gfx942", "MI300X_architecture.md"),
+    ("MI300X", "gfx942", "MI300X_architecture.md"),
+    ("MI325", "gfx942", "MI300X_architecture.md"),
+    ("MI325X", "gfx942", "MI300X_architecture.md"),
+    ("MI355X", "gfx950", "MI355X_architecture.md"),
+])
+@pytest.mark.parametrize("language", ["hip", "triton"])
+def test_cdna_keeps_default_language_guide(model, arch, architecture_file, language):
+    text, actual_arch = _load_cheatsheet(
+        f"{language}2{language}", model, ROOT, {}, LOGGER
+    )
+
+    assert actual_arch == arch
+    assert text == expected_guides(architecture_file, f"{language}_cheatsheet.md")
+
+
+@pytest.mark.parametrize("task_type", ["repository", "image_kernel"])
+@pytest.mark.parametrize("language,guide", [
+    ("hip", "hip_rdna_cheatsheet.md"),
+    ("triton", "triton_rdna_cheatsheet.md"),
+    ("flydsl", "flydsl_cheatsheet.md"),
+    ("tilelang", "tilelang_cheatsheet.md"),
+])
+def test_repository_language_uses_rdna_override_or_default(task_type, language, guide):
+    text, arch = _load_cheatsheet(
+        task_type, "RDNA4", ROOT, {"repository_language": language}, LOGGER
+    )
+
+    assert arch == "gfx1201"
+    assert text == expected_guides("RDNA4_architecture.md", guide)
+
+
+@pytest.mark.parametrize("task_type", ["torch2flydsl", "triton2flydsl", "flydsl2flydsl"])
+def test_conversion_uses_target_language_not_input_language(task_type):
+    text, arch = _load_cheatsheet(task_type, "RDNA4", ROOT, {}, LOGGER)
+
+    assert arch == "gfx1201"
+    assert text == expected_guides("RDNA4_architecture.md", "flydsl_cheatsheet.md")
+
+
+@pytest.mark.parametrize("override", ["Task-owned context", ""])
+def test_task_override_replaces_both_architecture_and_language(override):
+    result = _load_cheatsheet(
+        "hip2hip", "RDNA4", ROOT, {"prompt": {"cheatsheet": override}}, LOGGER
+    )
+
+    assert result == (override, None)
+
+
+def test_unknown_gpu_does_not_infer_rdna_support():
+    text, arch = _load_cheatsheet("hip2hip", "UNKNOWN_GPU", ROOT, {}, LOGGER)
+
+    assert arch is None
+    assert text == expected_guides("hip_cheatsheet.md")
+
+
+@pytest.mark.parametrize("task_path,language", [
+    ("hip2hip/gpumode/GELU", "hip"),
+    ("triton2triton/vllm/triton_rms_norm", "triton"),
+])
+def test_complete_task_prompt_includes_rdna_context_and_harness_rules(
+    task_path, language, tmp_path
+):
+    text = prompt_builder(
+        str(ROOT / "tasks" / task_path / "config.yaml"),
+        tmp_path,
+        {"target_gpu_model": "RDNA4"},
+        LOGGER,
+    )
+
+    assert expected_guides(
+        "RDNA4_architecture.md", f"{language}_rdna_cheatsheet.md"
+    ) in text
+    assert "architecture token: `gfx1201`" in text
+    assert "### Protected Harness / Test Files" in text
+    assert "DO NOT write task_result.yaml" in text

--- a/tests/test_rdna4_runtime.py
+++ b/tests/test_rdna4_runtime.py
@@ -1,0 +1,144 @@
+"""CPU regression tests for the RDNA4 image layout and Docker smoke policy."""
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "rdna4_prepare_runtime", ROOT / "docker/rdna4/prepare_runtime.py"
+)
+runtime = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(runtime)
+
+
+class RuntimeLayoutTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name).resolve()
+        self.private = root / "root"
+        self.private.mkdir(mode=0o700)
+        self.base = self.private / "uv/python"
+        (self.base / "bin").mkdir(parents=True)
+        (self.base / "bin/python3.14").write_text("interpreter bytes")
+        (self.base / "lib").mkdir()
+        (self.base / "lib/stdlib").write_text("standard library bytes")
+        self.prefix = root / "opt"
+        self.venv = self.prefix / "python"
+        (self.venv / "bin").mkdir(parents=True)
+        (self.venv / "bin/python").symlink_to(self.base / "bin/python3.14")
+        (self.venv / "bin/python3").symlink_to("python")
+        (self.venv / "pyvenv.cfg").write_text(
+            f"home = {self.base / 'bin'}\ninclude-system-site-packages = false\n"
+        )
+        self.sdk = self.venv / "lib/site-packages/_rocm_sdk_devel"
+        (self.sdk / "bin").mkdir(parents=True)
+        (self.sdk / "bin/hipcc").write_text("compiler bytes")
+
+    def prepare(self):
+        runtime.prepare_runtime(self.venv, self.base, self.sdk, self.prefix)
+
+    def test_relocates_interpreter_and_stdlib_without_exposing_root(self):
+        self.prepare()
+        destination = self.prefix / "aka-python-runtime"
+        for name in ("python", "python3"):
+            link = self.venv / "bin" / name
+            self.assertEqual(link.resolve(), destination / "bin/python3.14")
+            self.assertEqual(link.read_text(), "interpreter bytes")
+        self.assertEqual((destination / "lib/stdlib").read_text(), "standard library bytes")
+        self.assertEqual(self.private.stat().st_mode & 0o777, 0o700)
+        self.assertEqual((self.base / "bin/python3.14").read_text(), "interpreter bytes")
+        self.assertEqual((self.venv / "pyvenv.cfg").read_text(),
+                         f"home = {destination / 'bin'}\ninclude-system-site-packages = false\n")
+        self.assertEqual((self.prefix / "venv").resolve(), self.venv)
+        self.assertEqual((self.prefix / "rocm/bin/hipcc").read_text(), "compiler bytes")
+
+    def test_existing_runtime_paths_are_not_replaced(self):
+        (self.prefix / "venv").symlink_to("missing-target")
+        with self.assertRaises(FileExistsError):
+            self.prepare()
+        self.assertEqual(os.readlink(self.prefix / "venv"), "missing-target")
+        self.assertFalse((self.prefix / "aka-python-runtime").exists())
+
+    def test_missing_sdk_fails_before_relocating(self):
+        (self.sdk / "bin/hipcc").unlink()
+        with self.assertRaises(ValueError):
+            self.prepare()
+        self.assertFalse((self.prefix / "aka-python-runtime").exists())
+        self.assertEqual((self.venv / "bin/python").resolve(), self.base / "bin/python3.14")
+
+    def test_unexpected_interpreter_location_is_rejected(self):
+        (self.venv / "bin/python3").unlink()
+        (self.venv / "bin/python3").symlink_to(sys.executable)
+        with self.assertRaises(ValueError):
+            self.prepare()
+        self.assertFalse((self.prefix / "aka-python-runtime").exists())
+
+
+class SmokeProfilerTests(unittest.TestCase):
+    def run_smoke(self, selected, commands, actual=None):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "python").symlink_to(sys.executable)
+            for command in ("dirname", "id"):
+                (bin_dir / command).symlink_to(shutil.which(command))
+            for command in commands:
+                path = bin_dir / command
+                path.write_text("#!/bin/sh\nexit 0\n")
+                path.chmod(0o755)
+            for name in ("triton", "pytest", "yaml", "numpy", "flydsl"):
+                (root / f"{name}.py").write_text("__version__ = 'mock'\n")
+            (root / "torch.py").write_text(
+                "from types import SimpleNamespace\nimport os\n"
+                "cuda = SimpleNamespace(is_available=lambda: True, "
+                "get_device_name=lambda i: 'mock GPU', "
+                "get_device_properties=lambda i: SimpleNamespace("
+                "gcnArchName=os.environ['MOCK_GPU_ARCH']))\n"
+            )
+            env = {**os.environ, "PATH": str(bin_dir), "PYTHONPATH": str(root),
+                   "HOME": str(root), "AGENT_KERNEL_ARENA_GPU_ARCH": selected,
+                   "MOCK_GPU_ARCH": actual or selected}
+            return subprocess.run(
+                [shutil.which("bash"), str(ROOT / "src/scripts/docker_benchmark.sh"),
+                 "_container_smoke"], env=env, capture_output=True, text=True, timeout=30,
+            )
+
+    def test_rdna4_accepts_rocprofv3_without_rocprof_compute(self):
+        result = self.run_smoke("gfx1201", ("hipcc", "rocprofv3"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("rocprofv3=", result.stdout)
+
+    def test_rdna4_rejects_missing_rocprofv3(self):
+        result = self.run_smoke("gfx1201", ("hipcc", "rocprof-compute"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing command: rocprofv3", result.stderr)
+
+    def test_cdna_still_requires_rocprof_compute(self):
+        for arch in ("gfx942", "gfx950"):
+            with self.subTest(arch=arch):
+                result = self.run_smoke(arch, ("hipcc", "rocprofv3"))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("missing command: rocprof-compute", result.stderr)
+                result = self.run_smoke(arch, ("hipcc", "rocprof-compute"))
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rdna4_still_requires_compiler(self):
+        result = self.run_smoke("gfx1201", ("rocprofv3",))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing command: hipcc", result.stderr)
+
+    def test_rdna4_still_rejects_architecture_mismatch(self):
+        result = self.run_smoke("gfx1201", ("hipcc", "rocprofv3"), actual="gfx950")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match visible device arch gfx950", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The stock ROCm vLLM image cannot run through AKA's normal host-UID Docker path: its Python interpreter resolves below private `/root`, its Python/SDK layout differs from the runner's PATH, and smoke assumes `rocprof-compute`. This adds a `gfx1201` runtime that builds automatically on first use when missing and RDNA4 quickstart, and corrects the architecture guidance supplied to agents. **Scope: a validated gfx1201 kernel-task runtime and RDNA4 agent guidance. The task compatibility gaps below remain; support is not established for every category.**

The derived image pins the upstream digest, relocates the Python base interpreter/stdlib, exposes the existing Python packages and ROCm SDK through `/opt/venv` and `/opt/rocm`, and installs only hash-locked missing plotting dependencies. Build-time imports run as an unprivileged UID with `/root` private. The runner supplies a username for host UIDs absent from image passwd, directs both AITER cache variants to writable `/tmp` directories, and uses `rocprofv3` for gfx1201 smoke. CDNA image/profiler/cache selection remains intact. Task contracts, kernels, harnesses and timing helpers are unchanged.

Before the first container launch, the runner checks whether the default RDNA4 image exists in the Docker daemon and builds the pinned recipe if needed. Subsequent runs reuse the image; parallel workers start after preflight has prepared it. Build or daemon failures stop the run. `make docker-build-rdna4` remains an optional prebuild/rebuild command; recipe updates are not applied automatically to existing images. Explicit global or architecture-specific image overrides keep Docker’s normal run/pull behavior and disable automatic builds, including overrides equal to the default tag.

The RDNA4 architecture, HIP and Triton guides distinguish WMMA hardware formats (including FP8/BF8) from installed compiler support, use SIMD/CU/WGP resource units consistently, preserve HIP’s 64-bit ballot mask types on wave32, and separate tracing from counter collection. Device-specific capacity and speculative tuning prescriptions are replaced by device queries, compiler inspection and measurement. Sources link to AMD, LLVM and Triton documentation. The existing `knowledge_override` route is retained, with regression coverage for RDNA/CDNA selection, target-language fallback, repository/image tasks, inline overrides, and complete task prompts with harness rules.

```bash
make docker-smoke
make docker-check-agents CONFIG=example_configs/quickstart_claude_rdna4.yaml
make docker-run CONFIG=example_configs/quickstart_claude_rdna4.yaml
```

Validation used Ubuntu 24.04.1 / kernel 6.8.0-52, one 16 GB gfx1201 GPU (wave32), and host UID 1064. Python 3.14.7, PyTorch 2.12.0+rocm10.0.0, Triton 3.8.0, FlyDSL 0.3.1. Derived image ID for all attempts: `sha256:e9626d3c31b6adfc5c059fe36e39f285a5c02e2ea6a98b8ca45ef83620e88853`.

- Image build, Docker smoke, Docker/Slurm runner regression tests and perf-helper checks pass.
- At guidance revision `5db401b5`, in the RDNA4 container, `python3 -m pytest -q tests`: **530 passed, 2 skipped**, 1 existing collection warning; 5 subtests passed. The two prompt suites pass all 40 tests, including 36 new routing cases. Docker/Slurm runner checks and the perf-helper audit also pass.
- `make docker-check-agents AGENTS=all`: Claude Code, Codex and Cursor Agent authenticate inside the image.
- Nine layout/profiler tests cover relocation, private-root preservation, malformed layouts, missing tools and architecture mismatch. Shell tests cover image selection/overrides, host UID and username fallback, both AITER caches, worker suffix isolation and preserved CDNA behavior.
- The historical 45-task matrix and Claude optimization smoke below were run at runtime revision `282dda2d`, whose 2,610 tracked source hashes were verified. The guidance revision changes no task, harness, evaluator, benchmark helper, image recipe, or runner; it adds a new prompt-routing test. Its 2,611-file remote snapshot is checked against the local source hashes.

Five tasks were selected in each of nine existing categories, without replacing failures. The serial diagnostic driver uses the Docker runner's actual container arguments and AKA's workspace setup, compilation/correctness evaluators and baseline timer. Declared timeouts are honored, with a 600-second default for missing stage budgets and `MAX_JOBS=4`. Positive finite device timing with a scoreable method is required. **Baseline-only results do not validate generated target kernels; this matrix is not 45 full `task_validator` passes.**

| Task type | Selected | Kernel checks pass | Baseline only | Failed / blocked | Arch skip |
| --- | ---: | ---: | ---: | ---: | ---: |
| `hip2hip` | 5 | 4 | 0 | 1 | 0 |
| `triton2triton` | 5 | 5 | 0 | 0 | 0 |
| `instruction2triton` | 5 | 5 | 0 | 0 | 0 |
| `torch2hip` | 5 | 0 | 5 | 0 | 0 |
| `torch2flydsl` | 5 | 0 | 4 | 1 | 0 |
| `triton2flydsl` | 5 | 0 | 5 | 0 | 0 |
| `flydsl2flydsl` | 5 | 0 | 0 | 3 | 2 |
| `image_kernel` | 5 | 0 | 0 | 5 | 0 |
| `repository` | 5 | 1 | 0 | 4 | 0 |

The six tasks affected by username/home-cache errors were retried with the runner fixes. Four torch2flydsl reference/oracle paths now pass; LayerNorm's cold AITER C++ build exceeds the 600-second stage budget. Its timed-out child compiler outlived the command until the batch container exited, so all three later activation checks were repeated in a fresh container; only those clean results are counted above. This is a build timeout, not evidence of a numerical error in LayerNorm.

Remaining gaps:

- Device capacity (16 GB tested): HIP Transpose's original correctness allocation exceeds VRAM on the tested board. `gfx1201` spans boards with different memory capacities; larger-memory boards, including 32 GB models, have not been validated here.
- Per-workgroup LDS (`gfx1201`): the previously checked persistent matmul requests 96 KiB shared memory against a 64 KiB per-workgroup limit. Increasing board VRAM does not increase this separate LDS limit.
- Three native FlyDSL tasks import `vector` / `buffer_ops` APIs absent from the bundled FlyDSL version. The other two selected native FlyDSL tasks require gfx942 and were not run; there are only three unrestricted native FlyDSL packages in the current tree.
- All five selected image-bound tasks declare source/package paths from other images, including Python 3.12 paths absent from this Python 3.14 image. No path was redirected to a different package version.
- rocPRIM binary search passes; device search-n and block radix rank fail wave64 compile assertions; merge sort compiles but fails 40 of 41 upstream correctness tests. These failures were retained.
- The AITER repository task's declared `moe_routing_sigmoid_top1_fused` target module is absent from its resolved upstream clone. All attempts use AITER `cc2ebf2ff485f0ebc8bde4028612337ce24c0ad0`; rocPRIM tasks use `14cd5e3c27a4b9ae7d510823a450723a03985ac0`.

A Docker-first, authenticated `task_validator` smoke finalized GELU's schema-v3 report with **overall WARN**: compilation, correctness and performance pass (11 cases), but its existing harness lacks exact timed Graph-replay output validation. This is not a clean PASS or an approved exception. The subsequent broad semantic audit was stopped; its partial second task is not counted. No task/harness contract changed in this PR.

Other Radeon architectures, generated HIP/FlyDSL targets for conversion tasks, full vLLM serving, and evaluation-tool sidecars remain unqualified. `make vllm` uses a separate serving image defined in the Makefile; that serving path is unverified on RDNA4 and is not qualified by the kernel-runtime checks. No speedup is claimed from the compatibility matrix. The Docker recipe documents the pinned external inputs, minimal build context and security/reproducibility review.

<details>
<summary>All 45 selected tasks and their final diagnostic scope</summary>

| Task | Final diagnostic | Compilation | Correctness | Device timing | Scope / limitation |
| --- | --- | --- | --- | --- | --- |
| `hip2hip/gpumode/GELU` | PASS | PASS | PASS | PASS (11 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `triton2triton/vllm/triton_rms_norm` | PASS | PASS | PASS | PASS (5 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `instruction2triton/rocmbench/test_add_kernel` | PASS | PASS | PASS | PASS (4 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `torch2hip/gpumode/14539_GELU` | BASELINE_PASS | Placeholder | Placeholder | PASS (11 timing cases) | PyTorch reference timing only; HIP target is empty |
| `torch2flydsl/rmsnorm2d_kernel` | BASELINE_PASS | PASS | PASS | PASS (6 timing cases) | Reference / AITER oracle only; FlyDSL target is a starter stub |
| `triton2flydsl/aiter/rmsnorm` | BASELINE_PASS | PASS | PASS | PASS (10 timing cases) | Input Triton baseline only; no FlyDSL conversion |
| `flydsl2flydsl/preshuffle_gemm_v2_kernel` | FAIL | FAIL | Not run | Not run | Task imports vector / buffer_ops APIs absent from bundled FlyDSL |
| `image_kernel/mi300x_sglang_triton_gemm` | SETUP_OR_DRIVER_FAIL | Not run | Not run | Not run | Declared image_repo_path is absent from this image |
| `repository/aiter/moe_routing_sigmoid_top1_fused` | FAIL | FAIL | Not run | Not run | Declared target module absent from resolved upstream clone |
| `hip2hip/gpumode/Transpose` | FAIL | PASS | FAIL | Not run | Original correctness allocation exceeds 16 GB VRAM |
| `triton2triton/geak_eval/L3/gemm` | PASS | PASS | PASS | PASS (1 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `instruction2triton/rocmbench/test_load_reduce` | PASS | PASS | PASS | PASS (42 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `torch2hip/gpumode/1067_Transpose` | BASELINE_PASS | Placeholder | Placeholder | PASS (4 timing cases) | PyTorch reference timing only; HIP target is empty |
| `torch2flydsl/layernorm2d_kernel` | FAIL | PASS | FAIL | Not run | AITER cold build exceeds the 600-second stage budget; no numerical failure claim |
| `triton2flydsl/aiter/softmax` | BASELINE_PASS | PASS | PASS | PASS (9 timing cases) | Input Triton baseline only; no FlyDSL conversion |
| `flydsl2flydsl/blockscale_preshuffle_gemm_kernel` | FAIL | FAIL | Not run | Not run | Task imports vector / buffer_ops APIs absent from bundled FlyDSL |
| `image_kernel/mi355x_vllm_triton_paged_attention_2d` | SETUP_OR_DRIVER_FAIL | Not run | Not run | Not run | Declared image_repo_path is absent from this image |
| `repository/rocprim/device_binary_search` | PASS | PASS | PASS | PASS (6 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `hip2hip/gpumode/SiLU` | PASS | PASS | PASS | PASS (11 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `triton2triton/rocmbench/medium/naive_softmax` | PASS | PASS | PASS | PASS (21 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `instruction2triton/rocmbench/naive_softmax` | PASS | PASS | PASS | PASS (21 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `torch2hip/gpumode/16636_SiLU` | BASELINE_PASS | Placeholder | Placeholder | PASS (11 timing cases) | PyTorch reference timing only; HIP target is empty |
| `torch2flydsl/silu_and_mul_kernel` | BASELINE_PASS | PASS | PASS | PASS (4 timing cases) | Reference / AITER oracle only; FlyDSL target is a starter stub |
| `triton2flydsl/aiter/rope_fwd` | BASELINE_PASS | PASS | PASS | PASS (4 timing cases) | Input Triton baseline only; no FlyDSL conversion |
| `flydsl2flydsl/pa_decode_fp8_kernel` | FAIL | FAIL | Not run | Not run | Task imports vector / buffer_ops APIs absent from bundled FlyDSL |
| `image_kernel/mi355x_vllm_triton_fused_moe_gptq_awq` | SETUP_OR_DRIVER_FAIL | Not run | Not run | Not run | Declared image_repo_path is absent from this image |
| `repository/rocprim/device_search_n` | FAIL | FAIL | Not run | Not run | Compile-time wave64 assertion on wave32 GPU |
| `hip2hip/gpumode/layer_normalization` | PASS | PASS | PASS | PASS (6 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `triton2triton/vllm/triton_per_token_quant_int8` | PASS | PASS | PASS | PASS (5 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `instruction2triton/rocmbench/test_batched_vecmat` | PASS | PASS | PASS | PASS (28 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `torch2hip/gpumode/11754_layer_normalization` | BASELINE_PASS | Placeholder | Placeholder | PASS (6 timing cases) | PyTorch reference timing only; HIP target is empty |
| `torch2flydsl/gelu_fast_kernel` | BASELINE_PASS | PASS | PASS | PASS (4 timing cases) | Reference / AITER oracle only; FlyDSL target is a starter stub |
| `triton2flydsl/sglang/gdn_l2norm_fwd` | BASELINE_PASS | PASS | PASS | PASS (8 timing cases) | Input Triton baseline only; no FlyDSL conversion |
| `flydsl2flydsl/rmsnorm_kernel` | SKIP_ARCH | Not run | Not run | Not run | Requires gfx942; guard honored |
| `image_kernel/mi355x_vllm_hip_dynamic_per_tensor_quant` | SETUP_OR_DRIVER_FAIL | Not run | Not run | Not run | Declared image_repo_path is absent from this image |
| `repository/rocprim/block_radix_rank` | FAIL | FAIL | Not run | Not run | Compile-time wave64 assertion on wave32 GPU |
| `hip2hip/gpumode/SimpleMatmulModule` | PASS | PASS | PASS | PASS (11 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `triton2triton/vllm/triton_bmm` | PASS | PASS | PASS | PASS (5 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `instruction2triton/rocmbench/test_triton_flip` | PASS | PASS | PASS | PASS (24 timing cases) | Existing kernel compilation, correctness and baseline device timing |
| `torch2hip/gpumode/3267_SimpleMatmulModule` | BASELINE_PASS | Placeholder | Placeholder | PASS (11 timing cases) | PyTorch reference timing only; HIP target is empty |
| `torch2flydsl/swiglu_and_mul_kernel` | BASELINE_PASS | PASS | PASS | PASS (4 timing cases) | Reference / AITER oracle only; FlyDSL target is a starter stub |
| `triton2flydsl/generative_recommenders/jagged_dense_broadcast_add` | BASELINE_PASS | PASS | PASS | PASS (6 timing cases) | Input Triton baseline only; no FlyDSL conversion |
| `flydsl2flydsl/softmax_kernel` | SKIP_ARCH | Not run | Not run | Not run | Requires gfx942; guard honored |
| `image_kernel/mi355x_vllm_triton_unified_attention` | SETUP_OR_DRIVER_FAIL | Not run | Not run | Not run | Declared image_repo_path is absent from this image |
| `repository/rocprim/device_merge_sort` | FAIL | PASS | FAIL | Not run | 40 of 41 upstream correctness tests fail |

</details>

At runtime revision `282dda2d`, the complete Claude Code quickstart also passes: `make docker-run CONFIG=example_configs/quickstart_claude_rdna4.yaml RUN_ARGS="--run-suffix rdna4_claude_smoke_20260909"` exits zero. The unchanged default agent configuration produces a candidate, passes the harness guard, and reaches centralized evaluation: compilation and correctness pass, with 11 valid baseline and 11 valid candidate cases, all `cuda_graph`, and no method mismatches. At that revision, post-run source hashes match all 2,610 tracked files, and no KFD process remains. This separate end-to-end smoke does not upgrade baseline-only rows in the 45-task matrix.

The prompt-guidance revision does not claim a measured optimization gain; the full agent optimization and 45-task matrix were not repeated for these documentation and routing-test changes.

Guidance verification on `5db401b5` also passes `make docker-smoke` and actual HIP/Triton tracing on the same gfx1201 image. A compiled HIP probe verifies wave32, 65,536-byte `sharedMemPerBlock`, and 64-bit ballot/active-mask types; its ballot result matches the expected active lanes. A Triton probe passes exact tail-mask correctness. The documented `rocprofv3 --hip-trace --kernel-trace --output-format csv` commands produce nonempty API/kernel CSVs with valid timestamps (HIP: 11 API / 2 kernel records; Triton: 98,343 API / 5 kernel records, including initialization). `rocprofv3 --list-avail` succeeds. These are diagnostic traces, not hardware-counter collection or scoreable performance measurements. All 2,611 source hashes still match after verification.

Documentation-only follow-up `de3f7ace`: relative links/anchors and `git diff --check` pass. Checks at that documentation revision passed: [GitHub CI 1](https://github.com/AMD-AGI/AgentKernelArena/actions/runs/34511861688/job/102987679023), [GitHub CI 2](https://github.com/AMD-AGI/AgentKernelArena/actions/runs/34511853418/job/102987652690), [documentation build](https://advanced-micro-devices-demo--97.com.readthedocs.build/projects/agent-kernel-arena/en/97/). GPU experiments were not repeated for this documentation-only change.

Automatic-build follow-up `c917f57f`: `make check-docker-runner` passes, including first-use and cached launches for shell, smoke, agent checks, preflight, serial and parallel runs; build/daemon failure recovery; and override/CDNA isolation. `python3 -m pytest -q tests/test_rdna4_runtime.py` passes all 9 tests (2 subtests). On the same gfx1201 host, an isolated initially absent test tag exercised the runner’s preparation/launch functions: Docker built the unchanged recipe using cached layers, then two GPU smoke launches passed with only one build. The resulting image ID matches the existing runtime above. Ordinary `make docker-smoke` also passes using the unchanged default image. This verifies first-use preparation without deleting or replacing the shared image; it does not re-test downloading all layers into an empty daemon. All 2,611 source hashes match after verification, 31 relative documentation links and `git diff --check` pass, and no KFD process remains. The 45-task matrix, agent optimization, and profiler probes were not repeated for this image-preparation change.
