### PR TITLE
audit(tasks): quality_loop task quality pass

### DIFF
--- a/tasks/triton2triton/geak_eval/L1/refk_identity/kernel.py
+++ b/tasks/triton2triton/geak_eval/L1/refk_identity/kernel.py
@@ -6,7 +6,6 @@ Copies an input tensor to an output tensor element-wise.
 Triton kernel generated from PyTorch's `output.copy_(input)` on float16 1-D tensors.
 """
 
-import torch
 import triton
 import triton.language as tl
 
@@ -32,91 +31,3 @@ def _identity_kernel(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr):
     xmask = xindex < xnumel
     tmp0 = tl.load(in_ptr0 + xindex, xmask).to(tl.float32)
     tl.store(out_ptr0 + xindex, tmp0, xmask)
-
-
-# ============================================================================
-# PYTHON WRAPPER
-# ============================================================================
-
-
-def identity_triton(input_tensor: torch.Tensor, output_tensor: torch.Tensor) -> torch.Tensor:
-    xnumel = input_tensor.numel()
-    grid = lambda meta: (triton.cdiv(xnumel, meta["XBLOCK"]),)
-    _identity_kernel[grid](input_tensor, output_tensor, xnumel)
-    return output_tensor
-
-
-# ============================================================================
-# REFERENCE IMPLEMENTATION (pure PyTorch)
-# ============================================================================
-
-
-def identity_pytorch(input_tensor: torch.Tensor, output_tensor: torch.Tensor) -> torch.Tensor:
-    output_tensor[...] = input_tensor
-    return output_tensor
-
-
-# ============================================================================
-# ENTRY POINTS (for GEAK harness)
-# ============================================================================
-
-
-def triton_op(size, seed):
-    gen = torch.Generator(device="cuda")
-    gen.manual_seed(seed)
-    data = torch.empty(size, device="cuda", dtype=torch.float16)
-    data.uniform_(0, 1, generator=gen)
-    output = torch.empty_like(data)
-    return identity_triton(data, output)
-
-
-def torch_op(size, seed):
-    gen = torch.Generator(device="cuda")
-    gen.manual_seed(seed)
-    data = torch.empty(size, device="cuda", dtype=torch.float16)
-    data.uniform_(0, 1, generator=gen)
-    output = torch.empty_like(data)
-    return identity_pytorch(data, output)
-
-
-# ============================================================================
-# SYNTHETIC INPUT BUILDER
-# ============================================================================
-
-
-def get_inputs(size, seed=42, device="cuda"):
-    gen = torch.Generator(device=device)
-    gen.manual_seed(seed)
-    data = torch.empty(size, device=device, dtype=torch.float16)
-    data.uniform_(0, 1, generator=gen)
-    output = torch.empty_like(data)
-    return data, output
-
-
-# ============================================================================
-# CONFIG SPACE — shapes exercised by test_kernel_harness.py
-# ============================================================================
-
-
-EVAL_CONFIGS = [
-    # tests from task.yml
-    {"size": 127, "seed": 4242},
-    {"size": 128, "seed": 5236},
-    {"size": 129, "seed": 1001},
-    {"size": 256, "seed": 5531},
-    {"size": 512, "seed": 9173},
-    # benchmarks from task.yml
-    {"size": 1024, "seed": 54352},
-    {"size": 2048, "seed": 93246},
-    {"size": 4096, "seed": 6256},
-    {"size": 8192, "seed": 8841},
-    {"size": 16384, "seed": 6252},
-    {"size": 32768, "seed": 52624},
-    {"size": 65536, "seed": 125432},
-]
-
-PROFILE_CONFIGS = [
-    {"size": 1024, "seed": 54352},
-    {"size": 8192, "seed": 8841},
-    {"size": 65536, "seed": 125432},
-]

--- a/tasks/triton2triton/geak_eval/L1/refk_identity/test_kernel_harness.py
+++ b/tasks/triton2triton/geak_eval/L1/refk_identity/test_kernel_harness.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Test harness for the identity kernel.
-
-Timing and correctness live HERE, not in kernel.py — the agent edits kernel.py,
-so an embedded benchmark there could be gamed. The harness owns the measurement
-and only imports the kernel-side building blocks (kernel, wrapper, input builder).
-"""
+"""Protected correctness and performance harness for the identity kernel."""
 import argparse
 import json
 import math
@@ -53,14 +48,51 @@ if _HARNESS_DIR not in sys.path:
     sys.path.insert(0, _HARNESS_DIR)
 
 import torch
+import triton
 
-from kernel import (
-    EVAL_CONFIGS,
-    PROFILE_CONFIGS,
-    get_inputs,
-    identity_triton,
-    identity_pytorch,
-)
+from kernel import _identity_kernel
+
+
+def identity_triton(input_tensor: torch.Tensor, output_tensor: torch.Tensor) -> torch.Tensor:
+    """Launch the editable kernel using the task's immutable call contract."""
+    xnumel = input_tensor.numel()
+    grid = lambda meta: (triton.cdiv(xnumel, meta["XBLOCK"]),)
+    _identity_kernel[grid](input_tensor, output_tensor, xnumel)
+    return output_tensor
+
+
+def identity_pytorch(input_tensor: torch.Tensor, output_tensor: torch.Tensor) -> torch.Tensor:
+    """Trusted reference implementation."""
+    output_tensor[...] = input_tensor
+    return output_tensor
+
+
+def get_inputs(size, seed=42, device="cuda"):
+    """Build deterministic representative inputs and a reusable output tensor."""
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    data = torch.empty(size, device=device, dtype=torch.float16)
+    data.uniform_(0, 1, generator=gen)
+    output = torch.empty_like(data)
+    return data, output
+
+
+EVAL_CONFIGS = [
+    # tests from task.yml
+    {"size": 127, "seed": 4242},
+    {"size": 128, "seed": 5236},
+    {"size": 129, "seed": 1001},
+    {"size": 256, "seed": 5531},
+    {"size": 512, "seed": 9173},
+    # benchmarks from task.yml
+    {"size": 1024, "seed": 54352},
+    {"size": 2048, "seed": 93246},
+    {"size": 4096, "seed": 6256},
+    {"size": 8192, "seed": 8841},
+    {"size": 16384, "seed": 6252},
+    {"size": 32768, "seed": 52624},
+    {"size": 65536, "seed": 125432},
+]
 
 WARMUP = 10
 ITERATIONS = int(os.environ.get("GEAK_BENCHMARK_ITERATIONS", "100"))

--- a/tasks/triton2triton/geak_eval/L3/fused_rms_fp8/test_kernel_harness.py
+++ b/tasks/triton2triton/geak_eval/L3/fused_rms_fp8/test_kernel_harness.py
@@ -136,7 +136,12 @@ import math
 import torch
 import torch.nn.functional as F
 
-from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
+from aiter.ops.triton.fused_fp8_quant import (
+    fused_flatten_fp8_group_quant,
+    fused_reduce_act_mul_fp8_group_quant,
+    fused_reduce_rms_fp8_group_quant,
+    fused_rms_fp8_group_quant,
+)
 import aiter
 
 fp8_dtype = aiter.dtypes.fp8
@@ -257,6 +262,104 @@ def run_torch_rms_fp8_group_quant(
     return (y1_q, y1_s), y1.to(x1.dtype), y2.to(x1.dtype), s.to(x1.dtype)
 
 
+def assert_group_quant_close(actual, expected, group_size=128):
+    actual_q, actual_scale = actual
+    expected_q, expected_scale = expected
+    torch.testing.assert_close(
+        actual_scale, expected_scale, atol=1e-5, rtol=RTOL
+    )
+    actual_upcast = upcast(
+        actual_q, actual_scale, dtype=torch.float32, group_size=group_size
+    )
+    expected_upcast = upcast(
+        expected_q, expected_scale, dtype=torch.float32, group_size=group_size
+    )
+    torch.testing.assert_close(
+        actual_upcast, expected_upcast, atol=ATOL, rtol=RTOL
+    )
+
+
+def check_flatten_fp8_group_quant(dtype, group_size):
+    torch.manual_seed(43)
+    x = (torch.randn((3, 2, 256), dtype=dtype) / 10).to("cuda")
+    actual = fused_flatten_fp8_group_quant(
+        x, group_size=group_size, dtype_quant=fp8_dtype
+    )
+    flattened = x.reshape(x.shape[0], -1).to(torch.float32)
+    expected = per_token_fp8_group_quant(flattened, fp8_dtype, group_size)
+    assert_group_quant_close(actual, expected, group_size)
+
+
+def check_reduce_act_mul_fp8_group_quant(dtype, group_size):
+    torch.manual_seed(44)
+    split_k, M, N, N2 = 3, 3, 256, 128
+    x = (torch.randn((split_k, M, 2 * N), dtype=dtype) / 10).to("cuda")
+    x2 = (torch.randn((split_k, M, N2), dtype=dtype) / 10).to("cuda")
+
+    actual, actual_y2 = fused_reduce_act_mul_fp8_group_quant(
+        x,
+        activation="silu",
+        x2=x2,
+        group_size=group_size,
+        dtype_quant=fp8_dtype,
+        dtype=dtype,
+    )
+
+    reduced = x.to(torch.float32).sum(dim=0)
+    expected_unquantized = F.silu(reduced[:, :N]) * reduced[:, N:]
+    expected = per_token_fp8_group_quant(
+        expected_unquantized, fp8_dtype, group_size
+    )
+    expected_y2 = x2.to(torch.float32).sum(dim=0).to(dtype)
+    assert_group_quant_close(actual, expected, group_size)
+    torch.testing.assert_close(actual_y2, expected_y2, atol=ATOL, rtol=RTOL)
+
+
+def check_reduce_rms_fp8_group_quant(dtype, group_size):
+    torch.manual_seed(45)
+    split_k, M, N1, N2, N3 = 3, 2, 256, 256, 128
+    inp1 = (torch.randn((split_k, M, N1), dtype=dtype) / 10).to("cuda")
+    inp2 = (torch.randn((split_k, M, N2), dtype=dtype) / 10).to("cuda")
+    inp3 = (torch.randn((split_k, M, N3), dtype=dtype) / 10).to("cuda")
+    res1 = (torch.randn((M, N1), dtype=dtype) / 10).to("cuda")
+    weight1 = torch.linspace(0.5, 1.5, N1, dtype=torch.float32).to("cuda")
+    weight2 = torch.linspace(1.5, 0.5, N2, dtype=torch.float32).to("cuda")
+
+    actual, actual_y1, actual_y2, actual_res1, actual_y3 = \
+        fused_reduce_rms_fp8_group_quant(
+            inp1,
+            weight1,
+            1e-6,
+            inp2=inp2,
+            inp2_weight=weight2,
+            inp2_epsilon=1e-6,
+            inp3=inp3,
+            group_size=group_size,
+            dtype_quant=fp8_dtype,
+            dtype=dtype,
+            res1=res1,
+            output_unquantized_inp1=True,
+        )
+
+    expected_res1_fp32 = inp1.to(torch.float32).sum(dim=0) + res1.to(torch.float32)
+    expected_y1_fp32 = rmsnorm(expected_res1_fp32, weight1, 1e-6)
+    expected = per_token_fp8_group_quant(
+        expected_y1_fp32, fp8_dtype, group_size
+    )
+    expected_y2 = rmsnorm(inp2.to(torch.float32).sum(dim=0), weight2, 1e-6).to(dtype)
+    expected_y3 = inp3.to(torch.float32).sum(dim=0).to(dtype)
+
+    assert_group_quant_close(actual, expected, group_size)
+    torch.testing.assert_close(
+        actual_y1, expected_y1_fp32.to(dtype), atol=ATOL, rtol=RTOL
+    )
+    torch.testing.assert_close(
+        actual_res1, expected_res1_fp32.to(dtype), atol=ATOL, rtol=RTOL
+    )
+    torch.testing.assert_close(actual_y2, expected_y2, atol=ATOL, rtol=RTOL)
+    torch.testing.assert_close(actual_y3, expected_y3, atol=ATOL, rtol=RTOL)
+
+
 # ============================================================================
 # INPUT GENERATION
 # ============================================================================
@@ -330,10 +433,28 @@ def run_correctness(shapes=None, verbose=True):
             if verbose:
                 print(f"  FAIL: ({M}, {N1}, {N2}) - {str(e)[:50]}")
 
+    additional_checks = [
+        ("flatten_fp8_group_quant", check_flatten_fp8_group_quant),
+        ("reduce_act_mul_fp8_group_quant", check_reduce_act_mul_fp8_group_quant),
+        ("reduce_rms_fp8_group_quant", check_reduce_rms_fp8_group_quant),
+    ]
+    for name, check in additional_checks:
+        try:
+            check(dtype, group_size)
+            results.append({"config": name, "correct": True})
+            if verbose:
+                print(f"  PASS: {name}")
+        except Exception as e:
+            failures.append({"config": name, "error": str(e)})
+            if verbose:
+                print(f"  FAIL: {name} - {str(e)[:120]}")
+        finally:
+            torch.cuda.empty_cache()
+
     if verbose:
         print("-" * 62)
         print(
-            f"{'Status:':<22} {'ALL PASS' if not failures else f'FAILED ({len(failures)}/{len(shapes)})'}"
+            f"{'Status:':<22} {'ALL PASS' if not failures else f'FAILED ({len(failures)}/{len(shapes) + len(additional_checks)})'}"
         )
 
     return {
@@ -537,7 +658,9 @@ if __name__ == "__main__":
 
     if args.correctness:
         print("\n[Correctness Mode]")
-        run_correctness(HARNESS_SHAPES)
+        correctness = run_correctness(HARNESS_SHAPES)
+        if not correctness["correct"]:
+            raise SystemExit(1)
     elif args.profile:
         print("\n[Profile Mode]")
         run_profile(PROFILE_SHAPES, warmup=args.warmup, iters=args.iterations)

--- a/tasks/triton2triton/rocmbench/hard/rmsnorm_bwd/rmsnorm_bwd.py
+++ b/tasks/triton2triton/rocmbench/hard/rmsnorm_bwd/rmsnorm_bwd.py
@@ -632,8 +632,8 @@ def test_rmsnorm(M, N, ZERO_CENTERED_GAMMA, in_dtype_str, out_dtype_str, request
     f"Triton grad g:\n{grad_g_triton}\n\nPyTorch grad_g:\n{grad_g_ref}"
 
 
-# --- Define TFLOPS and GB/s calculators for RMSNorm Forward ---
-def calculate_rmsnorm_fwd_gbps(params: dict, ms: float) -> float:
+# --- Define TFLOPS and GB/s calculators for the RMSNorm backward target ---
+def calculate_rmsnorm_bwd_gbps(params: dict, ms: float) -> float:
     M, N = params['M'], params['N']
     dtype_str = params.get('dtype_str', 'fp16')
     if dtype_str == 'fp32': current_dtype = torch.float32
@@ -641,28 +641,20 @@ def calculate_rmsnorm_fwd_gbps(params: dict, ms: float) -> float:
     else: current_dtype = torch.float16
     element_size = torch.tensor([], dtype=current_dtype).element_size()
     
-    # Read x (M,N), g (N)
-    # Write y (M,N), rsigma (M)
-    bytes_read_x = M * N * element_size
-    bytes_read_g = N * element_size
-    bytes_write_y = M * N * element_size
-    bytes_write_rsigma = M * 4 # rsigma is usually float32
+    # Read grad_output (M,N), x (M,N), g (N), and rsigma (M).
+    # Write dx (M,N) and the fp32 intermediate dg (M,N).
+    bytes_read = 2 * M * N * element_size + N * element_size + M * 4
+    bytes_written = M * N * element_size + M * N * 4
 
-    total_bytes = bytes_read_x + bytes_read_g + bytes_write_y + bytes_write_rsigma
+    total_bytes = bytes_read + bytes_written
     gbps = total_bytes / (ms / 1000) / 1e9
     return gbps
 
-def calculate_rmsnorm_fwd_tflops(params: dict, ms: float) -> float:
+def calculate_rmsnorm_bwd_tflops(params: dict, ms: float) -> float:
     M, N = params['M'], params['N']
-    # FLOPs for RMSNorm forward:
-    # 1. Sum of squares: N squares, N-1 additions per row (2N-1 ops)
-    # 2. Mean square: 1 division per row (1 op)
-    # 3. rsqrt: (approx ~5-10 ops, let's say 5)
-    # 4. Normalize & Scale: N mult (x*rsigma), N mult (*g) per row (2N ops)
-    # (If ZERO_CENTERED_GAMMA, N additions for g = g+1)
-    # Total per row approx: (2N-1) + 1 + 5 + 2N = 4N + 5 ops
-    # If ZERO_CENTERED_GAMMA: add N ops => 5N + 5
-    flops_per_row = 4 * N + 5
+    # Per row: grad_sum uses 3N-1 ops, dx approximately 7N+3 ops,
+    # and dg uses 2N ops. Zero-centered gamma adds N additions.
+    flops_per_row = 12 * N + 2
     if params.get('ZERO_CENTERED_GAMMA', False):
         flops_per_row += N
     total_flops = M * flops_per_row
@@ -691,18 +683,15 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, dtype_str, request):
     elif dtype_str == 'bf16': current_dtype = torch.bfloat16
     else: current_dtype = torch.float16
 
-    # Prepare inputs and output buffers for RMSNorm.apply
+    # Prepare inputs and output buffers for rms_bwd_kernel.
     x = torch.randn(M, N, device='cuda', dtype=current_dtype)
     g = torch.rand(N, device='cuda', dtype=current_dtype) # Original test_rmsnorm used (1,N)
                                                        # Kernel expects g_ptr + col_offsets, so 1D g is fine.
-    y_buffer = torch.empty_like(x) # Output buffer for forward
-    rsigma_buffer = torch.empty(M, device='cuda', dtype=torch.float32) # rsigma output
-
-    # Dummy buffers for backward context (not used by fwd pass, but part of RMSNorm.apply signature)
-    # Their dtypes should match what backward pass would expect if it were called.
-    dx_dummy = torch.empty_like(x)
-    dg_dummy = torch.empty_like(g)
-    dg_tmp_dummy = torch.empty(M, N, device='cuda', dtype=torch.float32) # As per original test_rmsnorm
+    grad_output = torch.randn_like(x)
+    y_buffer = torch.empty_like(x)
+    rsigma_buffer = torch.empty(M, device='cuda', dtype=torch.float32)
+    dx_buffer = torch.empty_like(x)
+    dg_tmp_buffer = torch.empty(M, N, device='cuda', dtype=torch.float32)
 
     # Kernel launch parameters (from original test_rmsnorm)
     n_rows, n_cols = x.shape
@@ -716,13 +705,26 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, dtype_str, request):
     NUM_PRGMS_fwd = min(n_rows, get_num_sms()) if n_rows > 0 and get_num_sms() > 0 else 1
 
 
-    # --- Create op_lambda for benchmarking the forward pass ---
-    op_lambda = lambda: rmsnorm(
-        x, g, y_buffer, rsigma_buffer,
-        dx_dummy, dg_dummy, dg_tmp_dummy,
-        n_rows, n_cols, ZERO_CENTERED_GAMMA,
-        blk_size_fwd, USE_BLOCKED_fwd, NUM_PRGMS_fwd, eps
+    # Populate the saved forward statistic outside the timed region.
+    grid_fwd = lambda meta: (NUM_PRGMS_fwd, )
+    rms_kernel[grid_fwd](
+        y_buffer, x, g, rsigma_buffer, x.stride(0), y_buffer.stride(0),
+        n_rows, n_cols, eps, ZERO_CENTERED_GAMMA,
+        blk_size_fwd, USE_BLOCKED_fwd, NUM_PRGMS_fwd
     )
+
+    # Time exactly the declared editable target. Both outputs are fully
+    # overwritten on every invocation, so repeated samples need no state reset.
+    grid_bwd = lambda meta: (NUM_PRGMS_fwd, )
+
+    def op_lambda():
+        rms_bwd_kernel[grid_bwd](
+            grad_output, x, g, rsigma_buffer, dx_buffer, dg_tmp_buffer,
+            x.stride(0), grad_output.stride(0), n_rows, n_cols,
+            ZERO_CENTERED_GAMMA, blk_size_fwd, USE_BLOCKED_fwd,
+            NUM_PRGMS_fwd, num_warps=8
+        )
+        return dx_buffer, dg_tmp_buffer
 
     # --- Benchmarking ---
     bench_config = do_bench_config(warm_up=10, repetition=100)
@@ -739,8 +741,8 @@ def test_performance(M, N, ZERO_CENTERED_GAMMA, dtype_str, request):
     }
 
     benchmarker.run_benchmark(current_params_dict=current_params_for_logs_and_calc,
-                              gbps_calculator=calculate_rmsnorm_fwd_gbps,
-                              tflops_calculator=calculate_rmsnorm_fwd_tflops)
+                              gbps_calculator=calculate_rmsnorm_bwd_gbps,
+                              tflops_calculator=calculate_rmsnorm_bwd_tflops)
     
 ######################################## HELPERS for Eval ########################################     
 # --- Pytest hook to save the dictionary at the end of the session ---  

--- a/tasks/triton2triton/rocmbench/medium/test_cast_matmul/test_cast_matmul.py
+++ b/tasks/triton2triton/rocmbench/medium/test_cast_matmul/test_cast_matmul.py
@@ -114,7 +114,12 @@ def set_seed(seed: int = 42) -> None:
                           for (M, K, N) in [(128, 128, 128), (1280, 768, 1024)]  #
                           for w in input_dtypes
                           for x in input_dtypes  #
-                          for o in out_dtypes])
+                          for o in out_dtypes] + [
+                             pytest.param(31, 48, 48, "float16", "float32", "float16",
+                                          id="sub_64_ragged_k_tail"),
+                             pytest.param(65, 48, 80, "float64", "float16", "float32",
+                                          id="cross_64_ragged_k_tail"),
+                         ])
 def test_cast_matmul(M, K, N, w_dtype, x_dtype, out_dtype, request):
     set_seed()
 

--- a/tasks/triton2triton/vllm/triton_awq_dequantize/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_awq_dequantize/scripts/task_runner.py
@@ -12,14 +12,32 @@ os.chdir(TASK_DIR)
 TASK_NAME = "triton2triton/triton_awq_dequantize"
 SOURCE_FILE = os.path.join(TASK_DIR, "source", "triton_awq_dequantize.py")
 
-# Test configurations: (K, N_packed, group_size)
+# Performance configurations: (K, N_packed, group_size)
 # qweight shape: [K, N_packed], scales shape: [K//G, N_packed*8], zeros shape: [K//G, N_packed]
-TEST_SHAPES = [
+PERFORMANCE_TEST_SHAPES = [
     (64, 8, 32),
     (128, 16, 32),
     (128, 16, 64),
     (256, 32, 128),
     (256, 32, 64),
+]
+
+# Correctness extends the benchmark shapes with focused boundary coverage. Keep
+# these separate so correctness hardening does not change performance scoring.
+CORRECTNESS_TEST_CASES = [
+    {"K": K, "N_packed": N_packed, "group_size": group_size}
+    for K, N_packed, group_size in PERFORMANCE_TEST_SHAPES
+] + [
+    {
+        "K": 33,
+        "N_packed": 9,
+        "group_size": 33,
+        "scale_dtype": "float32",
+        "signed_packed": True,
+    },
+    {"K": 96, "N_packed": 33, "group_size": 32, "scale_dtype": "bfloat16"},
+    {"K": 512, "N_packed": 65, "group_size": 64},
+    {"K": 1024, "N_packed": 128, "group_size": 128},
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
@@ -79,6 +97,23 @@ def reference_awq_dequantize(qweight, scales, zeros, group_size):
     return result.to(scales.dtype)
 
 
+def make_packed_int32(shape, device, signed_top_nibbles=False):
+    """Create packed AWQ words, optionally covering every signed top nibble."""
+    import torch
+
+    if not signed_top_nibbles:
+        return torch.randint(0, 2**31, shape, device=device, dtype=torch.int32)
+
+    lower_bits = torch.randint(0, 2**28, shape, device=device, dtype=torch.int32)
+    top_nibbles = (
+        torch.arange(lower_bits.numel(), device=device, dtype=torch.int64)
+        .reshape(shape)
+        .remainder(8)
+        .add(8)
+    )
+    return (lower_bits.to(torch.int64) | (top_nibbles << 28)).to(torch.int32)
+
+
 def run_compile():
     try:
         import ast
@@ -101,18 +136,25 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    dtype = torch.float16
-
-    for i, (K, N_packed, group_size) in enumerate(TEST_SHAPES):
+    for i, case in enumerate(CORRECTNESS_TEST_CASES):
+        K = case["K"]
+        N_packed = case["N_packed"]
+        group_size = case["group_size"]
+        dtype = getattr(torch, case.get("scale_dtype", "float16"))
+        signed_packed = case.get("signed_packed", False)
         try:
             torch.manual_seed(42 + i)
             N = N_packed * 8
             num_groups = K // group_size
 
             # Create random packed weights (int32, each packing 8x 4-bit values)
-            qweight = torch.randint(0, 2**31, (K, N_packed), device=device, dtype=torch.int32)
+            qweight = make_packed_int32(
+                (K, N_packed), device, signed_top_nibbles=signed_packed
+            )
             scales = torch.randn(num_groups, N, device=device, dtype=dtype).abs() * 0.1 + 0.01
-            zeros = torch.randint(0, 2**31, (num_groups, N_packed), device=device, dtype=torch.int32)
+            zeros = make_packed_int32(
+                (num_groups, N_packed), device, signed_top_nibbles=signed_packed
+            )
 
             # Run Triton kernel
             result = mod.awq_dequantize_triton(qweight, scales, zeros)
@@ -125,12 +167,14 @@ def run_correctness():
             if not torch.allclose(result, ref, atol=1e-2, rtol=1e-2):
                 max_diff = (result - ref).abs().max().item()
                 return False, (
-                    f"Shape {i+1} (K={K}, N_packed={N_packed}, G={group_size}): "
+                    f"Shape {i+1} (K={K}, N_packed={N_packed}, G={group_size}, "
+                    f"dtype={dtype}, signed_packed={signed_packed}): "
                     f"max diff = {max_diff:.6f}"
                 )
         except Exception as e:
             return False, (
-                f"Shape {i+1} (K={K}, N_packed={N_packed}, G={group_size}): "
+                f"Shape {i+1} (K={K}, N_packed={N_packed}, G={group_size}, "
+                f"dtype={dtype}, signed_packed={signed_packed}): "
                 f"exception: {e}"
             )
 
@@ -148,7 +192,7 @@ def run_performance():
     dtype = torch.float16
     test_cases = []
 
-    for test_idx, (K, N_packed, group_size) in enumerate(TEST_SHAPES):
+    for test_idx, (K, N_packed, group_size) in enumerate(PERFORMANCE_TEST_SHAPES):
         try:
             N = N_packed * 8
             num_groups = K // group_size
@@ -210,7 +254,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(CORRECTNESS_TEST_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_compute_slot_mappings/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_compute_slot_mappings/scripts/task_runner.py
@@ -20,6 +20,50 @@ TEST_SHAPES = [
     (32, 256, 16, 256),
     (64, 512, 32, 256),
 ]
+
+# Correctness-only coverage. Keep these separate from TEST_SHAPES so coverage
+# changes do not alter the performance workload.
+ADDITIONAL_CORRECTNESS_CASES = [
+    {
+        "name": "uneven_empty_permuted_int64",
+        "query_lengths": [0, 1, 9, 17, 3],
+        "idx_mapping": [6, 0, 4, 2, 7],
+        "position_starts": [0, 7, 31, 4093, 1024],
+        "block_size": 8,
+        "max_num_reqs": 8,
+        "max_num_blocks": 520,
+        "block_table_row_padding": 5,
+        "max_num_tokens": 47,
+        "index_dtype": "int64",
+        "block_table_dtype": "int64",
+    },
+    {
+        "name": "multi_tile_data_and_padding",
+        "query_lengths": [1025, 0, 6],
+        "idx_mapping": [2, 5, 1],
+        "position_starts": [8190, 0, 65533],
+        "block_size": 64,
+        "max_num_reqs": 6,
+        "max_num_blocks": 1025,
+        "block_table_row_padding": 7,
+        "max_num_tokens": 3082,
+        "index_dtype": "int32",
+        "block_table_dtype": "int32",
+    },
+    {
+        "name": "all_empty_multi_tile_padding",
+        "query_lengths": [0, 0, 0],
+        "idx_mapping": [2, 0, 1],
+        "position_starts": [0, 0, 0],
+        "block_size": 8,
+        "max_num_reqs": 3,
+        "max_num_blocks": 1,
+        "block_table_row_padding": 3,
+        "max_num_tokens": 2053,
+        "index_dtype": "int32",
+        "block_table_dtype": "int32",
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -67,6 +111,62 @@ def reference_compute_slot_mappings(idx_mapping, query_start_loc, positions,
             slot_mappings[t] = block_num * block_size + block_off
 
     return slot_mappings
+
+
+def validate_slot_mappings(result, ref, case_name):
+    """Validate the token prefix returned by compute_slot_mappings."""
+    import torch
+
+    if result.shape != ref.shape:
+        return f"{case_name}: output shape {tuple(result.shape)} expected {tuple(ref.shape)}"
+    if result.dtype != torch.int64:
+        return f"{case_name}: output dtype {result.dtype} expected torch.int64"
+
+    result_cpu = result.cpu()
+    if not torch.equal(result_cpu, ref):
+        diff_mask = result_cpu != ref
+        first_diff = diff_mask.nonzero(as_tuple=True)[0][0].item()
+        return (
+            f"{case_name}: mismatch at index {first_diff}, "
+            f"got {result_cpu[first_diff].item()} expected {ref[first_diff].item()}"
+        )
+
+    return None
+
+
+def validate_padding(mod, idx_mapping, query_start_loc, positions, block_table,
+                     block_size, max_num_tokens, case_name):
+    """Launch into a poisoned full buffer and directly validate all padding."""
+    import torch
+
+    num_tokens = positions.shape[0]
+    padding_poison = 123456789
+    full_result = torch.full(
+        (max_num_tokens,), padding_poison, dtype=torch.int64,
+        device=positions.device,
+    )
+    mod._compute_slot_mappings_kernel[(idx_mapping.shape[0] + 1,)](
+        num_tokens,
+        max_num_tokens,
+        idx_mapping,
+        query_start_loc,
+        positions,
+        block_table,
+        block_table.stride(0),
+        block_size,
+        full_result,
+        PAD_ID=-1,
+        TRITON_BLOCK_SIZE=1024,
+    )
+    padding = full_result[num_tokens:].cpu()
+    if not torch.all(padding == -1).item():
+        first_diff = (padding != -1).nonzero(as_tuple=True)[0][0].item()
+        return (
+            f"{case_name}: padding mismatch at index {num_tokens + first_diff}, "
+            f"got {padding[first_diff].item()} expected -1"
+        )
+
+    return None
 
 
 def run_compile():
@@ -123,12 +223,85 @@ def run_correctness():
                 block_table.cpu(), block_size,
             )
 
-            if not torch.equal(result.cpu(), ref):
-                diff_mask = result.cpu() != ref
-                first_diff = diff_mask.nonzero(as_tuple=True)[0][0].item()
-                return False, f"Shape {i+1}: mismatch at index {first_diff}, got {result.cpu()[first_diff].item()} expected {ref[first_diff].item()}"
+            error = validate_slot_mappings(result, ref, f"Shape {i+1}")
+            if error:
+                return False, error
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, case in enumerate(ADDITIONAL_CORRECTNESS_CASES):
+        case_name = case["name"]
+        try:
+            torch.manual_seed(1042 + i)
+            query_lengths = case["query_lengths"]
+            query_start_values = [0]
+            for query_len in query_lengths:
+                query_start_values.append(query_start_values[-1] + query_len)
+
+            index_dtype = getattr(torch, case["index_dtype"])
+            idx_mapping = torch.tensor(
+                case["idx_mapping"], dtype=index_dtype, device=device
+            )
+            query_start_loc = torch.tensor(
+                query_start_values, dtype=index_dtype, device=device
+            )
+            position_values = []
+            for position_start, query_len in zip(
+                case["position_starts"], query_lengths
+            ):
+                position_values.extend(range(position_start, position_start + query_len))
+            positions = torch.tensor(
+                position_values, dtype=torch.int64, device=device
+            )
+
+            # Slice a wider allocation to retain a nonstandard row stride while
+            # keeping columns contiguous, as required by the kernel contract.
+            table_storage = torch.randint(
+                0,
+                10000,
+                (
+                    case["max_num_reqs"],
+                    case["max_num_blocks"] + case["block_table_row_padding"],
+                ),
+                dtype=getattr(torch, case["block_table_dtype"]),
+                device=device,
+            )
+            block_table = table_storage[:, :case["max_num_blocks"]]
+
+            result = mod.compute_slot_mappings(
+                idx_mapping,
+                query_start_loc,
+                positions,
+                block_table,
+                case["block_size"],
+                case["max_num_tokens"],
+            )
+            torch.cuda.synchronize()
+
+            ref = reference_compute_slot_mappings(
+                idx_mapping.cpu(),
+                query_start_loc.cpu(),
+                positions.cpu(),
+                block_table.cpu(),
+                case["block_size"],
+            )
+            error = validate_slot_mappings(result, ref, case_name)
+            if error:
+                return False, error
+            error = validate_padding(
+                mod,
+                idx_mapping,
+                query_start_loc,
+                positions,
+                block_table,
+                case["block_size"],
+                case["max_num_tokens"],
+                case_name,
+            )
+            if error:
+                return False, error
+        except Exception as e:
+            return False, f"{case_name}: exception: {e}"
 
     return True, None
 
@@ -213,7 +386,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(ADDITIONAL_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_ep_scatter_2/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_ep_scatter_2/scripts/task_runner.py
@@ -15,6 +15,19 @@ TEST_SHAPES = [
     (128, 512, 16, 2),
     (256, 512, 8, 2),
 ]
+
+# Correctness-only coverage. Keep TEST_SHAPES above stable because it also defines
+# the scored performance workload.
+# (name, num_tokens, hidden_size, num_experts, topk, dtype, negative_assignments)
+CORRECTNESS_CASES = [
+    (f"baseline_{i + 1}", *shape, "float16", False)
+    for i, shape in enumerate(TEST_SHAPES)
+] + [
+    ("single_token_boundary", 1, 1, 1, 1, "float32", False),
+    ("non_power_of_two_topk_1", 37, 65, 5, 1, "float32", True),
+    ("non_power_of_two_topk_3", 129, 257, 8, 3, "float16", True),
+    ("above_program_cap", 8209, 33, 8, 4, "float16", True),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -69,16 +82,25 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, (num_tokens, hidden_size, num_experts, topk) in enumerate(TEST_SHAPES):
+    for i, case in enumerate(CORRECTNESS_CASES):
+        (case_name, num_tokens, hidden_size, num_experts, topk,
+         dtype_name, negative_assignments) = case
         try:
             torch.manual_seed(42 + i)
-            recv_x = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.float16)
+            dtype = getattr(torch, dtype_name)
+            recv_x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
             recv_topk = torch.randint(0, num_experts, (num_tokens, topk), device=device, dtype=torch.int32)
+            if negative_assignments:
+                # Deterministically exercise ignored assignments throughout the
+                # tensor, including beyond the kernel's 8192-program grid cap.
+                recv_topk.view(-1)[::5] = -1
 
             # Compute tokens per expert
-            counts = torch.zeros(num_experts, dtype=torch.int32)
-            for e in range(num_experts):
-                counts[e] = (recv_topk.cpu() == e).sum().item()
+            recv_topk_cpu = recv_topk.cpu()
+            valid_assignments_cpu = recv_topk_cpu[recv_topk_cpu >= 0]
+            counts = torch.bincount(
+                valid_assignments_cpu.to(torch.int64), minlength=num_experts
+            ).to(torch.int32)
             aligned = [round_up_128(c.item()) for c in counts]
             total = sum(aligned)
 
@@ -87,26 +109,43 @@ def run_correctness():
             for a in aligned:
                 starts.append(s)
                 s += a
-            expert_start_loc = torch.tensor(starts, device=device, dtype=torch.int32)
+            initial_expert_start_loc = torch.tensor(starts, device=device, dtype=torch.int32)
+            expert_start_loc = initial_expert_start_loc.clone()
 
-            output_tensor = torch.zeros(total, hidden_size, device=device, dtype=torch.float16)
+            output_tensor = torch.zeros(total, hidden_size, device=device, dtype=dtype)
             output_index = torch.full((num_tokens, topk), -1, device=device, dtype=torch.int32)
 
             mod.ep_scatter_2(recv_x, recv_topk, expert_start_loc, output_tensor, output_index)
             torch.cuda.synchronize()
 
-            # Verify: each token's data was scattered to output_tensor at output_index positions
-            for t in range(min(num_tokens, 16)):  # Check subset
-                for k in range(topk):
-                    eid = recv_topk[t, k].item()
-                    if eid >= 0:
-                        idx = output_index[t, k].item()
-                        if idx < 0:
-                            return False, f"Shape {i+1}: output_index not set for token {t} topk {k}"
-                        if not torch.allclose(output_tensor[idx], recv_x[t], atol=1e-5):
-                            return False, f"Shape {i+1}: data mismatch at token {t} topk {k}"
+            valid_mask = recv_topk >= 0
+            invalid_mask = ~valid_mask
+            if invalid_mask.any() and not torch.all(output_index[invalid_mask] == -1):
+                return False, f"Case {case_name}: negative assignment modified output_index"
+
+            valid_indices = output_index[valid_mask].to(torch.int64)
+            valid_experts = recv_topk[valid_mask].to(torch.int64)
+            region_starts = initial_expert_start_loc[valid_experts].to(torch.int64)
+            counts_device = counts.to(device=device, dtype=torch.int64)
+            region_ends = region_starts + counts_device[valid_experts]
+            in_expert_region = ((valid_indices >= region_starts)
+                                & (valid_indices < region_ends))
+            if not torch.all(in_expert_region):
+                return False, f"Case {case_name}: output_index outside assigned expert region"
+
+            if torch.unique(valid_indices).numel() != valid_indices.numel():
+                return False, f"Case {case_name}: duplicate output_index values"
+
+            token_ids = torch.arange(num_tokens, device=device, dtype=torch.int64)
+            token_ids = token_ids[:, None].expand(num_tokens, topk)[valid_mask]
+            if not torch.equal(output_tensor[valid_indices], recv_x[token_ids]):
+                return False, f"Case {case_name}: scattered token data mismatch"
+
+            expected_final_counters = initial_expert_start_loc + counts.to(device)
+            if not torch.equal(expert_start_loc, expected_final_counters):
+                return False, f"Case {case_name}: final expert counters mismatch"
         except Exception as e:
-            return False, f"Shape {i+1}: exception: {e}"
+            return False, f"Case {case_name}: exception: {e}"
     return True, None
 
 
@@ -214,7 +253,7 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(CORRECTNESS_CASES)}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_fla_layernorm/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_fla_layernorm/scripts/task_runner.py
@@ -58,17 +58,20 @@ def reference(x, weight, bias=None, eps=1e-5, z=None, norm_before_gate=True, is_
     if is_rms_norm:
         var = (x_f * x_f).mean(dim=-1, keepdim=True)
         x_hat = x_f * torch.rsqrt(var + eps)
+        mean = None
     else:
         mean = x_f.mean(dim=-1, keepdim=True)
         var = ((x_f - mean) ** 2).mean(dim=-1, keepdim=True)
         x_hat = (x_f - mean) * torch.rsqrt(var + eps)
+    rstd = torch.rsqrt(var + eps)
     y = x_hat * weight.float().cpu()
     if bias is not None:
         y = y + bias.float().cpu()
     if z is not None and norm_before_gate:
         z_f = z.float().cpu()
         y = y * z_f * torch.sigmoid(z_f)
-    return y
+    mean = mean.squeeze(-1) if mean is not None else None
+    return y, mean, rstd.squeeze(-1)
 
 
 def gen_inputs(seed, case_idx, device):
@@ -111,16 +114,39 @@ def run_correctness():
             args_cpu = tuple(a.float().cpu() if isinstance(a, torch.Tensor) else a for a in args)
 
             result_tuple = mod.layer_norm_fwd(*args, **kwargs)
-            result = result_tuple[0] if isinstance(result_tuple, tuple) else result_tuple
-            ref = reference(
+            if not isinstance(result_tuple, tuple) or len(result_tuple) != 3:
+                return False, (
+                    f"Case {i+1} {test_case}: expected (out, mean, rstd), "
+                    f"got {type(result_tuple).__name__}"
+                )
+
+            results = result_tuple
+            refs = reference(
                 args_cpu[0], args_cpu[1], args_cpu[2],
                 z=kwargs["z"], norm_before_gate=kwargs["norm_before_gate"], is_rms_norm=kwargs["is_rms_norm"]
             )
-            r_cpu = result.float().cpu()
-            ref_f = ref.float()
-            if not torch.allclose(r_cpu, ref_f, atol=1e-3, rtol=1e-3):
-                max_diff = (r_cpu - ref_f).abs().max().item()
-                return False, f"Case {i+1} {test_case}: max diff = {max_diff:.6f}"
+            for name, result, ref in zip(("out", "mean", "rstd"), results, refs):
+                if ref is None:
+                    if result is not None:
+                        return False, f"Case {i+1} {test_case}: {name} must be None"
+                    continue
+                if not isinstance(result, torch.Tensor):
+                    return False, f"Case {i+1} {test_case}: {name} is not a tensor"
+
+                r_cpu = result.float().cpu()
+                ref_f = ref.float()
+                if r_cpu.shape != ref_f.shape:
+                    return False, (
+                        f"Case {i+1} {test_case}: {name} shape {tuple(r_cpu.shape)} "
+                        f"!= {tuple(ref_f.shape)}"
+                    )
+                if not torch.isfinite(r_cpu).all():
+                    return False, f"Case {i+1} {test_case}: {name} contains non-finite values"
+                if not torch.allclose(r_cpu, ref_f, atol=1e-3, rtol=1e-3):
+                    max_diff = (r_cpu - ref_f).abs().max().item()
+                    return False, (
+                        f"Case {i+1} {test_case}: {name} max diff = {max_diff:.6f}"
+                    )
 
             torch.cuda.synchronize()
         except Exception as e:

--- a/tasks/triton2triton/vllm/triton_gather_block_tables/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_gather_block_tables/scripts/task_runner.py
@@ -20,6 +20,47 @@ TEST_SHAPES = [
     (32, 256, 128),
     (64, 512, 256),
 ]
+
+# Correctness-only cases for non-power-of-two row counts and widths. The
+# explicit mappings repeat requests whose block counts cover empty, full, and
+# partial rows. Keeping these separate from TEST_SHAPES ensures correctness
+# coverage does not alter the performance workload.
+CORRECTNESS_EDGE_CASES = [
+    {
+        "name": "short_non_power_of_two",
+        "shape": (5, 11, 17),
+        "idx_mapping": (0, 1, 0, 10, 2),
+        "num_blocks": {0: 0, 1: 17, 10: 8, 2: 1},
+    },
+    {
+        "name": "wide_non_power_of_two",
+        "shape": (7, 13, 1009),
+        "idx_mapping": (3, 1, 3, 12, 0, 1, 6),
+        "num_blocks": {3: 0, 1: 1009, 12: 1008, 0: 1, 6: 503},
+    },
+    {
+        "name": "just_above_block_size",
+        "shape": (9, 17, 1025),
+        "idx_mapping": (4, 2, 4, 16, 0, 2, 7, 1, 9),
+        "num_blocks": {4: 0, 2: 1025, 16: 1024, 0: 1, 7: 513, 1: 17, 9: 1009},
+    },
+    {
+        "name": "multi_iteration_non_power_of_two",
+        "shape": (11, 19, 1537),
+        "idx_mapping": (5, 3, 5, 18, 0, 3, 8, 1, 10, 2, 12),
+        "num_blocks": {
+            5: 0,
+            3: 1537,
+            18: 1536,
+            0: 1,
+            8: 769,
+            1: 1024,
+            10: 1025,
+            2: 17,
+            12: 1501,
+        },
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -48,16 +89,14 @@ def load_module():
     return mod
 
 
-def reference_gather(idx_mapping, src_block_table, num_blocks):
-    import torch
+def reference_gather(idx_mapping, src_block_table, dst_block_table, num_blocks):
     num_reqs = idx_mapping.shape[0]
-    max_num_blocks = src_block_table.shape[1]
-    dst = torch.zeros_like(src_block_table)
+    dst = dst_block_table.clone()
     for b in range(num_reqs):
         req_idx = idx_mapping[b].item()
         nb = num_blocks[req_idx].item()
         dst[b, :nb] = src_block_table[req_idx, :nb]
-    return dst[:num_reqs]
+    return dst
 
 
 def run_compile():
@@ -95,11 +134,62 @@ def run_correctness():
             result = mod.gather_block_tables(idx_mapping, src_block_table, dst_block_table, num_blocks)
             torch.cuda.synchronize()
 
-            ref = reference_gather(idx_mapping.cpu(), src_block_table.cpu(), num_blocks.cpu())
-            if not torch.equal(result.cpu(), ref):
+            ref = reference_gather(
+                idx_mapping.cpu(),
+                src_block_table.cpu(),
+                torch.zeros_like(src_block_table, device="cpu"),
+                num_blocks.cpu(),
+            )
+            if not torch.equal(result.cpu(), ref[:num_reqs]):
                 return False, f"Shape {i+1}: mismatch"
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for case in CORRECTNESS_EDGE_CASES:
+        name = case["name"]
+        num_reqs, max_num_reqs, max_num_blocks = case["shape"]
+        try:
+            torch.manual_seed(1000 + max_num_blocks)
+            idx_mapping = torch.tensor(
+                case["idx_mapping"], dtype=torch.int32, device=device
+            )
+            src_block_table = torch.randint(
+                0,
+                10000,
+                (max_num_reqs, max_num_blocks),
+                dtype=torch.int32,
+                device=device,
+            )
+            dst_block_table = -torch.arange(
+                1,
+                max_num_reqs * max_num_blocks + 1,
+                dtype=torch.int32,
+                device=device,
+            ).reshape(max_num_reqs, max_num_blocks)
+            initial_dst = dst_block_table.clone()
+            num_blocks = torch.zeros(
+                max_num_reqs, dtype=torch.int32, device=device
+            )
+            for req_idx, count in case["num_blocks"].items():
+                num_blocks[req_idx] = count
+
+            result = mod.gather_block_tables(
+                idx_mapping, src_block_table, dst_block_table, num_blocks
+            )
+            torch.cuda.synchronize()
+
+            ref = reference_gather(
+                idx_mapping.cpu(),
+                src_block_table.cpu(),
+                initial_dst.cpu(),
+                num_blocks.cpu(),
+            )
+            if not torch.equal(result.cpu(), ref[:num_reqs]):
+                return False, f"Edge case {name}: returned rows mismatch"
+            if not torch.equal(dst_block_table.cpu(), ref):
+                return False, f"Edge case {name}: destination buffer mismatch"
+        except Exception as e:
+            return False, f"Edge case {name}: exception: {e}"
 
     return True, None
 
@@ -174,7 +264,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(CORRECTNESS_EDGE_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_kda_dot_kkt_intra/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_kda_dot_kkt_intra/scripts/task_runner.py
@@ -113,9 +113,31 @@ def run_correctness():
 
             results = mod.kda_dot_kkt_intra(*args, **kwargs)
             refs = reference(*args_cpu, **kwargs)
-            for idx, (r, ref) in enumerate(zip(results, refs)):
+            if not isinstance(results, tuple):
+                return False, (
+                    f"Shape {i+1}: expected a tuple of {len(refs)} outputs, "
+                    f"got {type(results).__name__}"
+                )
+            if len(results) != len(refs):
+                return False, (
+                    f"Shape {i+1}: expected {len(refs)} outputs, "
+                    f"got {len(results)}"
+                )
+
+            for idx, ref in enumerate(refs):
                 if ref is None:
                     continue
+                r = results[idx]
+                if not isinstance(r, torch.Tensor):
+                    return False, (
+                        f"Shape {i+1} output {idx}: expected a tensor, "
+                        f"got {type(r).__name__}"
+                    )
+                if r.shape != ref.shape:
+                    return False, (
+                        f"Shape {i+1} output {idx}: expected shape "
+                        f"{tuple(ref.shape)}, got {tuple(r.shape)}"
+                    )
                 r_cpu = r.float().cpu()
                 ref_f = ref.float()
                 if not torch.allclose(r_cpu, ref_f, atol=1e-2, rtol=1e-2):

--- a/tasks/triton2triton/vllm/triton_kda_dot_kkt_intra/tests/test_task_runner.py
+++ b/tasks/triton2triton/vllm/triton_kda_dot_kkt_intra/tests/test_task_runner.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+import torch
+
+from scripts import task_runner
+
+
+def test_correctness_rejects_empty_result_tuple(monkeypatch):
+    mod = SimpleNamespace(kda_dot_kkt_intra=lambda *args, **kwargs: ())
+    refs = (torch.zeros(1), torch.zeros(1))
+
+    monkeypatch.setattr(task_runner, "SEEDS", [42])
+    monkeypatch.setattr(task_runner, "load_module", lambda: mod)
+    monkeypatch.setattr(task_runner, "gen_inputs", lambda seed, device: ((0,), {}))
+    monkeypatch.setattr(task_runner, "reference", lambda *args, **kwargs: refs)
+
+    ok, error = task_runner.run_correctness()
+
+    assert not ok
+    assert error == "Shape 1: expected 2 outputs, got 0"

--- a/tasks/triton2triton/vllm/triton_layernorm_gated/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_layernorm_gated/scripts/task_runner.py
@@ -14,6 +14,36 @@ TEST_SHAPES = [
     (256, 1024, False, True, True),
     (512, 2048, True, False, True),
 ]
+
+# Correctness-only coverage for options and boundaries not represented by the
+# performance shapes. Keep these out of TEST_SHAPES so benchmark methodology is
+# unchanged.
+CORRECTNESS_CASES = [
+    {
+        "name": "norm_before_gate_false_fp32_tail_out",
+        "M": 7,
+        "N": 130,
+        "is_rms": False,
+        "has_bias": True,
+        "has_z": True,
+        "dtype": "float32",
+        "group_size": None,
+        "norm_before_gate": False,
+        "explicit_out": True,
+    },
+    {
+        "name": "grouped_bf16_tail",
+        "M": 5,
+        "N": 390,
+        "is_rms": False,
+        "has_bias": False,
+        "has_z": False,
+        "dtype": "bfloat16",
+        "group_size": 130,
+        "norm_before_gate": True,
+        "explicit_out": False,
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -42,26 +72,42 @@ def load_module():
     return mod
 
 
-def reference(x, weight, bias, eps, z, is_rms, norm_before_gate=True):
+def reference(
+    x,
+    weight,
+    bias,
+    eps,
+    z,
+    is_rms,
+    group_size=None,
+    norm_before_gate=True,
+):
     import torch
-    x_f = x.float()
+    M, N = x.shape
+    if group_size is None:
+        group_size = N
+    ngroups = N // group_size
+    x_f = x.float().reshape(M, ngroups, group_size)
     if z is not None and not norm_before_gate:
-        z_f = z.float()
+        z_f = z.float().reshape(M, ngroups, group_size)
         x_f = x_f * z_f * torch.sigmoid(z_f)
     if is_rms:
+        mean = None
         var = (x_f ** 2).mean(-1, keepdim=True)
         x_hat = x_f * torch.rsqrt(var + eps)
     else:
-        mean = x_f.mean(-1, keepdim=True)
-        var = ((x_f - mean) ** 2).mean(-1, keepdim=True)
-        x_hat = (x_f - mean) * torch.rsqrt(var + eps)
-    y = x_hat * weight.float()
+        grouped_mean = x_f.mean(-1, keepdim=True)
+        var = ((x_f - grouped_mean) ** 2).mean(-1, keepdim=True)
+        x_hat = (x_f - grouped_mean) * torch.rsqrt(var + eps)
+        mean = grouped_mean.squeeze(-1).T.contiguous().flatten()
+    rstd = torch.rsqrt(var + eps).squeeze(-1).T.contiguous().flatten()
+    y = x_hat * weight.float().reshape(ngroups, group_size)
     if bias is not None:
-        y = y + bias.float()
+        y = y + bias.float().reshape(ngroups, group_size)
     if z is not None and norm_before_gate:
-        z_f = z.float()
+        z_f = z.float().reshape(M, ngroups, group_size)
         y = y * z_f * torch.sigmoid(z_f)
-    return y.to(x.dtype)
+    return y.reshape(M, N).to(x.dtype), mean, rstd
 
 
 def run_compile():
@@ -84,21 +130,79 @@ def run_correctness():
     except Exception as e:
         return False, f"Load failed: {e}"
     device = "cuda"
-    for i, (M, N, is_rms, has_bias, has_z) in enumerate(TEST_SHAPES):
+    cases = [
+        {
+            "name": f"base_{i}",
+            "M": M,
+            "N": N,
+            "is_rms": is_rms,
+            "has_bias": has_bias,
+            "has_z": has_z,
+            "dtype": "float16",
+            "group_size": None,
+            "norm_before_gate": True,
+            "explicit_out": False,
+        }
+        for i, (M, N, is_rms, has_bias, has_z) in enumerate(TEST_SHAPES)
+    ] + CORRECTNESS_CASES
+    for i, case in enumerate(cases):
         try:
             torch.manual_seed(42 + i)
-            x = torch.randn(M, N, device=device, dtype=torch.float16)
-            w = torch.randn(N, device=device, dtype=torch.float16)
-            b = torch.randn(N, device=device, dtype=torch.float16) if has_bias else None
-            z = torch.randn(M, N, device=device, dtype=torch.float16) if has_z else None
+            dtype = getattr(torch, case["dtype"])
+            x = torch.randn(case["M"], case["N"], device=device, dtype=dtype)
+            w = torch.randn(case["N"], device=device, dtype=dtype)
+            b = (
+                torch.randn(case["N"], device=device, dtype=dtype)
+                if case["has_bias"]
+                else None
+            )
+            z = torch.randn_like(x) if case["has_z"] else None
+            supplied_out = torch.full_like(x, torch.nan) if case["explicit_out"] else None
             eps = 1e-5
-            out, _, _ = mod.layer_norm_fwd(x, w, b, eps, z=z, is_rms_norm=is_rms)
-            ref = reference(x, w, b, eps, z, is_rms)
-            if not torch.allclose(out, ref, atol=1e-2, rtol=1e-2):
-                diff = (out - ref).abs().max().item()
-                return False, f"Shape {i}: max diff={diff}"
+            out, mean, rstd = mod.layer_norm_fwd(
+                x,
+                w,
+                b,
+                eps,
+                z=z,
+                out=supplied_out,
+                group_size=case["group_size"],
+                norm_before_gate=case["norm_before_gate"],
+                is_rms_norm=case["is_rms"],
+            )
+            ref_out, ref_mean, ref_rstd = reference(
+                x,
+                w,
+                b,
+                eps,
+                z,
+                case["is_rms"],
+                group_size=case["group_size"],
+                norm_before_gate=case["norm_before_gate"],
+            )
+            if supplied_out is not None and out.data_ptr() != supplied_out.data_ptr():
+                return False, f"{case['name']}: did not return the supplied out buffer"
+            if not torch.allclose(out, ref_out, atol=1e-2, rtol=1e-2):
+                diff = (out - ref_out).abs().max().item()
+                return False, f"{case['name']}: output max diff={diff}"
+            if case["is_rms"]:
+                if mean is not None:
+                    return False, f"{case['name']}: RMSNorm returned a mean buffer"
+            else:
+                if mean is None:
+                    return False, f"{case['name']}: LayerNorm did not return mean"
+                if mean.shape != ref_mean.shape or mean.dtype != ref_mean.dtype:
+                    return False, f"{case['name']}: mean metadata mismatch"
+                if not torch.allclose(mean, ref_mean, atol=1e-5, rtol=1e-4):
+                    diff = (mean - ref_mean).abs().max().item()
+                    return False, f"{case['name']}: mean max diff={diff}"
+            if rstd.shape != ref_rstd.shape or rstd.dtype != ref_rstd.dtype:
+                return False, f"{case['name']}: rstd metadata mismatch"
+            if not torch.allclose(rstd, ref_rstd, atol=1e-5, rtol=1e-4):
+                diff = (rstd - ref_rstd).abs().max().item()
+                return False, f"{case['name']}: rstd max diff={diff}"
         except Exception as e:
-            return False, f"Shape {i}: {e}"
+            return False, f"{case['name']}: {e}"
     return True, None
 
 

--- a/tasks/triton2triton/vllm/triton_merge_16x16_to_32x32/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_merge_16x16_to_32x32/scripts/task_runner.py
@@ -13,6 +13,14 @@ TASK_NAME = "triton2triton/triton_merge_16x16_to_32x32"
 SOURCE_FILE = os.path.join(TASK_DIR, "source", "triton_merge_16x16_to_32x32.py")
 
 SEEDS = [42, 43, 44, 45, 46]
+CORRECTNESS_CASES = [
+    {"seed": seed, "B": 2, "T": 64, "H": 4, "dtype": "float32"}
+    for seed in SEEDS
+] + [
+    {"seed": 47, "B": 1, "T": 31, "H": 1, "dtype": "float16"},
+    {"seed": 48, "B": 3, "T": 33, "H": 2, "dtype": "bfloat16"},
+    {"seed": 49, "B": 1, "T": 47, "H": 5, "dtype": "float32"},
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -64,11 +72,11 @@ def reference(A):
     return Ai
 
 
-def gen_inputs(seed, device):
+def gen_inputs(seed, device, B=2, T=64, H=4, dtype="float32"):
     import torch
     torch.manual_seed(seed)
-    B, T, H, BT = 2, 64, 4, 32
-    A = torch.randn(B, T, H, BT, device=device, dtype=torch.float32) * 0.1
+    BT = 32
+    A = torch.randn(B, T, H, BT, device=device, dtype=getattr(torch, dtype)) * 0.1
     # The kernel expects strictly lower triangular blocks (within each BT x BT tile).
     # Zero out diagonal and upper triangular entries in the last dimension.
     idx = torch.arange(BT, device=device)
@@ -100,9 +108,9 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, seed in enumerate(SEEDS):
+    for i, case in enumerate(CORRECTNESS_CASES):
         try:
-            args, kwargs = gen_inputs(seed, device)
+            args, kwargs = gen_inputs(device=device, **case)
             args_cpu = tuple(a.float().cpu() if isinstance(a, torch.Tensor) else a for a in args)
 
             result = mod.merge_16x16_to_32x32(*args, **kwargs)
@@ -111,11 +119,11 @@ def run_correctness():
             ref_f = ref.float()
             if not torch.allclose(r_cpu, ref_f, atol=1e-2, rtol=1e-2):
                 max_diff = (r_cpu - ref_f).abs().max().item()
-                return False, f"Shape {i+1}: max diff = {max_diff:.6f}"
+                return False, f"Case {i+1} {case}: max diff = {max_diff:.6f}"
 
             torch.cuda.synchronize()
         except Exception as e:
-            return False, f"Shape {i+1}: exception: {e}"
+            return False, f"Case {i+1} {case}: exception: {e}"
     return True, None
 
 
@@ -180,7 +188,7 @@ def main():
 
     elif args_parsed.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(SEEDS)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(CORRECTNESS_CASES)}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_moe_mmk/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_moe_mmk/scripts/task_runner.py
@@ -8,12 +8,22 @@ TASK_NAME = "triton2triton/triton_moe_mmk"
 SOURCE_FILE = os.path.join(TASK_DIR, "source", "triton_moe_mmk.py")
 
 # (M, K, N)
-TEST_SHAPES = [
+PERFORMANCE_SHAPES = [
     (32, 64, 32),
     (64, 128, 64),
     (128, 256, 128),
     (256, 512, 256),
     (512, 1024, 512),
+]
+
+# Keep the scored benchmark set stable while exercising correctness-only tails
+# independently in each dimension. K=63 and K=65 cover both sides of the
+# K=64 block-size selection threshold.
+CORRECTNESS_SHAPES = PERFORMANCE_SHAPES + [
+    (33, 64, 64),
+    (64, 64, 47),
+    (64, 63, 32),
+    (32, 65, 64),
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
@@ -65,7 +75,7 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, (M, K, N) in enumerate(TEST_SHAPES):
+    for i, (M, K, N) in enumerate(CORRECTNESS_SHAPES):
         try:
             torch.manual_seed(42 + i)
             A = torch.randn(M, K, device=device, dtype=torch.float16) * 0.1
@@ -93,7 +103,7 @@ def run_performance():
     device = "cuda"
     test_cases = []
 
-    for test_idx, (M, K, N) in enumerate(TEST_SHAPES):
+    for test_idx, (M, K, N) in enumerate(PERFORMANCE_SHAPES):
         try:
             torch.manual_seed(42 + test_idx)
             A = torch.randn(M, K, device=device, dtype=torch.float16) * 0.1
@@ -147,7 +157,7 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(CORRECTNESS_SHAPES)}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_pack_seq/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_pack_seq/scripts/task_runner.py
@@ -20,6 +20,32 @@ TEST_SHAPES = [
     (3, [64, 32, 48], 256),
     (6, [10, 20, 15, 5, 25, 12], 128),
 ]
+
+# Correctness-only coverage beyond the fixed performance shapes above.  Each
+# case combines related boundaries so the suite stays small while exercising
+# the public wrapper's full input contract.
+ADDITIONAL_CORRECTNESS_CASES = [
+    {
+        "name": "default_pad_odd_d_float32",
+        "lengths": [17, 5, 9],
+        "feature_shape": (70,),
+        "dtype": "float32",
+    },
+    {
+        "name": "zero_lengths_long_time_bfloat16",
+        "lengths": [0, 70, 13, 0],
+        "feature_shape": (65,),
+        "dtype": "bfloat16",
+        "pad_value": 2.5,
+    },
+    {
+        "name": "multidimensional_float16",
+        "lengths": [9, 0, 4],
+        "feature_shape": (3, 5),
+        "dtype": "float16",
+        "pad_value": -1.25,
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -51,15 +77,19 @@ def load_module():
 def reference_pack_seq(x, lengths, pad_value=-float("inf")):
     """CPU/PyTorch reference for pack_seq."""
     import torch
-    N, D = x.shape
     B = len(lengths)
     Lmax = max(lengths)
 
-    out = torch.full((B, Lmax, D), pad_value, device=x.device, dtype=x.dtype)
+    out = torch.full(
+        (B, Lmax) + tuple(x.shape[1:]),
+        pad_value,
+        device=x.device,
+        dtype=x.dtype,
+    )
     offset = 0
     for b in range(B):
         seq_len = lengths[b]
-        out[b, :seq_len, :] = x[offset:offset + seq_len]
+        out[b, :seq_len] = x[offset:offset + seq_len]
         offset += seq_len
     return out
 
@@ -108,6 +138,33 @@ def run_correctness():
                 )
         except Exception as e:
             return False, f"Shape {i+1} (B={B}, D={D}): exception: {e}"
+
+    for i, case in enumerate(ADDITIONAL_CORRECTNESS_CASES):
+        try:
+            torch.manual_seed(100 + i)
+
+            lengths_list = case["lengths"]
+            N = sum(lengths_list)
+            x = torch.randn(
+                (N,) + case["feature_shape"],
+                device=device,
+                dtype=getattr(torch, case["dtype"]),
+            )
+            lengths = torch.tensor(lengths_list, device=device, dtype=torch.int32)
+
+            if "pad_value" in case:
+                pad_value = case["pad_value"]
+                result = mod.pack_seq(x, lengths, pad_value=pad_value)
+                ref = reference_pack_seq(x, lengths_list, pad_value=pad_value)
+            else:
+                result = mod.pack_seq(x, lengths)
+                ref = reference_pack_seq(x, lengths_list)
+            torch.cuda.synchronize()
+
+            if not torch.allclose(result, ref, atol=1e-3, rtol=1e-3):
+                return False, f"Case {case['name']}: output differs from reference"
+        except Exception as e:
+            return False, f"Case {case['name']}: exception: {e}"
 
     return True, None
 
@@ -206,7 +263,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(ADDITIONAL_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_per_token_group_quant_fp8/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_per_token_group_quant_fp8/scripts/task_runner.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import json
+import math
 import argparse
 import importlib.util
 
@@ -12,13 +13,59 @@ os.chdir(TASK_DIR)
 TASK_NAME = "triton2triton/triton_per_token_group_quant_fp8"
 SOURCE_FILE = os.path.join(TASK_DIR, "source", "triton_per_token_group_quant_fp8.py")
 
-# Test configs: (M, N, group_size)
+# Performance configs: (M, N, group_size)
 TEST_SHAPES = [
     (32, 128, 128),
     (64, 256, 128),
     (128, 512, 128),
     (256, 1024, 128),
     (64, 512, 64),
+]
+
+# Targeted correctness-only cases. Keep these separate from TEST_SHAPES so
+# hardening correctness coverage does not alter the performance workload.
+CORRECTNESS_CASES = [
+    {
+        "name": "zeros",
+        "shape": (1, 128),
+        "group_size": 32,
+        "input_kind": "zeros",
+        "input_dtype": "float16",
+    },
+    {
+        "name": "tiny_custom_eps",
+        "shape": (2, 96),
+        "group_size": 48,
+        "input_kind": "patterned",
+        "amplitudes": (5e-5, 1e-8),
+        "input_dtype": "float32",
+        "eps": 1e-4,
+    },
+    {
+        "name": "saturation_boundary_explicit_dtype",
+        "shape": (2, 128),
+        "group_size": 64,
+        "input_kind": "saturation_boundary",
+        "input_dtype": "float16",
+        "output_dtype": "wider_fp8",
+    },
+    {
+        "name": "mixed_dynamic_range_3d",
+        "shape": (2, 3, 192),
+        "group_size": 48,
+        "input_kind": "patterned",
+        "amplitudes": (2**-12, 2**-4, 1.0, 64.0),
+        "input_dtype": "bfloat16",
+    },
+    {
+        "name": "ue8m0_non_power_of_two_group",
+        "shape": (3, 120),
+        "group_size": 40,
+        "input_kind": "patterned",
+        "amplitudes": (0.75, 17.0, 93.0),
+        "input_dtype": "float32",
+        "use_ue8m0": True,
+    },
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
@@ -48,19 +95,22 @@ def load_module():
     return mod
 
 
-def reference_per_token_group_quant_fp8(x, group_size, fp8_dtype, eps=1e-10):
+def reference_per_token_group_quant_fp8(
+    x,
+    group_size,
+    fp8_dtype,
+    fp8_min,
+    fp8_max,
+    eps=1e-10,
+    use_ue8m0=False,
+):
     """CPU reference for per-token-group FP8 quantization."""
     import torch
-    M, N = x.shape
-    x_cpu = x.cpu().float()
-    finfo = torch.finfo(fp8_dtype)
 
-    # Use clamped values for fnuz
-    if fp8_dtype == torch.float8_e4m3fnuz:
-        fp8_min, fp8_max = -240.0, 240.0
-    else:
-        fp8_min, fp8_max = finfo.min, finfo.max
-
+    N = x.shape[-1]
+    leading_shape = x.shape[:-1]
+    x_cpu = x.cpu().float().reshape(-1, N)
+    M = x_cpu.shape[0]
     num_groups = N // group_size
     x_q = torch.zeros_like(x_cpu)
     x_s = torch.zeros(M, num_groups, dtype=torch.float32)
@@ -71,11 +121,111 @@ def reference_per_token_group_quant_fp8(x, group_size, fp8_dtype, eps=1e-10):
             end = start + group_size
             group = x_cpu[row, start:end]
             absmax = max(group.abs().max().item(), eps)
-            scale = absmax / fp8_max
+            scale_raw = absmax / fp8_max
+            scale = (
+                2.0 ** math.ceil(math.log2(scale_raw))
+                if use_ue8m0
+                else scale_raw
+            )
             x_s[row, g] = scale
             x_q[row, start:end] = (group / scale).clamp(fp8_min, fp8_max)
 
-    return x_q.to(fp8_dtype), x_s
+    scale_shape = leading_shape + (num_groups,)
+    return x_q.reshape(x.shape).to(fp8_dtype), x_s.reshape(scale_shape)
+
+
+def _get_reference_fp8_min_max(torch, fp8_dtype):
+    """Derive platform clamp limits independently of the implementation."""
+    if (
+        hasattr(torch, "float8_e4m3fnuz")
+        and fp8_dtype == torch.float8_e4m3fnuz
+    ):
+        return -240.0, 240.0
+    finfo = torch.finfo(fp8_dtype)
+    return finfo.min, finfo.max
+
+
+def _get_wider_fp8_dtype(torch, default_dtype, fp8_max):
+    """Return a supported explicit FP8 dtype that can represent the clamp range."""
+    for name in ("float8_e4m3fn", "float8_e4m3fnuz"):
+        if not hasattr(torch, name):
+            continue
+        dtype = getattr(torch, name)
+        if dtype == default_dtype or torch.finfo(dtype).max < fp8_max:
+            continue
+        try:
+            torch.empty(1, device="cuda", dtype=dtype)
+            return dtype
+        except Exception:
+            continue
+    return default_dtype
+
+
+def _make_patterned_input(torch, shape, group_size, amplitudes, dtype):
+    """Build deterministic groups whose maxima span the requested amplitudes."""
+    rows = math.prod(shape[:-1])
+    num_groups = shape[-1] // group_size
+    base = torch.linspace(-1.0, 1.0, group_size, dtype=torch.float32)
+    x = torch.empty((rows, shape[-1]), dtype=torch.float32)
+
+    for row in range(rows):
+        for group in range(num_groups):
+            amplitude = amplitudes[(row * num_groups + group) % len(amplitudes)]
+            start = group * group_size
+            x[row, start : start + group_size] = base * amplitude
+
+    return x.reshape(shape).to(device="cuda", dtype=dtype)
+
+
+def _make_correctness_input(torch, case, fp8_min, fp8_max):
+    dtype = getattr(torch, case["input_dtype"])
+    if case["input_kind"] == "zeros":
+        return torch.zeros(case["shape"], device="cuda", dtype=dtype)
+    if case["input_kind"] == "saturation_boundary":
+        return _make_patterned_input(
+            torch,
+            case["shape"],
+            case["group_size"],
+            (fp8_max * 0.25, abs(fp8_min) * 0.25),
+            dtype,
+        )
+    return _make_patterned_input(
+        torch,
+        case["shape"],
+        case["group_size"],
+        case["amplitudes"],
+        dtype,
+    )
+
+
+def _check_outputs(
+    torch,
+    case_name,
+    x_q,
+    x_s,
+    ref_q,
+    ref_s,
+    group_size,
+    *,
+    exact_quantized=False,
+    scale_atol=1e-5,
+    scale_rtol=1e-3,
+):
+    if not torch.allclose(x_s, ref_s, atol=scale_atol, rtol=scale_rtol):
+        max_diff = (x_s - ref_s).abs().max().item()
+        return f"{case_name}: scale max diff = {max_diff:.6g}"
+
+    if exact_quantized and not torch.equal(x_q.float(), ref_q.float()):
+        max_diff = (x_q.float() - ref_q.float()).abs().max().item()
+        return f"{case_name}: quantized max diff = {max_diff:.6g}"
+
+    x_dq = x_q.float() * x_s.repeat_interleave(group_size, dim=-1)
+    ref_dq = ref_q.float() * ref_s.repeat_interleave(group_size, dim=-1)
+    if not torch.allclose(x_dq, ref_dq, atol=1e-1, rtol=1e-1):
+        max_diff = (x_dq - ref_dq).abs().max().item()
+        return f"{case_name}: dequant max diff = {max_diff:.6f}"
+
+    return None
 
 
 def run_compile():
@@ -101,6 +251,7 @@ def run_correctness():
 
     device = "cuda"
     fp8_dtype = mod._get_fp8_dtype()
+    fp8_min, fp8_max = _get_reference_fp8_min_max(torch, fp8_dtype)
 
     for i, (M, N, group_size) in enumerate(TEST_SHAPES):
         try:
@@ -110,32 +261,80 @@ def run_correctness():
             x_q, x_s = mod.per_token_group_quant_fp8(x, group_size)
             torch.cuda.synchronize()
 
-            ref_q, ref_s = reference_per_token_group_quant_fp8(x, group_size, fp8_dtype)
+            ref_q, ref_s = reference_per_token_group_quant_fp8(
+                x, group_size, fp8_dtype, fp8_min, fp8_max
+            )
             ref_q = ref_q.to(device)
             ref_s = ref_s.to(device)
 
-            # Check scales
-            if not torch.allclose(x_s, ref_s, atol=1e-5, rtol=1e-3):
-                max_diff = (x_s - ref_s).abs().max().item()
-                return False, (
-                    f"Shape {i+1} (M={M}, N={N}, G={group_size}): "
-                    f"scale max diff = {max_diff:.6f}"
-                )
-
-            # Check quantized values by dequantizing
-            x_dq = x_q.float() * x_s.repeat_interleave(group_size, dim=-1)
-            ref_dq = ref_q.float().to(device) * ref_s.repeat_interleave(group_size, dim=-1)
-
-            if not torch.allclose(x_dq, ref_dq, atol=1e-1, rtol=1e-1):
-                max_diff = (x_dq - ref_dq).abs().max().item()
-                return False, (
-                    f"Shape {i+1} (M={M}, N={N}, G={group_size}): "
-                    f"dequant max diff = {max_diff:.6f}"
-                )
+            case_name = f"Shape {i+1} (M={M}, N={N}, G={group_size})"
+            error = _check_outputs(
+                torch, case_name, x_q, x_s, ref_q, ref_s, group_size
+            )
+            if error:
+                return False, error
         except Exception as e:
             return False, (
                 f"Shape {i+1} (M={M}, N={N}, G={group_size}): exception: {e}"
             )
+
+    wider_fp8_dtype = _get_wider_fp8_dtype(torch, fp8_dtype, fp8_max)
+    for case in CORRECTNESS_CASES:
+        case_name = case["name"]
+        try:
+            x = _make_correctness_input(torch, case, fp8_min, fp8_max)
+            output_dtype = (
+                wider_fp8_dtype
+                if case.get("output_dtype") == "wider_fp8"
+                else fp8_dtype
+            )
+            eps = case.get("eps", 1e-10)
+            use_ue8m0 = case.get("use_ue8m0", False)
+            group_size = case["group_size"]
+
+            x_q, x_s = mod.per_token_group_quant_fp8(
+                x,
+                group_size,
+                eps=eps,
+                dtype=output_dtype,
+                use_ue8m0=use_ue8m0,
+            )
+            torch.cuda.synchronize()
+
+            if x_q.dtype != output_dtype:
+                return False, (
+                    f"{case_name}: output dtype {x_q.dtype} does not match "
+                    f"requested dtype {output_dtype}"
+                )
+
+            ref_q, ref_s = reference_per_token_group_quant_fp8(
+                x,
+                group_size,
+                output_dtype,
+                fp8_min,
+                fp8_max,
+                eps=eps,
+                use_ue8m0=use_ue8m0,
+            )
+            ref_q = ref_q.to(device)
+            ref_s = ref_s.to(device)
+
+            error = _check_outputs(
+                torch,
+                case_name,
+                x_q,
+                x_s,
+                ref_q,
+                ref_s,
+                group_size,
+                exact_quantized=True,
+                scale_atol=0.0,
+                scale_rtol=1e-4,
+            )
+            if error:
+                return False, error
+        except Exception as e:
+            return False, f"{case_name}: exception: {e}"
 
     return True, None
 
@@ -206,7 +405,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_post_update/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_post_update/scripts/task_runner.py
@@ -20,6 +20,7 @@ TEST_SHAPES = [
     (32, 2048, 1024, 4),
     (64, 4096, 2048, 3),
 ]
+NUM_TARGETED_CORRECTNESS_CASES = 1
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -162,6 +163,73 @@ def run_correctness():
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
 
+    # Exercise a second 64-request program and its tail while covering state
+    # layouts and updates that random identity-mapped cases do not reach.
+    case_label = "Targeted multi-program tail"
+    try:
+        num_reqs = 70
+        max_num_reqs = 149
+        vocab_size = 257
+        max_model_len = 96
+        max_num_sampled = 5
+        query_len = max_num_sampled
+
+        req_ids = torch.arange(num_reqs, dtype=torch.int32, device=device)
+        # This affine permutation is unique over the selected requests, but is
+        # deliberately shuffled and sparse within the larger state arrays.
+        idx_mapping = (req_ids * 43 + 17) % max_num_reqs
+        query_start_loc = torch.arange(
+            num_reqs + 1, dtype=torch.int32, device=device
+        ) * query_len
+
+        state_ids = torch.arange(max_num_reqs, dtype=torch.int32, device=device)
+        num_computed_tokens = 10 + state_ids % 40
+        last_sampled_tokens = (state_ids * 11 + 3) % vocab_size
+        output_bin_counts = torch.full(
+            (max_num_reqs, vocab_size), 3, dtype=torch.int32, device=device
+        )
+
+        repeated_tokens = ((req_ids * 13 + 5) % vocab_size).unsqueeze(1)
+        sampled_tokens = repeated_tokens.expand(
+            num_reqs, max_num_sampled
+        ).clone()
+        num_sampled = req_ids % (max_num_sampled + 1)
+        num_rejected = query_len - num_sampled
+
+        all_token_ids = torch.full(
+            (max_num_reqs, max_model_len), -1, dtype=torch.int32, device=device
+        )
+        total_len = 8 + state_ids % 17
+
+        nct_g = num_computed_tokens.clone()
+        lst_g = last_sampled_tokens.clone()
+        obc_g = output_bin_counts.clone()
+        ati_g = all_token_ids.clone()
+        tl_g = total_len.clone()
+
+        mod.post_update(
+            idx_mapping, nct_g, lst_g, obc_g, sampled_tokens,
+            num_sampled, num_rejected, query_start_loc, ati_g, tl_g,
+        )
+        torch.cuda.synchronize()
+
+        ref = reference_post_update(
+            idx_mapping.cpu(), num_computed_tokens.cpu(), last_sampled_tokens.cpu(),
+            output_bin_counts.cpu(), sampled_tokens.cpu(), num_sampled.cpu(),
+            num_rejected.cpu(), query_start_loc.cpu(), all_token_ids.cpu(), total_len.cpu(),
+        )
+
+        outputs = (nct_g, lst_g, obc_g, ati_g, tl_g)
+        output_names = (
+            "num_computed_tokens", "last_sampled_tokens", "output_bin_counts",
+            "all_token_ids", "total_len",
+        )
+        for name, actual, expected in zip(output_names, outputs, ref):
+            if not torch.equal(actual.cpu(), expected):
+                return False, f"{case_label}: {name} mismatch"
+    except Exception as e:
+        return False, f"{case_label}: exception: {e}"
+
     return True, None
 
 
@@ -268,7 +336,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + NUM_TARGETED_CORRECTNESS_CASES,
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_prepare_pos_seq_lens/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_prepare_pos_seq_lens/scripts/task_runner.py
@@ -22,6 +22,7 @@ TEST_SHAPES = [
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
+OUTPUT_SENTINEL = -1
 
 
 # >>> AKA-GENERATED: shared CUDA-graph benchmark helpers - edit src/tools/perf/vllm_cuda_graph_block.py then run `make sync-perf-helpers` >>>
@@ -99,8 +100,14 @@ def run_correctness():
                 query_start_loc[r + 1] = query_start_loc[r] + query_len
             total_tokens = int(query_start_loc[-1].item())
             num_computed_tokens = torch.full((max_num_reqs,), nc_base, dtype=torch.int32, device=device)
-            pos = torch.zeros(total_tokens, dtype=torch.int64, device=device)
-            seq_lens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+            # A non-output sentinel makes every required store observable,
+            # including the zero stores for unused seq_lens entries.
+            pos = torch.full(
+                (total_tokens,), OUTPUT_SENTINEL, dtype=torch.int64, device=device
+            )
+            seq_lens = torch.full(
+                (max_num_reqs,), OUTPUT_SENTINEL, dtype=torch.int32, device=device
+            )
 
             mod.prepare_pos_seq_lens(idx_mapping, query_start_loc, num_computed_tokens, pos, seq_lens)
             torch.cuda.synchronize()
@@ -138,16 +145,44 @@ def run_performance():
                 query_start_loc[r + 1] = query_start_loc[r] + query_len
             total_tokens = int(query_start_loc[-1].item())
             num_computed_tokens = torch.full((max_num_reqs,), nc_base, dtype=torch.int32, device=device)
-            pos = torch.zeros(total_tokens, dtype=torch.int64, device=device)
-            seq_lens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+            pos = torch.full(
+                (total_tokens,), OUTPUT_SENTINEL, dtype=torch.int64, device=device
+            )
+            seq_lens = torch.full(
+                (max_num_reqs,), OUTPUT_SENTINEL, dtype=torch.int32, device=device
+            )
+
+            ref_pos, ref_seq = reference_prepare_pos_seq_lens(
+                idx_mapping.cpu(),
+                query_start_loc.cpu(),
+                num_computed_tokens.cpu(),
+                max_num_reqs,
+            )
+
+            def _prepare_outputs():
+                pos.fill_(OUTPUT_SENTINEL)
+                seq_lens.fill_(OUTPUT_SENTINEL)
 
             def _bench_fn():
                 mod.prepare_pos_seq_lens(idx_mapping, query_start_loc, num_computed_tokens, pos, seq_lens)
+                return pos, seq_lens
+
+            timed_run = _TimedRun()
             elapsed_ms, benchmark_metadata = _benchmark_cuda_graph_or_events(
                 _bench_fn,
                 warmup=WARMUP_ITERATIONS,
                 repetition=BENCHMARK_ITERATIONS,
+                prepare_fn=_prepare_outputs,
+                timed_run=timed_run,
             )
+
+            timed_pos, timed_seq_lens = timed_run.rerun()
+            if not torch.equal(timed_pos.cpu(), ref_pos):
+                raise RuntimeError("captured replay produced incorrect pos output")
+            if not torch.equal(timed_seq_lens.cpu(), ref_seq):
+                raise RuntimeError(
+                    "captured replay produced incorrect seq_lens output"
+                )
 
             test_cases.append({
                 "test_case_id": f"perf{test_idx + 1}",

--- a/tasks/triton2triton/vllm/triton_reduce_segments/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_reduce_segments/scripts/task_runner.py
@@ -20,6 +20,33 @@ TEST_SHAPES = [
     (4, 8, 128, 2, 64),
     (32, 16, 64, 8, 1024),
 ]
+
+# Additional cases are correctness-only so benchmark coverage and methodology
+# remain unchanged. A query-length entry of zero represents a sequence with no
+# query tokens in the packed batch.
+CORRECTNESS_CASES = [
+    {
+        "name": f"decode_{i + 1}",
+        "shape": shape,
+    }
+    for i, shape in enumerate(TEST_SHAPES)
+] + [
+    {
+        "name": "packed_variable_partial_fp16",
+        "shape": (4, 3, 80, 4, None),
+        "query_lens": (2, 0, 3, 1),
+        "seq_lens": (1, 127, 33, 65),
+        "segment_dtype": "float16",
+    },
+    {
+        "name": "zero_denom_extreme_max_float32_output",
+        "shape": (2, 2, 48, 4, None),
+        "query_lens": (1, 2),
+        "seq_lens": (64, 128),
+        "output_dtype": "float32",
+        "special_values": "zero_denom_extreme_max",
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -49,50 +76,97 @@ def load_module():
 
 
 def make_test_data(num_seqs, num_query_heads, head_size, num_segments, seq_len_k,
-                   device="cuda"):
+                   device="cuda", query_lens=None, seq_lens=None,
+                   segment_dtype="float32", output_dtype="float16"):
     import torch
     import triton
     head_size_padded = triton.next_power_of_2(head_size)
-    total_tokens = num_seqs  # 1 query token per seq (decode)
+    if query_lens is None:
+        query_lens = (1,) * num_seqs
+    if len(query_lens) != num_seqs or any(length < 0 for length in query_lens):
+        raise ValueError("query_lens must contain one nonnegative length per sequence")
+    total_tokens = sum(query_lens)
+
+    segment_torch_dtype = getattr(torch, segment_dtype)
+    output_torch_dtype = getattr(torch, output_dtype)
 
     # Simulate segment outputs with random values
     torch.manual_seed(42)
     segm_output = torch.randn(total_tokens, num_query_heads, num_segments, head_size_padded,
-                              device=device, dtype=torch.float32)
+                              device=device, dtype=segment_torch_dtype)
     segm_max = torch.randn(total_tokens, num_query_heads, num_segments,
-                           device=device, dtype=torch.float32)
+                           device=device, dtype=segment_torch_dtype)
     segm_expsum = torch.rand(total_tokens, num_query_heads, num_segments,
-                             device=device, dtype=torch.float32) + 0.1
+                             device=device, dtype=segment_torch_dtype) + 0.1
 
     output = torch.zeros(total_tokens, num_query_heads, head_size,
-                         device=device, dtype=torch.float16)
+                         device=device, dtype=output_torch_dtype)
 
-    seqused_k = torch.full((num_seqs,), seq_len_k, device=device, dtype=torch.int32)
-    cu_seqlens_q = torch.arange(0, num_seqs + 1, device=device, dtype=torch.int32)
+    if seq_lens is None:
+        seq_lens = (seq_len_k,) * num_seqs
+    if len(seq_lens) != num_seqs or any(length <= 0 for length in seq_lens):
+        raise ValueError("seq_lens must contain one positive length per sequence")
+    seqused_k = torch.tensor(seq_lens, device=device, dtype=torch.int32)
+    cu_seqlens_q = torch.zeros(num_seqs + 1, device=device, dtype=torch.int32)
+    cu_seqlens_q[1:] = torch.tensor(query_lens, device=device, dtype=torch.int32).cumsum(0)
 
     return segm_output, segm_max, segm_expsum, output, seqused_k, cu_seqlens_q
 
 
-def reference_reduce(segm_output, segm_max, segm_expsum, head_size):
-    """CPU reference for logsumexp reduction."""
+def reference_reduce(segm_output, segm_max, segm_expsum, head_size,
+                     seqused_k, cu_seqlens_q, tile_size=16):
+    """PyTorch reference for logsumexp reduction."""
     import torch
     total_tokens = segm_output.shape[0]
-    num_heads = segm_output.shape[1]
-    output = torch.zeros(total_tokens, num_heads, head_size,
-                         device=segm_output.device, dtype=torch.float32)
+    num_segments = segm_output.shape[2]
 
-    overall_max = segm_max.max(dim=-1).values  # [tokens, heads]
-    rescaled_expsum = segm_expsum * torch.exp(segm_max - overall_max.unsqueeze(-1))
+    token_indices = torch.arange(total_tokens, device=segm_output.device, dtype=torch.int32)
+    seq_indices = torch.searchsorted(cu_seqlens_q, token_indices, right=True) - 1
+    token_seq_lens = seqused_k[seq_indices]
+    tiles_per_segment = torch.div(
+        token_seq_lens + num_segments * tile_size - 1,
+        num_segments * tile_size,
+        rounding_mode="floor",
+    )
+    active_segments = torch.div(
+        token_seq_lens + tiles_per_segment * tile_size - 1,
+        tiles_per_segment * tile_size,
+        rounding_mode="floor",
+    )
+    segment_mask = (
+        torch.arange(num_segments, device=segm_output.device)[None, :]
+        < active_segments[:, None]
+    )[:, None, :]
+
+    segm_max_f32 = segm_max.float()
+    segm_expsum_f32 = segm_expsum.float()
+    segm_output_f32 = segm_output.float()
+    masked_max = torch.where(segment_mask, segm_max_f32, -torch.inf)
+    overall_max = masked_max.max(dim=-1).values  # [tokens, heads]
+    max_scale = torch.exp(masked_max - overall_max.unsqueeze(-1))
+    rescaled_expsum = torch.where(
+        segment_mask,
+        segm_expsum_f32 * max_scale,
+        0.0,
+    )
     overall_expsum = rescaled_expsum.sum(dim=-1)  # [tokens, heads]
 
-    rescaled_output = segm_output * torch.exp(segm_max - overall_max.unsqueeze(-1)).unsqueeze(-1)
+    rescaled_output = torch.where(
+        segment_mask.unsqueeze(-1),
+        segm_output_f32 * max_scale.unsqueeze(-1),
+        0.0,
+    )
     summed = rescaled_output.sum(dim=2)  # [tokens, heads, head_size_padded]
 
-    safe_denom = overall_expsum.unsqueeze(-1)
-    safe_denom = torch.where(safe_denom == 0, torch.ones_like(safe_denom), safe_denom)
-    output = summed[:, :, :head_size] / safe_denom
+    denominator = overall_expsum.unsqueeze(-1)
+    safe_denom = torch.where(denominator == 0, 1.0, denominator)
+    output = torch.where(
+        denominator == 0,
+        0.0,
+        summed[:, :, :head_size] / safe_denom,
+    )
 
-    return output.half()
+    return output
 
 
 def run_compile():
@@ -118,11 +192,27 @@ def run_correctness():
 
     device = "cuda"
 
-    for i, (num_seqs, nqh, hs, nseg, slk) in enumerate(TEST_SHAPES):
+    for i, case in enumerate(CORRECTNESS_CASES):
+        name = case["name"]
+        num_seqs, nqh, hs, nseg, slk = case["shape"]
         try:
             torch.manual_seed(42 + i)
             segm_output, segm_max_t, segm_expsum, output, seqused_k, cu_seqlens_q = \
-                make_test_data(num_seqs, nqh, hs, nseg, slk, device)
+                make_test_data(
+                    num_seqs, nqh, hs, nseg, slk, device,
+                    query_lens=case.get("query_lens"),
+                    seq_lens=case.get("seq_lens"),
+                    segment_dtype=case.get("segment_dtype", "float32"),
+                    output_dtype=case.get("output_dtype", "float16"),
+                )
+
+            if case.get("special_values") == "zero_denom_extreme_max":
+                segm_expsum[0, 0, :] = 0
+                segm_max_t[1, 0, :] = torch.tensor(
+                    (-1.0e4, -1.0e3, 0.0, 1.0e4),
+                    device=device,
+                    dtype=segm_max_t.dtype,
+                )
 
             mod.reduce_attention_segments(
                 segm_output, segm_max_t, segm_expsum, output,
@@ -130,13 +220,16 @@ def run_correctness():
             )
             torch.cuda.synchronize()
 
-            ref = reference_reduce(segm_output, segm_max_t, segm_expsum, hs)
+            ref = reference_reduce(
+                segm_output, segm_max_t, segm_expsum, hs,
+                seqused_k, cu_seqlens_q,
+            ).to(output.dtype)
 
             if not torch.allclose(output.float(), ref.float(), atol=1e-2, rtol=1e-2):
                 max_diff = (output.float() - ref.float()).abs().max().item()
-                return False, f"Shape {i+1}: max diff = {max_diff:.6f}"
+                return False, f"Case {name}: max diff = {max_diff:.6f}"
         except Exception as e:
-            return False, f"Shape {i+1}: exception: {e}"
+            return False, f"Case {name}: exception: {e}"
 
     return True, None
 
@@ -215,7 +308,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_scale_swizzle/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_scale_swizzle/scripts/task_runner.py
@@ -12,13 +12,17 @@ os.chdir(TASK_DIR)
 TASK_NAME = "triton2triton/triton_scale_swizzle"
 SOURCE_FILE = os.path.join(TASK_DIR, "source", "triton_scale_swizzle.py")
 
-# Test configs: (rows, cols) - must be multiples of (128, 4) for the kernel
-TEST_SHAPES = [
+# Keep performance coverage stable; additional padding cases are correctness-only.
+PERFORMANCE_SHAPES = [
     (128, 4),
     (256, 8),
     (128, 16),
     (384, 12),
     (512, 8),
+]
+CORRECTNESS_SHAPES = PERFORMANCE_SHAPES + [
+    (129, 4),  # Row padding with packed columns.
+    (128, 5),  # Column padding with aligned rows.
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
@@ -62,10 +66,8 @@ def reference_scale_swizzle(input_matrix):
     padded_rows = n_row_blocks * 128
     padded_cols = n_col_blocks * 4
 
-    padded = input_matrix
-    assert (rows, cols) == (padded_rows, padded_cols), (
-        f"Input must be padded to multiples of (128, 4), got ({rows}, {cols})"
-    )
+    padded = input_matrix.new_zeros((padded_rows, padded_cols))
+    padded[:rows, :cols] = input_matrix
 
     blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
     rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
@@ -96,7 +98,7 @@ def run_correctness():
 
     device = "cuda"
 
-    for i, (rows, cols) in enumerate(TEST_SHAPES):
+    for i, (rows, cols) in enumerate(CORRECTNESS_SHAPES):
         try:
             torch.manual_seed(42 + i)
 
@@ -131,7 +133,7 @@ def run_performance():
     device = "cuda"
     test_cases = []
 
-    for test_idx, (rows, cols) in enumerate(TEST_SHAPES):
+    for test_idx, (rows, cols) in enumerate(PERFORMANCE_SHAPES):
         try:
             torch.manual_seed(0)
             data = torch.randint(0, 256, (rows, cols), device=device, dtype=torch.uint8)
@@ -185,7 +187,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(CORRECTNESS_SHAPES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_silu_mul_quant_fp8/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_silu_mul_quant_fp8/scripts/task_runner.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import json
+import math
 import argparse
 import importlib.util
 
@@ -19,6 +20,29 @@ TEST_SHAPES = [
     (256, 512),
     (256, 1024),
     (512, 1024),
+]
+
+# Targeted correctness-only cases. Keep these separate from TEST_SHAPES so
+# hardening correctness coverage does not alter the performance workload.
+CORRECTNESS_CASES = [
+    {
+        "name": "bfloat16_ue8m0",
+        "shape": (128, 256),
+        "input_dtype": "bfloat16",
+        "input_kind": "random",
+        "inject_wide_value": True,
+        "eps": 1e-6,
+        "use_ue8m0": True,
+    },
+    {
+        "name": "float32_edges_preallocated_output",
+        "shape": (128, 512),
+        "input_dtype": "float32",
+        "input_kind": "edge_values",
+        "eps": 1e-4,
+        "preallocate_output": True,
+        "exact_quantized": True,
+    },
 ]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
@@ -48,7 +72,13 @@ def load_module():
     return mod
 
 
-def reference_silu_mul_quant_fp8(input_t, fp8_dtype):
+def reference_silu_mul_quant_fp8(
+    input_t,
+    fp8_dtype,
+    *,
+    eps=1e-10,
+    use_ue8m0=False,
+):
     """CPU reference: silu(x[:,:N/2]) * x[:,N/2:], then quantize per group."""
     import torch
     GROUP_SIZE = 128
@@ -79,12 +109,87 @@ def reference_silu_mul_quant_fp8(input_t, fp8_dtype):
             start = g * GROUP_SIZE
             end = start + GROUP_SIZE
             group = y[row, start:end]
-            absmax = max(group.abs().max().item(), 1e-10)
-            scale = absmax / fp8_max
+            absmax = max(group.abs().max().item(), eps)
+            scale_raw = absmax / fp8_max
+            scale = (
+                2.0 ** math.ceil(math.log2(scale_raw))
+                if use_ue8m0
+                else scale_raw
+            )
             y_s[row, g] = scale
             y_q[row, start:end] = (group / scale).clamp(fp8_min, fp8_max)
 
     return y_q.to(fp8_dtype), y_s
+
+
+def _make_correctness_input(torch, case):
+    """Create deterministic inputs for the targeted correctness cases."""
+    dtype = getattr(torch, case["input_dtype"])
+    shape = case["shape"]
+    if case["input_kind"] == "random":
+        torch.manual_seed(123)
+        x = torch.randn(shape, device="cuda", dtype=dtype)
+        if case.get("inject_wide_value", False):
+            N_2 = shape[1] // 2
+            x[:, 0] = 1e5
+            x[:, N_2] = 1e-4
+        return x
+
+    # Group zero mixes tiny values with large finite products, while group one
+    # remains exactly zero so the non-default epsilon determines its scale.
+    x = torch.zeros(shape, device="cuda", dtype=dtype)
+    N_2 = shape[1] // 2
+    x[:, 0] = 1e-20
+    x[:, N_2] = 1.0
+    x[:, 1] = -1e-20
+    x[:, N_2 + 1] = 1.0
+    x[:, 2] = 1e5
+    x[:, N_2 + 2] = 0.064
+    x[:, 3] = 1e5
+    x[:, N_2 + 3] = -0.064
+    return x
+
+
+def _check_outputs(
+    torch,
+    case_name,
+    y_q,
+    y_s,
+    ref_q,
+    ref_s,
+    *,
+    exact_quantized=False,
+    scale_atol=1e-2,
+    scale_rtol=1e-1,
+):
+    """Compare scales and quantized results without changing task tolerances."""
+    if y_q.shape != ref_q.shape or y_s.shape != ref_s.shape:
+        return (
+            f"{case_name}: output shapes {(tuple(y_q.shape), tuple(y_s.shape))} "
+            f"do not match expected {(tuple(ref_q.shape), tuple(ref_s.shape))}"
+        )
+    if y_q.dtype != ref_q.dtype or y_s.dtype != ref_s.dtype:
+        return (
+            f"{case_name}: output dtypes {(y_q.dtype, y_s.dtype)} do not match "
+            f"expected {(ref_q.dtype, ref_s.dtype)}"
+        )
+
+    if not torch.allclose(y_s, ref_s, atol=scale_atol, rtol=scale_rtol):
+        max_diff = (y_s - ref_s).abs().max().item()
+        return f"{case_name}: scale max diff = {max_diff:.6g}"
+
+    if exact_quantized and not torch.equal(y_q.float(), ref_q.float()):
+        max_diff = (y_q.float() - ref_q.float()).abs().max().item()
+        return f"{case_name}: quantized max diff = {max_diff:.6g}"
+
+    GROUP_SIZE = 128
+    y_dq = y_q.float() * y_s.repeat_interleave(GROUP_SIZE, dim=-1)
+    ref_dq = ref_q.float() * ref_s.repeat_interleave(GROUP_SIZE, dim=-1)
+    if not torch.allclose(y_dq, ref_dq, atol=5e-1, rtol=1e-1):
+        max_diff = (y_dq - ref_dq).abs().max().item()
+        return f"{case_name}: dequant max diff = {max_diff:.6f}"
+
+    return None
 
 
 def run_compile():
@@ -125,26 +230,67 @@ def run_correctness():
             ref_q = ref_q.to(device)
             ref_s = ref_s.to(device)
 
-            # Check scales
-            if not torch.allclose(y_s, ref_s, atol=1e-2, rtol=1e-1):
-                max_diff = (y_s - ref_s).abs().max().item()
-                return False, (
-                    f"Shape {i+1} (M={M}, N={N}): scale max diff = {max_diff:.6f}"
-                )
-
-            # Check quantized via dequant
-            N_2 = N // 2
-            GROUP_SIZE = 128
-            y_dq = y_q.float() * y_s.repeat_interleave(GROUP_SIZE, dim=-1)
-            ref_dq = ref_q.float().to(device) * ref_s.repeat_interleave(GROUP_SIZE, dim=-1)
-
-            if not torch.allclose(y_dq, ref_dq, atol=5e-1, rtol=1e-1):
-                max_diff = (y_dq - ref_dq).abs().max().item()
-                return False, (
-                    f"Shape {i+1} (M={M}, N={N}): dequant max diff = {max_diff:.6f}"
-                )
+            case_name = f"Shape {i+1} (M={M}, N={N})"
+            error = _check_outputs(
+                torch, case_name, y_q, y_s, ref_q, ref_s
+            )
+            if error:
+                return False, error
         except Exception as e:
             return False, f"Shape {i+1} (M={M}, N={N}): exception: {e}"
+
+    for case in CORRECTNESS_CASES:
+        case_name = case["name"]
+        try:
+            x = _make_correctness_input(torch, case)
+            M, N = x.shape
+            eps = case.get("eps", 1e-10)
+            use_ue8m0 = case.get("use_ue8m0", False)
+
+            output = None
+            if case.get("preallocate_output", False):
+                output = torch.full(
+                    (M, N // 2),
+                    240.0,
+                    device=device,
+                    dtype=fp8_dtype,
+                )
+
+            y_q, y_s = mod.silu_mul_per_token_group_quant_fp8_colmajor(
+                x,
+                output=output,
+                use_ue8m0=use_ue8m0,
+                eps=eps,
+            )
+            torch.cuda.synchronize()
+
+            if output is not None and y_q.data_ptr() != output.data_ptr():
+                return False, f"{case_name}: returned a different output buffer"
+
+            ref_q, ref_s = reference_silu_mul_quant_fp8(
+                x,
+                fp8_dtype,
+                eps=eps,
+                use_ue8m0=use_ue8m0,
+            )
+            ref_q = ref_q.to(device)
+            ref_s = ref_s.to(device)
+
+            error = _check_outputs(
+                torch,
+                case_name,
+                y_q,
+                y_s,
+                ref_q,
+                ref_s,
+                exact_quantized=case.get("exact_quantized", False),
+                scale_atol=1e-8,
+                scale_rtol=1e-4,
+            )
+            if error:
+                return False, error
+        except Exception as e:
+            return False, f"{case_name}: exception: {e}"
 
     return True, None
 
@@ -214,7 +360,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_ssd_chunk_scan/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_ssd_chunk_scan/scripts/task_runner.py
@@ -14,6 +14,42 @@ TEST_SHAPES = [
     (256, 4, 64, 2, 16, 64),
     (384, 8, 32, 4, 32, 128),
 ]
+
+# Correctness-only cases for contract paths that are intentionally absent from
+# the fixed performance workload. ``chunk_lengths`` describes the packed token
+# range assigned to each chunk and may be shorter than ``chunk_size``.
+CORRECTNESS_CASES = [
+    {
+        "name": f"regular_{i}",
+        "shape": shape,
+    }
+    for i, shape in enumerate(TEST_SHAPES)
+] + [
+    {
+        "name": "irregular_boundary_large_dstate",
+        "shape": (94, 4, 40, 2, 129, 48),
+        "chunk_lengths": (29, 48, 17),
+        "seq_idx": (0, 0, 1),
+        "D_shape": "head",
+    },
+    {
+        "name": "irregular_boundary_initial_state",
+        "shape": (53, 4, 35, 2, 31, 24),
+        "chunk_lengths": (24, 11, 18),
+        "seq_idx": (0, 1, 1),
+        "initial_states": True,
+        "disable_rocm_buffer_ops": True,
+    },
+    {
+        "name": "bf16_irregular_boundary_D_hdim_z",
+        "shape": (76, 6, 37, 3, 21, 33),
+        "chunk_lengths": (33, 16, 27),
+        "seq_idx": (0, 1, 1),
+        "dtype": "bfloat16",
+        "D_shape": "head_hdim",
+        "z": True,
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -42,13 +78,25 @@ def load_module():
     return mod
 
 
-def reference_chunk_scan(cb, x, dt, dA_cumsum, C, states, seq_idx, chunk_size):
+def reference_chunk_scan(
+    cb,
+    x,
+    dt,
+    dA_cumsum,
+    C,
+    states,
+    cu_chunk_seqlens,
+    seq_idx,
+    D=None,
+    z=None,
+    initial_states=None,
+):
     import torch
 
     seqlen, nheads, headdim = x.shape
     _, ngroups, dstate = C.shape
     ratio = nheads // ngroups
-    nchunks = seqlen // chunk_size
+    nchunks = cb.shape[0]
 
     cb_c = cb.float().cpu()
     x_c = x.float().cpu()
@@ -56,26 +104,40 @@ def reference_chunk_scan(cb, x, dt, dA_cumsum, C, states, seq_idx, chunk_size):
     dA_c = dA_cumsum.float().cpu()
     C_c = C.float().cpu()
     states_c = states.float().cpu()
+    cu_c = cu_chunk_seqlens.cpu()
     seq_c = seq_idx.cpu()
+    D_c = D.float().cpu() if D is not None else None
+    z_c = z.float().cpu() if z is not None else None
+    initial_states_c = (
+        initial_states.float().cpu() if initial_states is not None else None
+    )
 
     out = torch.zeros(seqlen, nheads, headdim, dtype=torch.float32)
     for c in range(nchunks):
+        chunk_start = cu_c[c].item()
+        chunk_end = cu_c[c + 1].item()
         for h in range(nheads):
             g = h // ratio
             if c == 0 or seq_c[c].item() != seq_c[c - 1].item():
-                prev_state = torch.zeros(headdim, dstate, dtype=torch.float32)
+                if initial_states_c is None:
+                    prev_state = torch.zeros(headdim, dstate, dtype=torch.float32)
+                else:
+                    prev_state = initial_states_c[seq_c[c].item(), h]
             else:
                 prev_state = states_c[c - 1, h]
-            for t in range(chunk_size):
-                tok = c * chunk_size + t
-                if tok >= seqlen:
-                    break
+            for t in range(chunk_end - chunk_start):
+                tok = chunk_start + t
                 dA_t = dA_c[h, c, t]
                 acc = torch.matmul(prev_state, C_c[tok, g]) * torch.exp(dA_t)
                 for k in range(t + 1):
-                    tok_k = c * chunk_size + k
+                    tok_k = chunk_start + k
                     coeff = cb_c[c, g, t, k] * torch.exp(dA_t - dA_c[h, c, k]) * dt_c[h, c, k]
                     acc = acc + coeff * x_c[tok_k, h]
+                if D_c is not None:
+                    acc = acc + x_c[tok, h] * D_c[h]
+                if z_c is not None:
+                    z_tok = z_c[tok, h]
+                    acc = acc * z_tok * torch.sigmoid(z_tok)
                 out[tok, h] = acc
     return out
 
@@ -100,27 +162,73 @@ def run_correctness():
     except Exception as e:
         return False, f"Load failed: {e}"
     device = "cuda"
-    for i, (seqlen, nheads, headdim, ngroups, dstate, chunk_size) in enumerate(TEST_SHAPES):
+    for i, case in enumerate(CORRECTNESS_CASES):
+        seqlen, nheads, headdim, ngroups, dstate, chunk_size = case["shape"]
+        case_name = case["name"]
         try:
             torch.manual_seed(42 + i)
-            nchunks = seqlen // chunk_size
-            cb = torch.randn(nchunks, ngroups, chunk_size, chunk_size, device=device, dtype=torch.float16) * 0.01
-            x = torch.randn(seqlen, nheads, headdim, device=device, dtype=torch.float16)
-            C = torch.randn(seqlen, ngroups, dstate, device=device, dtype=torch.float16)
+            chunk_lengths = case.get("chunk_lengths", (chunk_size,) * (seqlen // chunk_size))
+            assert sum(chunk_lengths) == seqlen
+            assert all(0 < length <= chunk_size for length in chunk_lengths)
+            nchunks = len(chunk_lengths)
+            input_dtype = getattr(torch, case.get("dtype", "float16"))
+            cb = torch.randn(nchunks, ngroups, chunk_size, chunk_size, device=device, dtype=input_dtype) * 0.01
+            x = torch.randn(seqlen, nheads, headdim, device=device, dtype=input_dtype)
+            C = torch.randn(seqlen, ngroups, dstate, device=device, dtype=input_dtype)
             dt = torch.rand(nheads, nchunks, chunk_size, device=device, dtype=torch.float32) * 0.1
             dA_cumsum = torch.cumsum(dt * (-0.1), dim=-1)
-            states = torch.randn(nchunks, nheads, headdim, dstate, device=device, dtype=torch.float32) * 0.01
-            seq_idx = torch.zeros(nchunks, device=device, dtype=torch.int32)
-            cu = torch.arange(0, nchunks + 1, device=device, dtype=torch.int32) * chunk_size
+            states = torch.randn(
+                nchunks, nheads, headdim, dstate, device=device, dtype=torch.float32
+            ) * 0.01
+            seq_idx = torch.tensor(
+                case.get("seq_idx", (0,) * nchunks), device=device, dtype=torch.int32
+            )
+            cu = torch.tensor(
+                (0, *chunk_lengths), device=device, dtype=torch.int32
+            ).cumsum(0, dtype=torch.int32)
+            initial_states = None
+            if case.get("initial_states"):
+                nseqs = max(case["seq_idx"]) + 1
+                initial_states = torch.randn(
+                    nseqs, nheads, headdim, dstate,
+                    device=device, dtype=torch.float32,
+                ) * 0.01
+            D = None
+            if case.get("D_shape") == "head":
+                D = torch.linspace(-0.75, 0.75, nheads, device=device, dtype=torch.float32)
+            elif case.get("D_shape") == "head_hdim":
+                D = torch.linspace(
+                    -0.5, 0.5, nheads * headdim, device=device, dtype=torch.float32
+                ).reshape(nheads, headdim)
+            z = torch.randn_like(x) if case.get("z") else None
             out = torch.zeros(seqlen, nheads, headdim, device=device, dtype=torch.float32)
-            mod.chunk_scan_fwd(cb, x, dt, dA_cumsum, C, states, cu, out, seq_idx)
+            # ROCm's optional buffer-op lowering cannot currently canonicalize
+            # this kernel's valid runtime selection between ``states`` and
+            # ``initial_states`` pointers. Disable that lowering only for this
+            # correctness specialization; CUDA and performance are unchanged.
+            restore_buffer_ops = None
+            if case.get("disable_rocm_buffer_ops") and torch.version.hip is not None:
+                import triton
+                restore_buffer_ops = triton.knobs.amd.use_buffer_ops
+                triton.knobs.amd.use_buffer_ops = False
+            try:
+                mod.chunk_scan_fwd(
+                    cb, x, dt, dA_cumsum, C, states, cu, out, seq_idx,
+                    D=D, z=z, initial_states=initial_states,
+                )
+            finally:
+                if restore_buffer_ops is not None:
+                    triton.knobs.amd.use_buffer_ops = restore_buffer_ops
             torch.cuda.synchronize()
-            ref = reference_chunk_scan(cb, x, dt, dA_cumsum, C, states, seq_idx, chunk_size).to(device)
+            ref = reference_chunk_scan(
+                cb, x, dt, dA_cumsum, C, states, cu, seq_idx,
+                D=D, z=z, initial_states=initial_states,
+            ).to(device)
             if not torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2):
                 diff = (out.float() - ref.float()).abs().max().item()
-                return False, f"Shape {i}: max diff = {diff:.6f}"
+                return False, f"Case {case_name}: max diff = {diff:.6f}"
         except Exception as e:
-            return False, f"Shape {i}: {e}"
+            return False, f"Case {case_name}: {e}"
     return True, None
 
 

--- a/tasks/triton2triton/vllm/triton_w8a8_block_int8_matmul/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_w8a8_block_int8_matmul/scripts/task_runner.py
@@ -20,6 +20,23 @@ TEST_SHAPES = [
     (256, 512, 512, 128, 128),
     (128, 256, 512, 128, 128),
 ]
+
+# Correctness cases: (A shape, N, block_n, block_k, output dtype name).
+# Keep these separate from TEST_SHAPES so correctness coverage does not alter
+# the scored performance workload.
+CORRECTNESS_CASES = [
+    ((64, 128), 128, 128, 128, "float16"),
+    ((128, 256), 256, 128, 128, "float16"),
+    ((64, 256), 128, 128, 128, "float16"),
+    ((256, 512), 512, 128, 128, "float16"),
+    ((128, 512), 256, 128, 128, "float16"),
+    # Exercise partial M, N, and K tiles with the default quantization blocks.
+    ((65, 130), 193, 128, 128, "float16"),
+    # Exercise another legal block size and the float32 output path.
+    ((67, 95), 79, 64, 64, "float32"),
+    # Exercise flattened batched A/As inputs and the bfloat16 output path.
+    ((2, 3, 95), 79, 64, 64, "bfloat16"),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -52,12 +69,14 @@ def reference_w8a8_block_int8_matmul(A, B, As, Bs, block_size, output_dtype):
     """CPU reference: block-wise dequantize INT8 then matmul."""
     import torch
     block_n, block_k = block_size
-    M, K = A.shape
+    output_shape = A.shape[:-1] + (B.shape[0],)
+    K = A.shape[-1]
+    M = A.numel() // K
     N = B.shape[0]
 
-    A_f = A.cpu().float()
+    A_f = A.cpu().float().reshape(M, K)
     B_f = B.cpu().float()
-    As_f = As.cpu().float()
+    As_f = As.cpu().float().reshape(M, -1)
     Bs_f = Bs.cpu().float()
 
     # Dequantize A
@@ -79,7 +98,7 @@ def reference_w8a8_block_int8_matmul(A, B, As, Bs, block_size, output_dtype):
             B_dq[start_n:end_n, start_k:end_k] = B_f[start_n:end_n, start_k:end_k] * Bs_f[ng, kg]
 
     result = A_dq @ B_dq.T
-    return result.to(output_dtype)
+    return result.reshape(output_shape).to(output_dtype)
 
 
 def run_compile():
@@ -105,36 +124,47 @@ def run_correctness():
 
     device = "cuda"
 
-    for i, (M, N, K, block_n, block_k) in enumerate(TEST_SHAPES):
+    for i, (a_shape, N, block_n, block_k, dtype_name) in enumerate(CORRECTNESS_CASES):
         try:
             torch.manual_seed(42 + i)
             import triton as _triton
+            K = a_shape[-1]
+            output_dtype = getattr(torch, dtype_name)
 
             # Create INT8 tensors
-            A = torch.randint(-128, 127, (M, K), device=device, dtype=torch.int8)
+            A = torch.randint(-128, 127, a_shape, device=device, dtype=torch.int8)
             B = torch.randint(-128, 127, (N, K), device=device, dtype=torch.int8)
 
             # Scales
-            As = torch.rand(M, _triton.cdiv(K, block_k), device=device, dtype=torch.float32) * 0.1 + 0.01
+            As = torch.rand(
+                a_shape[:-1] + (_triton.cdiv(K, block_k),),
+                device=device,
+                dtype=torch.float32,
+            ) * 0.1 + 0.01
             Bs = torch.rand(_triton.cdiv(N, block_n), _triton.cdiv(K, block_k),
                            device=device, dtype=torch.float32) * 0.1 + 0.01
 
             result = mod.w8a8_block_int8_matmul(
-                A, B, As, Bs, [block_n, block_k], output_dtype=torch.float16
+                A, B, As, Bs, [block_n, block_k], output_dtype=output_dtype
             )
             torch.cuda.synchronize()
 
             ref = reference_w8a8_block_int8_matmul(
-                A, B, As, Bs, [block_n, block_k], torch.float16
+                A, B, As, Bs, [block_n, block_k], output_dtype
             ).to(device)
 
             if not torch.allclose(result, ref, atol=1e-1, rtol=1e-1):
                 max_diff = (result - ref).abs().max().item()
                 return False, (
-                    f"Shape {i+1} (M={M}, N={N}, K={K}): max diff = {max_diff:.6f}"
+                    f"Shape {i+1} (A={a_shape}, N={N}, K={K}, "
+                    f"blocks=({block_n}, {block_k}), dtype={dtype_name}): "
+                    f"max diff = {max_diff:.6f}"
                 )
         except Exception as e:
-            return False, f"Shape {i+1} (M={M}, N={N}, K={K}): exception: {e}"
+            return False, (
+                f"Shape {i+1} (A={a_shape}, N={N}, K={K}, "
+                f"blocks=({block_n}, {block_k}), dtype={dtype_name}): exception: {e}"
+            )
 
     return True, None
 
@@ -214,7 +244,11 @@ def main():
 
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")


### PR DESCRIPTION
> **Superseded by [draft PR #105](https://github.com/AMD-AGI/AgentKernelArena/pull/105).** This PR is closed without merging. Review the consolidated robustness changes in #105 instead.

Retains the robustness changes across 22 tasks; excludes the rmsnorm_bwd and test_cast_matmul generated tensor results.

The replacement also fixes quality-loop artifact filtering and commit-time checks to prevent recurrence. Its description records the curation decisions, historical MI355X run evidence, local CPU tests, and the lack of a fresh GPU run for the consolidated head. Generated experiment artifacts remain outside Git.

---

## Summary

- Audited tasks: 41
- Accepted task changes: 22
- Validator warnings recorded: 69
- Unresolved validation failures: 1
- Optimizer: Codex, exactly one iteration per task
- Easy-task threshold: reproducible 5.0x

## Changed tasks

- `triton2triton/geak_eval/L1/refk_identity`
- `triton2triton/geak_eval/L3/fused_rms_fp8`
- `triton2triton/rocmbench/hard/rmsnorm_bwd`
- `triton2triton/rocmbench/medium/test_cast_matmul`
- `triton2triton/vllm/triton_awq_dequantize`
- `triton2triton/vllm/triton_compute_slot_mappings`
- `triton2triton/vllm/triton_ep_scatter_2`
- `triton2triton/vllm/triton_fla_layernorm`
- `triton2triton/vllm/triton_gather_block_tables`
- `triton2triton/vllm/triton_kda_dot_kkt_intra`
- `triton2triton/vllm/triton_layernorm_gated`
- `triton2triton/vllm/triton_merge_16x16_to_32x32`
- `triton2triton/vllm/triton_moe_mmk`
- `triton2triton/vllm/triton_pack_seq`
- `triton2triton/vllm/triton_per_token_group_quant_fp8`
- `triton2triton/vllm/triton_post_update`
- `triton2triton/vllm/triton_prepare_pos_seq_lens`
- `triton2triton/vllm/triton_reduce_segments`
- `triton2triton/vllm/triton_scale_swizzle`
- `triton2triton/vllm/triton_silu_mul_quant_fp8`
- `triton2triton/vllm/triton_ssd_chunk_scan`
- `triton2triton/vllm/triton_w8a8_block_int8_matmul`

## Unresolved validation failures

- `triton2triton/geak_eval/L1/llama_ff_triton`

The full machine-readable report is stored in the local run artifact
`quality_loop_runs/20260909_ql_triton_s1/audit_report.yaml`. Every promoted baseline and case change passed the fail-closed
dual correctness gate against the pre-audit kernel.
