### PR TITLE
audit(tasks): quality_loop task quality pass

### DIFF
--- a/tasks/triton2triton/geak_eval/L1/refk_fp8_blockwise_mm/test_kernel_harness.py
+++ b/tasks/triton2triton/geak_eval/L1/refk_fp8_blockwise_mm/test_kernel_harness.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Test harness for the FP8 block-scale GEMM kernel.
 
-Timing and correctness live HERE, not in kernel.py — the agent edits kernel.py,
-so an embedded benchmark there could be gamed. The harness owns the measurement
-and only imports the kernel-side building blocks (kernels, wrappers, inputs).
+Timing, inputs, cases, tolerances, and the reference implementation live HERE,
+not in kernel.py, because the agent edits kernel.py. The harness imports only
+the candidate operation from the editable module.
 """
 import argparse
 import math
@@ -29,19 +29,103 @@ if _HARNESS_DIR not in sys.path:
 
 import torch
 
-from kernel import (
-    EVAL_CONFIGS,
-    RTOL,
-    ATOL,
-    get_inputs,
-    fp8_blockwise_mm_triton,
-    fp8_blockwise_mm_pytorch,
-)
+from kernel import fp8_blockwise_mm_triton
 
 WARMUP = 50
 ITERATIONS = int(os.environ.get("GEAK_BENCHMARK_ITERATIONS", "200"))
+BLOCK_SHAPE_N = 128
+BLOCK_SHAPE_K = 128
+RTOL, ATOL = 2e-2, 1e-3
 
-ALL_CONFIGS = EVAL_CONFIGS
+TEST_CONFIGS = [
+    {"m": 64, "n": 64, "k": 128, "seed": 6635},
+    {"m": 64, "n": 1536, "k": 7168, "seed": 6635},
+    {"m": 64, "n": 3072, "k": 1536, "seed": 1236},
+    {"m": 64, "n": 576, "k": 7168, "seed": 542},
+    {"m": 96, "n": 7168, "k": 256, "seed": 1234},
+    {"m": 96, "n": 7168, "k": 2048, "seed": 4153},
+    {"m": 96, "n": 4608, "k": 7168, "seed": 412},
+    {"m": 128, "n": 7168, "k": 2304, "seed": 624},
+    {"m": 128, "n": 512, "k": 7168, "seed": 2514},
+    {"m": 512, "n": 4096, "k": 512, "seed": 543},
+    {"m": 512, "n": 1536, "k": 7168, "seed": 12341},
+]
+
+BENCHMARK_CONFIGS = [
+    {"m": 1024, "n": 1536, "k": 7168, "seed": 8135},
+    {"m": 1024, "n": 3072, "k": 1536, "seed": 6251},
+    {"m": 1024, "n": 576, "k": 7168, "seed": 12346},
+    {"m": 1024, "n": 7168, "k": 256, "seed": 5364},
+    {"m": 1024, "n": 7168, "k": 2048, "seed": 6132},
+    {"m": 1024, "n": 4608, "k": 7168, "seed": 7531},
+    {"m": 1024, "n": 7168, "k": 2304, "seed": 12345},
+    {"m": 1024, "n": 512, "k": 7168, "seed": 6563},
+    {"m": 1024, "n": 4096, "k": 512, "seed": 17512},
+    {"m": 6144, "n": 1536, "k": 7168, "seed": 6543},
+    {"m": 6144, "n": 3072, "k": 1536, "seed": 234},
+    {"m": 6144, "n": 576, "k": 7168, "seed": 9863},
+    {"m": 6144, "n": 7168, "k": 256, "seed": 764243},
+    {"m": 6144, "n": 7168, "k": 2048, "seed": 76547},
+    {"m": 6144, "n": 4608, "k": 7168, "seed": 65436},
+    {"m": 6144, "n": 7168, "k": 2304, "seed": 452345},
+    {"m": 6144, "n": 512, "k": 7168, "seed": 12341},
+    {"m": 6144, "n": 4096, "k": 512, "seed": 45245},
+]
+
+ALL_CONFIGS = TEST_CONFIGS + BENCHMARK_CONFIGS
+
+
+def get_inputs(m, n, k, seed=42, device="cuda"):
+    """Build representative inputs independently of the editable candidate."""
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    scale_n = (n + BLOCK_SHAPE_N - 1) // BLOCK_SHAPE_N
+    scale_k = (k + BLOCK_SHAPE_K - 1) // BLOCK_SHAPE_K
+
+    a = torch.randn((k, m), dtype=torch.bfloat16, device=device, generator=gen).to(
+        torch.float8_e4m3fnuz
+    )
+    b = torch.randn((k, n), dtype=torch.bfloat16, device=device, generator=gen).to(
+        torch.float8_e4m3fnuz
+    )
+    a_scale = torch.randn(
+        [scale_k, m], dtype=torch.float32, device=device, generator=gen
+    )
+    b_scale = torch.randn(
+        [scale_k, scale_n], dtype=torch.float32, device=device, generator=gen
+    )
+    c = torch.zeros((m, n), dtype=torch.bfloat16, device=device)
+    return (a.T, b.T, a_scale.T, b_scale.T, c)
+
+
+def fp8_blockwise_mm_pytorch(a, b, a_scale, b_scale, c):
+    """Protected PyTorch reference for the blockwise-scaled multiplication."""
+    a_c = a.contiguous()
+    a_s = a_scale.contiguous()
+    b_s = b_scale.contiguous()
+
+    m, k = a_c.shape
+    n = b.shape[0]
+    sn, sk = b_s.shape
+
+    a_sc = (
+        a_s.unsqueeze(-1)
+        .repeat(1, 1, BLOCK_SHAPE_K)
+        .reshape(m, sk * BLOCK_SHAPE_K)[:, :k]
+    )
+    a_deq = a_c.to(a_sc.dtype) * a_sc
+
+    b_sc = (
+        b_s.view(-1, 1)
+        .repeat(1, BLOCK_SHAPE_N * BLOCK_SHAPE_K)
+        .view(sn, sk, BLOCK_SHAPE_N, BLOCK_SHAPE_K)
+        .permute(0, 2, 1, 3)
+        .reshape(sn * BLOCK_SHAPE_N, sk * BLOCK_SHAPE_K)
+    )[:n, :k]
+    b_deq = b.to(b_sc.dtype) * b_sc
+
+    c[...] = (a_deq @ b_deq.T).to(torch.bfloat16)
+    return c
 
 
 def _pick(configs, count):

--- a/tasks/triton2triton/geak_eval/L2/topk/test_kernel_harness.py
+++ b/tasks/triton2triton/geak_eval/L2/topk/test_kernel_harness.py
@@ -301,7 +301,7 @@ def run_correctness(shapes, verbose: bool = True) -> dict:
             torch.testing.assert_close(
                 res_val_cpu,
                 ref_val.to(torch.float32),
-                atol=1e-4 * hidden,
+                atol=1e-4,
                 rtol=1.3e-6,
             )
             # Check indices: gather from input using result indices and compare values
@@ -310,7 +310,7 @@ def run_correctness(shapes, verbose: bool = True) -> dict:
             torch.testing.assert_close(
                 gathered_res,
                 gathered_ref.to(torch.float32),
-                atol=1e-4 * hidden,
+                atol=1e-4,
                 rtol=1.3e-6,
             )
 

--- a/tasks/triton2triton/geak_eval/L3/fused_qkv_rope/test_kernel_harness.py
+++ b/tasks/triton2triton/geak_eval/L3/fused_qkv_rope/test_kernel_harness.py
@@ -4,8 +4,9 @@ Test harness for fused_qkv_split_qk_rope kernel (aiter reference).
 
 Modes: --correctness, --profile, --benchmark, --full-benchmark
 
-The kernel and reference helpers are imported from the task-local
-``kernel.py`` so the materialized task has no external AITER dependency.
+Only the declared Triton kernel is imported from editable ``kernel.py``.
+Launch policy, output allocation, and the PyTorch oracle stay in this protected
+harness so candidate edits cannot change the measured contract or reference.
 """
 from __future__ import annotations
 from _aka_benchmark import benchmark_cuda_graph_or_events_samples
@@ -21,6 +22,23 @@ def benchmark_cuda_graph_or_events(*args, **kwargs):
         else (values[midpoint - 1] + values[midpoint]) / 2.0
     )
     return median_ms, metadata
+
+
+class CapturedGraphRun:
+    """Handle populated by the benchmark helper with the exact timed graph."""
+
+    def __init__(self):
+        self._replay = None
+        self.output = None
+
+    def _bind(self, replay, output):
+        self._replay = replay
+        self.output = output
+
+    def replay(self):
+        if self._replay is None:
+            raise RuntimeError("captured graph replay was not bound")
+        return self._replay()
 
 # GEAK materialized harness bootstrap
 import importlib.util
@@ -85,15 +103,91 @@ if _KERNEL_DIR and _KERNEL_DIR not in sys.path:
 
 import argparse
 import math
+from enum import IntEnum
 
 import torch
+import triton
 
-from kernel import (
-    RotateStyle,
-    fused_qkv_split_qk_rope,
-    generate_rope_cached_freqs,
-    ref_rope_sbhd_fwd,
-)
+from kernel import _fused_qkv_split_qk_rope_kernel
+
+
+def fused_qkv_split_qk_rope(
+    qkv,
+    cos,
+    sin,
+    positions,
+    qh,
+    kvh,
+    head_dim,
+    is_neox=True,
+    offsets=None,
+    reuse_freqs_front_part=True,
+    nope_first=False,
+):
+    """Protected allocation and launch contract for the editable kernel."""
+    T = qkv.shape[0]
+    q_size = qh * head_dim
+    kv_size = kvh * head_dim
+
+    assert qh >= kvh and qh % kvh == 0, "qh must be mutiple of kvh"
+
+    q = torch.empty((T, qh, head_dim), dtype=qkv.dtype, device=qkv.device)
+    k = torch.empty((T, kvh, head_dim), dtype=qkv.dtype, device=qkv.device)
+    v = torch.empty((T, kvh, head_dim), dtype=qkv.dtype, device=qkv.device)
+
+    if cos.shape[-1] == head_dim // 2:
+        have_nope = not reuse_freqs_front_part
+    elif cos.shape[-1] == head_dim // 4:
+        have_nope = True
+    else:
+        have_nope = False
+
+    assert qkv.shape[-1] == q_size + 2 * kv_size, "Shape error"
+    effective_head_dim = head_dim // (2 if have_nope else 1)
+    assert effective_head_dim == triton.next_power_of_2(
+        effective_head_dim
+    ), "head_dim should be power of 2"
+
+    if have_nope:
+        block_d = head_dim // 2
+        block_d_half = head_dim // 4
+    else:
+        block_d = head_dim
+        block_d_half = head_dim // 2
+
+    block_t = 32
+    grid = (triton.cdiv(T, block_t), qh, 1)
+    _fused_qkv_split_qk_rope_kernel[grid](
+        qkv,
+        cos,
+        sin,
+        positions,
+        offsets,
+        q,
+        k,
+        v,
+        T,
+        *qkv.stride(),
+        cos.stride(0),
+        cos.stride(-1),
+        *positions.stride(),
+        *q.stride(),
+        *k.stride(),
+        HAVE_NOPE=have_nope,
+        NOPE_FIRST=nope_first,
+        REUSE_FREQS_FRONT_PART=reuse_freqs_front_part,
+        IS_NEOX=is_neox,
+        HAVE_POS=(positions is not None),
+        HAVE_OFFS=(offsets is not None),
+        QH=qh,
+        KVH=kvh,
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+        BLOCK_D_HALF=block_d_half,
+        num_warps=4,
+        waves_per_eu=0,
+    )
+    return q, k, v
 
 
 def triton_op(qkv, cos, sin, positions, qh, kvh, head_dim, is_neox,
@@ -109,6 +203,62 @@ def triton_op(qkv, cos, sin, positions, qh, kvh, head_dim, is_neox,
 # ============================================================================
 # REFERENCE IMPLEMENTATIONS
 # ============================================================================
+
+
+class RotateStyle(IntEnum):
+    NEOX = 0
+    GPTJ = 1
+
+
+def rotate_half_neox(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def rotate_half_gptj(x):
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    return torch.stack((-x2, x1), dim=-1).flatten(-2)
+
+
+def ref_rope_sbhd_fwd(
+    x_,
+    freqs_,
+    rotate_style,
+    reuse_freqs_front_part,
+    nope_first,
+):
+    rotate_half = (
+        rotate_half_neox if rotate_style == RotateStyle.NEOX else rotate_half_gptj
+    )
+    rotate_dim = freqs_.shape[-1] * (2 if reuse_freqs_front_part else 1)
+    if nope_first:
+        d = x_.shape[-1]
+        x, x_forward = x_[..., d - rotate_dim :], x_[..., : d - rotate_dim]
+    else:
+        x, x_forward = x_[..., :rotate_dim], x_[..., rotate_dim:]
+
+    freqs = freqs_
+    if reuse_freqs_front_part:
+        if rotate_style == RotateStyle.NEOX:
+            freqs = freqs.repeat([1] * (freqs.dim() - 1) + [2])
+        else:
+            freqs = freqs.repeat_interleave(2, dim=-1)
+    x_embed = x * torch.cos(freqs) + rotate_half(x) * torch.sin(freqs)
+    if nope_first:
+        return torch.cat((x_forward, x_embed), dim=-1).to(dtype=x_.dtype)
+    return torch.cat((x_embed, x_forward), dim=-1).to(dtype=x_.dtype)
+
+
+def generate_rope_cached_freqs(B, max_embed_positions, freqs_D, dtype):
+    pos = torch.randint(0, max_embed_positions, (B,), device="cuda")
+    freqs = torch.randn(
+        (max_embed_positions, 1, 1, freqs_D), dtype=dtype, device="cuda"
+    )
+    cos = torch.cos(freqs)
+    sin = torch.sin(freqs)
+    return pos, freqs, cos, sin
 
 
 def generate_qkv_inputs(
@@ -336,9 +486,26 @@ def run_benchmark(configs=None, warmup=50, iters=200, verbose=True):
                 nope_first=nope_first,
             )
 
+        timed_run = CapturedGraphRun()
         triton_ms, triton_meta = benchmark_cuda_graph_or_events(
-            run_kernel, warmup=warmup, repetition=iters,
+            run_kernel, warmup=warmup, repetition=iters, timed_run=timed_run,
         )
+
+        # Poison the graph-owned outputs, replay the exact executable that was
+        # timed, and compare those outputs with the protected oracle. This
+        # catches captures that omit work or fail to overwrite an output.
+        q_expected, k_expected, v_expected = torch_op(
+            qkv, QH_PER_KH, KH, head_dim, ref_freqs,
+            reuse, nope, nope_first, rs,
+        )
+        if not isinstance(timed_run.output, tuple) or len(timed_run.output) != 3:
+            raise AssertionError("timed graph did not expose Q/K/V outputs")
+        for output in timed_run.output:
+            output.fill_(float("nan"))
+        q_replayed, k_replayed, v_replayed = timed_run.replay()
+        torch.testing.assert_close(q_expected, q_replayed, atol=ATOL, rtol=RTOL)
+        torch.testing.assert_close(k_expected, k_replayed, atol=ATOL, rtol=RTOL)
+        torch.testing.assert_close(v_expected, v_replayed, atol=ATOL, rtol=RTOL)
 
         def run_reference():
             if baseline_fn is not None:

--- a/tasks/triton2triton/rocmbench/hard/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
+++ b/tasks/triton2triton/rocmbench/hard/triton_multreduce_matmul_kernel/triton_multreduce_matmul_kernel.py
@@ -346,10 +346,10 @@ def multreduce_matmul_triton_wrapper(a_tensor, b_tensor, c_buffer, bias_tensor,
                                      block_m_const, block_n_const, block_k_const_tile, # block_k_const_tile is K-tile for kernel
                                      use_bias_flag, num_warps_launch, num_stages_launch): # num_stages for launch
     grid = (triton.cdiv(M_dim, block_m_const) * triton.cdiv(N_dim, block_n_const), )
-    even_k_flag = (K_dim % block_k_const_tile == 0)
 
-    # Call the CORE kernel directly, not the autotuned one, to avoid meta-param conflict
-    triton_matmul_kernel[grid]( # Calling the non-autotuned version
+    # Launch the declared target's heuristic/JIT layer so each benchmark case can
+    # retain its fixed launch parameters without conflicting with its autotuner.
+    triton_multreduce_matmul_kernel.fn[grid](
         a_tensor, b_tensor, c_buffer, bias_tensor,
         M_dim, N_dim, K_dim,
         a_tensor.stride(0), a_tensor.stride(1),
@@ -360,8 +360,6 @@ def multreduce_matmul_triton_wrapper(a_tensor, b_tensor, c_buffer, bias_tensor,
         BLOCK_SIZE_N=block_n_const, 
         BLOCK_SIZE_K=block_k_const_tile, # This is the K-tile size
         USE_BIAS=use_bias_flag, 
-        USE_DOT=False, # Explicitly set for "multreduce" behavior
-        EVEN_K=even_k_flag,
         num_warps=num_warps_launch,
         num_stages=num_stages_launch # Pass num_stages
     )

--- a/tasks/triton2triton/vllm/triton_apply_write/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_apply_write/scripts/task_runner.py
@@ -20,6 +20,7 @@ TEST_SHAPES = [
     (32, 1024, 64),
     (64, 2048, 128),
 ]
+NUM_CORRECTNESS_BOUNDARY_CASES = 3
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -85,6 +86,22 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
+
+    def check_case(case_name, output, write_indices, write_starts, write_contents, cu_lens):
+        output_gpu = output.clone()
+        mod.apply_write(
+            output_gpu, write_indices, write_starts, write_contents, cu_lens
+        )
+        torch.cuda.synchronize()
+
+        ref = reference_apply_write(
+            output.cpu(), write_indices.cpu(), write_starts.cpu(),
+            write_contents.cpu(), cu_lens.cpu(),
+        )
+        if not torch.equal(output_gpu.cpu(), ref):
+            return False, f"{case_name}: mismatch"
+        return True, None
+
     for i, (num_writes, row_size, avg_content_len) in enumerate(TEST_SHAPES):
         try:
             torch.manual_seed(42 + i)
@@ -105,19 +122,73 @@ def run_correctness():
             total_content = int(cu_lens[-1].item())
             write_contents = torch.randint(1, 10000, (total_content,), dtype=torch.int32, device=device)
 
-            output_gpu = output.clone()
-            mod.apply_write(output_gpu, write_indices, write_starts, write_contents, cu_lens)
-            torch.cuda.synchronize()
-
-            ref = reference_apply_write(
-                output.cpu(), write_indices.cpu(), write_starts.cpu(),
-                write_contents.cpu(), cu_lens.cpu(),
+            ok, err = check_case(
+                f"Shape {i + 1}", output, write_indices, write_starts,
+                write_contents, cu_lens,
             )
-
-            if not torch.equal(output_gpu.cpu(), ref):
-                return False, f"Shape {i+1}: mismatch"
+            if not ok:
+                return False, err
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    boundary_cases = [
+        {
+            "name": "zero writes",
+            "output": torch.randint(
+                -100, 100, (4, 64), dtype=torch.int32, device=device
+            ),
+            "write_indices": torch.empty(0, dtype=torch.int32, device=device),
+            "write_starts": torch.empty(0, dtype=torch.int32, device=device),
+            "content_lens": [],
+        },
+        {
+            "name": "zero-length segments",
+            "output": torch.randint(
+                -100, 100, (10, 64), dtype=torch.int32, device=device
+            ),
+            "write_indices": torch.tensor(
+                [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int32, device=device
+            ),
+            "write_starts": torch.tensor(
+                [3, 7, 11, 17, 23, 31, 37, 41],
+                dtype=torch.int32,
+                device=device,
+            ),
+            "content_lens": [0, 0, 5, 0, 9, 0, 3, 0],
+        },
+        {
+            "name": "skewed lengths at the block cap",
+            "output": torch.randint(
+                -100, 100, (6, 4096), dtype=torch.int32, device=device
+            ),
+            "write_indices": torch.tensor(
+                [0, 1, 2, 3], dtype=torch.int32, device=device
+            ),
+            "write_starts": torch.tensor(
+                [4095, 3072, 1536, 2047], dtype=torch.int32, device=device
+            ),
+            "content_lens": [1, 1024, 1025, 2049],
+        },
+    ]
+
+    for case in boundary_cases:
+        try:
+            content_lens = torch.tensor(
+                case["content_lens"], dtype=torch.int32, device=device
+            )
+            cu_lens = torch.cumsum(content_lens, dim=0).to(torch.int32)
+            total_content = int(cu_lens[-1].item()) if cu_lens.numel() else 0
+            write_contents = torch.randint(
+                1, 10000, (total_content,), dtype=torch.int32, device=device
+            )
+            ok, err = check_case(
+                case["name"], case["output"], case["write_indices"],
+                case["write_starts"], write_contents, cu_lens,
+            )
+            if not ok:
+                return False, err
+        except Exception as e:
+            return False, f"{case['name']}: exception: {e}"
 
     return True, None
 
@@ -198,7 +269,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + NUM_CORRECTNESS_BOUNDARY_CASES,
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_compute_identity/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_compute_identity/scripts/task_runner.py
@@ -15,6 +15,15 @@ TEST_SHAPES = [
     (256, 2048, 4),
     (512, 4096, 2),
 ]
+CORRECTNESS_CASES = [
+    (*shape, "positive") for shape in TEST_SHAPES
+] + [
+    # Keep hidden_dim divisible by the original kernel's 256-element block while
+    # exercising both masked dimensions in candidates that tile multiple tokens.
+    (33, 768, 2, "positive"),
+    # Exercise a second hidden-dimension tail and signed, near-cancelling scales.
+    (31, 1280, 4, "cancellation"),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -72,11 +81,30 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, (num_tokens, hidden_dim, top_k) in enumerate(TEST_SHAPES):
+    for i, (num_tokens, hidden_dim, top_k, scale_pattern) in enumerate(
+        CORRECTNESS_CASES
+    ):
         try:
             torch.manual_seed(42 + i)
-            hidden_states = torch.randn(num_tokens, hidden_dim, device=device, dtype=torch.float16)
-            expert_scales = torch.randn(num_tokens, top_k, device=device, dtype=torch.float32).abs() * 0.5
+            hidden_states = torch.randn(
+                num_tokens, hidden_dim, device=device, dtype=torch.float16
+            )
+            if scale_pattern == "cancellation":
+                magnitudes = torch.rand(num_tokens, 2, device=device, dtype=torch.float32) + 0.5
+                residual = torch.linspace(-1e-3, 1e-3, num_tokens, device=device)
+                expert_scales = torch.stack(
+                    (
+                        magnitudes[:, 0],
+                        -magnitudes[:, 0],
+                        magnitudes[:, 1],
+                        -magnitudes[:, 1] + residual,
+                    ),
+                    dim=1,
+                )
+            else:
+                expert_scales = torch.randn(
+                    num_tokens, top_k, device=device, dtype=torch.float32
+                ).abs() * 0.5
 
             result = mod.compute_identity(hidden_states, expert_scales, top_k)
             torch.cuda.synchronize()
@@ -154,7 +182,7 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(CORRECTNESS_CASES)}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_decode_attn_stage2/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_decode_attn_stage2/scripts/task_runner.py
@@ -20,6 +20,18 @@ TEST_SHAPES = [
     (1, 8, 1, 64, 64, 2, 16),    # MQA
     (8, 8, 8, 64, 128, 4, 16),
 ]
+
+# Correctness-only cases pair a shape with optional per-batch sequence lengths.
+# Keep these separate from TEST_SHAPES so coverage additions do not change the
+# scored performance workload.
+CORRECTNESS_CASES = [(shape, None) for shape in TEST_SHAPES] + [
+    # Non-power-of-two head dimension and split count. The sequence lengths
+    # exercise partial final splits (17 and 11), an inactive split (2), and
+    # per-batch length variation in one compact case.
+    ((3, 6, 2, 80, 17, 3, 16), (17, 2, 11)),
+    # NUM_KV_SPLITS lower boundary.
+    ((2, 4, 1, 64, 13, 1, 16), (13, 5)),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -100,7 +112,8 @@ def reference_stage2(mid_o, b_seqlen, num_kv_splits, Lv):
 
 
 def make_stage1_outputs(bs, num_heads, num_kv_heads, head_dim, max_seq,
-                        num_kv_splits, page_size, device="cuda", dtype=None):
+                        num_kv_splits, page_size, device="cuda", dtype=None,
+                        seq_lengths=None):
     """
     Create synthetic stage1 outputs for testing stage2.
 
@@ -118,14 +131,22 @@ def make_stage1_outputs(bs, num_heads, num_kv_heads, head_dim, max_seq,
     mid_o = torch.zeros(bs, num_heads, num_kv_splits, Lv + 1,
                         device=device, dtype=torch.float32)
 
-    b_seqlen = torch.full((bs,), max_seq, device=device, dtype=torch.int32)
-    kv_len_per_split = (max_seq + num_kv_splits - 1) // num_kv_splits
+    if seq_lengths is None:
+        seq_lengths = (max_seq,) * bs
+    if len(seq_lengths) != bs:
+        raise ValueError("seq_lengths must contain one entry per batch element")
+    if any(seq_len <= 0 or seq_len > max_seq for seq_len in seq_lengths):
+        raise ValueError("sequence lengths must be in the range [1, max_seq]")
+
+    b_seqlen = torch.tensor(seq_lengths, device=device, dtype=torch.int32)
 
     for b in range(bs):
+        seq_len = seq_lengths[b]
+        kv_len_per_split = (seq_len + num_kv_splits - 1) // num_kv_splits
         for h in range(num_heads):
             for s in range(num_kv_splits):
                 start = kv_len_per_split * s
-                end = min(start + kv_len_per_split, max_seq)
+                end = min(start + kv_len_per_split, seq_len)
                 if end <= start:
                     continue
                 # Random partial output (normalized, like after softmax @ V)
@@ -172,10 +193,14 @@ def run_correctness():
     device = "cuda"
     dtype = torch.float16
 
-    for i, (bs, nh, nkv, hd, max_seq, num_splits, ps) in enumerate(TEST_SHAPES):
+    for i, (shape, seq_lengths) in enumerate(CORRECTNESS_CASES):
+        bs, nh, nkv, hd, max_seq, num_splits, ps = shape
         try:
             mid_o, q, o, lse, v_buffer, b_seqlen = \
-                make_stage1_outputs(bs, nh, nkv, hd, max_seq, num_splits, ps, device, dtype)
+                make_stage1_outputs(
+                    bs, nh, nkv, hd, max_seq, num_splits, ps, device, dtype,
+                    seq_lengths=seq_lengths,
+                )
 
             mod.decode_softmax_reducev_fwd(
                 mid_o, q, o, lse, v_buffer, b_seqlen, num_splits,
@@ -293,7 +318,7 @@ def main():
         report = {
             "status": "ok" if ok else "fail",
             "error": err,
-            "num_shapes": len(TEST_SHAPES),
+            "num_shapes": len(CORRECTNESS_CASES),
         }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)

--- a/tasks/triton2triton/vllm/triton_ep_scatter_1/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_ep_scatter_1/scripts/task_runner.py
@@ -15,6 +15,10 @@ TEST_SHAPES = [
     (32, 64),
     (64, 128),
 ]
+DETERMINISTIC_CORRECTNESS_CASES = [
+    ("boundary_counts_5_experts", (0, 127, 128, 129, 1)),
+    ("multi_tile_counts_3_experts", (255, 256, 257)),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -88,29 +92,45 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
+
+    def check_case(case_name, tokens_per_expert):
+        num_experts = tokens_per_expert.shape[0]
+        aligned_counts = [round_up_128(t.item()) for t in tokens_per_expert]
+        total = sum(aligned_counts)
+
+        expert_start_loc = torch.empty(num_experts, device=device, dtype=torch.int32)
+        m_indices = torch.full((total,), -1, device=device, dtype=torch.int32)
+
+        mod.ep_scatter_1(tokens_per_expert, expert_start_loc, m_indices)
+        torch.cuda.synchronize()
+
+        ref_starts, ref_m_indices = reference_scatter_1(tokens_per_expert.cpu())
+
+        if not torch.equal(expert_start_loc.cpu(), ref_starts):
+            return f"Case {case_name}: expert_start_loc mismatch"
+        if not torch.equal(m_indices.cpu(), ref_m_indices):
+            return f"Case {case_name}: m_indices mismatch"
+        return None
+
     for i, (num_experts, max_tpe) in enumerate(TEST_SHAPES):
         try:
             torch.manual_seed(42 + i)
             tokens_per_expert = torch.randint(0, max_tpe + 1, (num_experts,), device=device, dtype=torch.int32)
-
-            # Compute total aligned size
-            aligned_counts = [round_up_128(t.item()) for t in tokens_per_expert]
-            total = sum(aligned_counts)
-
-            expert_start_loc = torch.empty(num_experts, device=device, dtype=torch.int32)
-            m_indices = torch.full((total,), -1, device=device, dtype=torch.int32)
-
-            mod.ep_scatter_1(tokens_per_expert, expert_start_loc, m_indices)
-            torch.cuda.synchronize()
-
-            ref_starts, ref_m_indices = reference_scatter_1(tokens_per_expert.cpu())
-
-            if not torch.equal(expert_start_loc.cpu(), ref_starts):
-                return False, f"Shape {i+1}: expert_start_loc mismatch"
-            if not torch.equal(m_indices.cpu(), ref_m_indices):
-                return False, f"Shape {i+1}: m_indices mismatch"
+            error = check_case(f"seeded_shape_{i + 1}", tokens_per_expert)
+            if error:
+                return False, error
         except Exception as e:
-            return False, f"Shape {i+1}: exception: {e}"
+            return False, f"Case seeded_shape_{i + 1}: exception: {e}"
+
+    for case_name, token_counts in DETERMINISTIC_CORRECTNESS_CASES:
+        try:
+            tokens_per_expert = torch.tensor(token_counts, device=device, dtype=torch.int32)
+            error = check_case(case_name, tokens_per_expert)
+            if error:
+                return False, error
+        except Exception as e:
+            return False, f"Case {case_name}: exception: {e}"
+
     return True, None
 
 
@@ -182,7 +202,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(DETERMINISTIC_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_fused_moe_lora/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_fused_moe_lora/scripts/task_runner.py
@@ -15,6 +15,43 @@ TEST_SHAPES = [
     (64, 512, 8, 32, 256, 4, 2),
     (128, 1024, 8, 32, 512, 4, 2),
 ]
+
+# Targeted correctness-only coverage. Keep performance tied to TEST_SHAPES so
+# hardening the harness does not change the benchmark methodology.
+CORRECTNESS_CASES = [
+    {
+        "name": "naive_irregular_slices_offset",
+        "shape": (7, 70, 5, 13, 45, 3, 3),
+        "num_slices": 2,
+        "offset": 5,
+        "dtype": "float16",
+        "sorted_assignment": False,
+        "mul_routed_weight": False,
+        "include_invalid_routes": True,
+    },
+    {
+        "name": "sorted_routed_weight_bfloat16",
+        "shape": (9, 65, 3, 17, 33, 3, 3),
+        "num_slices": 1,
+        "offset": 0,
+        "dtype": "bfloat16",
+        "sorted_assignment": True,
+        "mul_routed_weight": True,
+        "include_invalid_routes": True,
+    },
+    {
+        "name": "split_k2_no_l2_cache",
+        "shape": (5, 70, 3, 11, 37, 2, 2),
+        "num_slices": 1,
+        "offset": 0,
+        "dtype": "float16",
+        "sorted_assignment": False,
+        "mul_routed_weight": False,
+        "include_invalid_routes": False,
+        "shrink_split_k": 2,
+        "use_b_l2_cache": False,
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -47,9 +84,10 @@ def reference_fused_moe_lora(qcurr_hidden_states, lora_a_stacked, lora_b_stacked
                               topk_weights, expert_ids, token_lora_mapping,
                               top_k_num, adapter_enabled, mul_routed_weight):
     """CPU reference: per-token shrink then expand with MoE expert routing.
-    Uses naive (non-sorted) assignment for simplicity."""
+    expert_ids contains the canonical flat route-to-expert mapping, regardless
+    of whether the kernel launch uses naive or sorted assignment."""
     import torch
-    M = qcurr_hidden_states.shape[0]
+    M = topk_weights.shape[0]
     K = qcurr_hidden_states.shape[1]
     num_slices = len(lora_a_stacked)
     max_lora_rank = lora_a_stacked[0].shape[2]
@@ -73,7 +111,8 @@ def reference_fused_moe_lora(qcurr_hidden_states, lora_a_stacked, lora_b_stacked
             exp_id = expert_ids[flat_idx].item()
             if exp_id == -1:
                 continue
-            inp = qcurr_hidden_states[token_idx].float()
+            input_idx = flat_idx if mul_routed_weight else token_idx
+            inp = qcurr_hidden_states[input_idx].float()
             for s in range(num_slices):
                 # lora_a: [max_loras, num_experts, max_lora_rank, K]
                 wa = lora_a_stacked[s][lora_id, exp_id].float()  # [rank, K]
@@ -137,12 +176,161 @@ def make_test_data(M, K, num_experts, lora_rank, out_dim, num_loras, top_k, devi
             lora_rank, top_k, lora_ids, num_loras, adapter_enabled)
 
 
+def _make_sorted_assignment(route_expert_ids, token_lora_mapping, num_loras,
+                            block_size, device):
+    """Pack flat token routes into the block-sorted format consumed by the kernel."""
+    import torch
+
+    num_routes = route_expert_ids.numel()
+    top_k = num_routes // token_lora_mapping.numel()
+    rows = []
+    expert_rows = []
+    padded_counts = []
+
+    route_experts_cpu = route_expert_ids.cpu().tolist()
+    token_loras_cpu = token_lora_mapping.cpu().tolist()
+    for lora_id in range(num_loras):
+        row = []
+        row_experts = []
+        grouped_routes = {}
+        for route_id, expert_id in enumerate(route_experts_cpu):
+            token_id = route_id // top_k
+            if token_loras_cpu[token_id] == lora_id:
+                grouped_routes.setdefault(expert_id, []).append(route_id)
+
+        for expert_id in sorted(grouped_routes):
+            routes = grouped_routes[expert_id]
+            for start in range(0, len(routes), block_size):
+                block = routes[start: start + block_size]
+                row.extend(block)
+                row.extend([num_routes] * (block_size - len(block)))
+                row_experts.append(expert_id)
+
+        rows.append(row)
+        expert_rows.append(row_experts)
+        padded_counts.append(len(row))
+
+    max_blocks = max(1, max(len(row) for row in expert_rows))
+    row_width = max_blocks * block_size
+    sorted_token_ids = torch.full(
+        (num_loras, row_width), num_routes, dtype=torch.int64, device=device
+    )
+    sorted_expert_ids = torch.full(
+        (num_loras, max_blocks), -1, dtype=torch.int64, device=device
+    )
+    for lora_id, (row, row_experts) in enumerate(zip(rows, expert_rows)):
+        if row:
+            sorted_token_ids[lora_id, :len(row)] = torch.tensor(
+                row, dtype=torch.int64, device=device
+            )
+            sorted_expert_ids[lora_id, :len(row_experts)] = torch.tensor(
+                row_experts, dtype=torch.int64, device=device
+            )
+
+    num_tokens_post_padded = torch.tensor(
+        padded_counts, dtype=torch.int32, device=device
+    )
+    return sorted_token_ids, sorted_expert_ids, num_tokens_post_padded
+
+
+def make_correctness_data(case, device, seed):
+    """Build a correctness-only case without changing benchmark inputs."""
+    import torch
+
+    M, K, num_experts, lora_rank, out_dim, num_loras, top_k = case["shape"]
+    num_slices = case["num_slices"]
+    mul_routed_weight = case["mul_routed_weight"]
+    dtype = getattr(torch, case["dtype"])
+
+    torch.manual_seed(seed)
+    input_rows = M * top_k if mul_routed_weight else M
+    value_scale = 0.2
+    qcurr = torch.randn(input_rows, K, device=device, dtype=dtype) * value_scale
+    topk_weights = torch.linspace(
+        0.2, 1.1, M * top_k, device=device, dtype=torch.float32
+    ).reshape(M, top_k)
+    lora_a = [
+        torch.randn(
+            num_loras, num_experts, lora_rank, K, device=device, dtype=dtype
+        ) * value_scale
+        for _ in range(num_slices)
+    ]
+    lora_b = [
+        torch.randn(
+            num_loras, num_experts, out_dim, lora_rank,
+            device=device, dtype=dtype,
+        ) * value_scale
+        for _ in range(num_slices)
+    ]
+
+    route_expert_ids = (
+        torch.arange(M * top_k, device=device, dtype=torch.int64) % num_experts
+    )
+    token_lora_mapping = (
+        torch.arange(M, device=device, dtype=torch.int64) % num_loras
+    )
+    adapter_enabled = torch.ones(num_loras, device=device, dtype=torch.int32)
+
+    if case["include_invalid_routes"]:
+        # Exercise all three early exits: absent adapter, disabled adapter, and
+        # an invalid expert. Keep other routes valid so the case is nontrivial.
+        token_lora_mapping[0] = -1
+        if num_loras > 1:
+            token_lora_mapping[1] = 1
+            adapter_enabled[1] = 0
+        route_expert_ids[2 * top_k + (top_k - 1)] = -1
+
+    if case["sorted_assignment"]:
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            _make_sorted_assignment(
+                route_expert_ids, token_lora_mapping, num_loras, 64, device
+            )
+        )
+        # Exercise lora_ids indirection rather than relying on identity order.
+        active_ids = [num_loras - 1] + list(range(num_loras - 1))
+        lora_ids = torch.tensor(active_ids, device=device, dtype=torch.int64)
+        num_active_loras = len(active_ids)
+    else:
+        sorted_token_ids = None
+        expert_ids = route_expert_ids
+        num_tokens_post_padded = None
+        lora_ids = torch.arange(num_loras, device=device, dtype=torch.int64)
+        num_active_loras = num_loras
+
+    offset = case["offset"]
+    target_width = num_slices * out_dim
+    output_width = offset + target_width + (3 if offset else 0)
+    output = torch.full(
+        (M, top_k, output_width), -0.75, device=device, dtype=dtype
+    )
+    output[:, :, offset: offset + target_width] = 0
+
+    return {
+        "output": output,
+        "qcurr": qcurr,
+        "lora_a": lora_a,
+        "lora_b": lora_b,
+        "topk_weights": topk_weights,
+        "sorted_token_ids": sorted_token_ids,
+        "expert_ids": expert_ids,
+        "reference_expert_ids": route_expert_ids,
+        "num_tokens_post_padded": num_tokens_post_padded,
+        "token_lora_mapping": token_lora_mapping,
+        "max_lora_rank": lora_rank,
+        "top_k_num": top_k,
+        "lora_ids": lora_ids,
+        "num_active_loras": num_active_loras,
+        "adapter_enabled": adapter_enabled,
+    }
+
+
 def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
                           lora_b_stacked, topk_weights, sorted_token_ids,
                           expert_ids, num_tokens_post_padded,
                           token_lora_mapping, max_lora_rank, top_k_num,
                           lora_ids, num_active_loras, adapter_enabled,
-                          mul_routed_weight=False, offset=0):
+                          mul_routed_weight=False, offset=0,
+                          shrink_split_k=1, use_b_l2_cache=True):
     """Prepare stable shrink/expand launches for graph-first benchmarking.
 
     The public wrapper allocates pointer tables and an intermediate tensor on
@@ -172,8 +360,6 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
     shrink_group_size_m = 8
     shrink_num_warps = 4
     shrink_num_stages = 3
-    shrink_split_k = 1
-
     expand_block_size_m = 64
     expand_block_size_n = 64
     expand_block_size_k = max(16, min(32, mod._next_power_of_2(shrink_n)))
@@ -260,7 +446,7 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
         "naive_block_assignment": sorted_token_ids is None,
         "MUL_ROUTED_WEIGHT": False,
         "ADD_INPUTS": False,
-        "USE_B_L2_CACHE": True,
+        "USE_B_L2_CACHE": use_b_l2_cache,
         "IS_PRIMARY": True,
         "BLOCK_SIZE_M": shrink_block_size_m,
         "BLOCK_SIZE_N": shrink_block_size_n,
@@ -311,7 +497,7 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
         "naive_block_assignment": sorted_token_ids is None,
         "MUL_ROUTED_WEIGHT": mul_routed_weight,
         "ADD_INPUTS": True,
-        "USE_B_L2_CACHE": True,
+        "USE_B_L2_CACHE": use_b_l2_cache,
         "IS_PRIMARY": False,
         "BLOCK_SIZE_M": expand_block_size_m,
         "BLOCK_SIZE_N": expand_block_size_n,
@@ -327,6 +513,7 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
     shrink_launcher = mod.fused_moe_lora_kernel[shrink_grid]
     expand_launcher = mod.fused_moe_lora_kernel[expand_grid]
     reset_output = output.zero_
+    reset_intermediate = intermediate.zero_
 
     def launch_shrink():
         shrink_launcher(*shrink_args, **shrink_meta)
@@ -339,13 +526,18 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
         launch_expand()
 
     def launch_fused_no_reset():
-        # Shrink uses SPLIT_K=1 and ADD_INPUTS=False, so it overwrites every
-        # intermediate row consumed by expand; no workspace reset is required.
+        # The benchmark-default SPLIT_K=1 overwrites every intermediate row.
+        # Correctness callers selecting split-K accumulation use launch_fused,
+        # which resets the workspace first.
         launch_shrink()
         launch_expand()
 
     def launch_fused():
         reset_output()
+        if shrink_split_k > 1:
+            # Split-K uses atomic accumulation, so its destination must start
+            # from zero for each independent correctness invocation.
+            reset_intermediate()
         launch_fused_no_reset()
 
     return {
@@ -354,6 +546,7 @@ def prepare_direct_launch(mod, output, qcurr_hidden_states, lora_a_stacked,
         "shrink": launch_shrink,
         "reset_expand": launch_reset_expand,
         "reset_output": reset_output,
+        "reset_intermediate": reset_intermediate,
         "output": output,
         "intermediate": intermediate,
         "lora_a_ptrs": lora_a_ptrs,
@@ -426,6 +619,66 @@ def run_correctness():
                 )
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, case in enumerate(CORRECTNESS_CASES):
+        name = case["name"]
+        try:
+            data = make_correctness_data(case, device, 100 + i)
+            output = data["output"]
+            offset = case["offset"]
+
+            ref = reference_fused_moe_lora(
+                data["qcurr"], data["lora_a"], data["lora_b"],
+                data["topk_weights"], data["reference_expert_ids"],
+                data["token_lora_mapping"], data["top_k_num"],
+                data["adapter_enabled"], case["mul_routed_weight"],
+            ).to(device)
+            target_width = ref.shape[2]
+            expected = output.clone()
+            expected[:, :, offset: offset + target_width] = ref
+
+            mod.fused_moe_lora(
+                output, data["qcurr"], data["lora_a"], data["lora_b"],
+                data["topk_weights"], data["sorted_token_ids"],
+                data["expert_ids"], data["num_tokens_post_padded"],
+                data["token_lora_mapping"], data["max_lora_rank"],
+                data["top_k_num"], data["lora_ids"],
+                data["num_active_loras"], data["adapter_enabled"],
+                mul_routed_weight=case["mul_routed_weight"], offset=offset,
+            )
+            torch.cuda.synchronize()
+
+            if not torch.allclose(
+                output.float(), expected.float(), atol=5e-2, rtol=5e-2
+            ):
+                max_diff = (output.float() - expected.float()).abs().max().item()
+                return False, f"Case {name}: wrapper max diff = {max_diff:.6f}"
+
+            direct = prepare_direct_launch(
+                mod, output, data["qcurr"], data["lora_a"], data["lora_b"],
+                data["topk_weights"], data["sorted_token_ids"],
+                data["expert_ids"], data["num_tokens_post_padded"],
+                data["token_lora_mapping"], data["max_lora_rank"],
+                data["top_k_num"], data["lora_ids"],
+                data["num_active_loras"], data["adapter_enabled"],
+                mul_routed_weight=case["mul_routed_weight"], offset=offset,
+                shrink_split_k=case.get("shrink_split_k", 1),
+                use_b_l2_cache=case.get("use_b_l2_cache", True),
+            )
+            direct["fused"]()
+            torch.cuda.synchronize()
+
+            direct_expected = torch.zeros_like(output)
+            direct_expected[:, :, offset: offset + target_width] = ref
+            if not torch.allclose(
+                output.float(), direct_expected.float(), atol=5e-2, rtol=5e-2
+            ):
+                max_diff = (
+                    output.float() - direct_expected.float()
+                ).abs().max().item()
+                return False, f"Case {name}: direct max diff = {max_diff:.6f}"
+        except Exception as e:
+            return False, f"Case {name}: exception: {e}"
     return True, None
 
 
@@ -510,7 +763,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_logit_bias/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_logit_bias/scripts/task_runner.py
@@ -92,6 +92,40 @@ def reference_apply_logit_bias(
 
     return out
 
+
+def compare_outputs(got, ref, case_name):
+    import torch
+
+    got_nan = torch.isnan(got)
+    if got_nan.any():
+        return False, f"{case_name}: output contains {got_nan.sum().item()} NaN value(s)"
+
+    for kind, predicate in (
+        ("positive-infinity", torch.isposinf),
+        ("negative-infinity", torch.isneginf),
+    ):
+        got_mask = predicate(got)
+        ref_mask = predicate(ref)
+        if not torch.equal(got_mask, ref_mask):
+            mismatch = (got_mask ^ ref_mask).sum().item()
+            return False, f"{case_name}: {kind} mismatch ({mismatch} elements)"
+
+    got_finite = torch.isfinite(got)
+    ref_finite = torch.isfinite(ref)
+    if not torch.equal(got_finite, ref_finite):
+        mismatch = (got_finite ^ ref_finite).sum().item()
+        return False, f"{case_name}: finite-mask mismatch ({mismatch} elements)"
+
+    if got_finite.any():
+        got_v = got[got_finite]
+        ref_v = ref[got_finite]
+        if not torch.allclose(got_v, ref_v, atol=1e-2, rtol=1e-2):
+            max_diff = (got_v - ref_v).abs().max().item()
+            return False, f"{case_name}: finite max diff = {max_diff}"
+
+    return True, None
+
+
 def run_correctness():
     import torch
     try: mod = load_module()
@@ -124,18 +158,9 @@ def run_correctness():
             )
             mod.apply_logit_bias(logits, idx_mapping, pos, num_allowed, allowed_ids, num_bias, bias_token_ids, bias_vals, min_lens, num_stop, stop_ids)
             torch.cuda.synchronize()
-            got_finite = torch.isfinite(logits)
-            ref_finite = torch.isfinite(ref)
-            if not torch.equal(got_finite, ref_finite):
-                mismatch = (got_finite ^ ref_finite).sum().item()
-                return False, f"Shape {i+1}: finite-mask mismatch ({mismatch} elements)"
-
-            if got_finite.any():
-                got_v = logits[got_finite]
-                ref_v = ref[got_finite]
-                if not torch.allclose(got_v, ref_v, atol=1e-2, rtol=1e-2):
-                    max_diff = (got_v - ref_v).abs().max().item()
-                    return False, f"Shape {i+1}: finite max diff = {max_diff}"
+            ok, err = compare_outputs(logits, ref, f"Shape {i+1}")
+            if not ok:
+                return False, err
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
 
@@ -172,14 +197,9 @@ def run_correctness():
         )
         torch.cuda.synchronize()
 
-        got_finite = torch.isfinite(got)
-        ref_finite = torch.isfinite(ref)
-        if not torch.equal(got_finite, ref_finite):
-            mismatch = (got_finite ^ ref_finite).sum().item()
-            return False, f"Allowlist case: finite-mask mismatch ({mismatch} elements)"
-        if got_finite.any() and not torch.allclose(got[got_finite], ref[got_finite], atol=1e-2, rtol=1e-2):
-            max_diff = (got[got_finite] - ref[got_finite]).abs().max().item()
-            return False, f"Allowlist case: finite max diff = {max_diff}"
+        ok, err = compare_outputs(got, ref, "Allowlist case")
+        if not ok:
+            return False, err
     except Exception as e:
         return False, f"Allowlist case: exception: {e}"
     return True, None

--- a/tasks/triton2triton/vllm/triton_pack_bitmatrix/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_pack_bitmatrix/scripts/task_runner.py
@@ -15,6 +15,15 @@ TEST_SHAPES = [
     (256, 64, 4),
     (512, 64, 2),
 ]
+
+# Correctness-only coverage for row tails, topk limits, and 32-bit word edges.
+# These are intentionally separate from TEST_SHAPES so benchmark inputs remain
+# unchanged.
+BOUNDARY_TEST_SHAPES = [
+    (17, 31, 1),
+    (33, 32, 31),
+    (513, 33, 32),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -75,6 +84,33 @@ def reference_pack_bitmatrix(topk_ids, num_experts):
     return bitmatrix
 
 
+def make_boundary_topk_ids(n_rows, num_experts, topk, device):
+    """Build deterministic valid IDs with duplicates and word-edge values."""
+    import torch
+
+    rows = torch.arange(n_rows, dtype=torch.int64)[:, None]
+    cols = torch.arange(topk, dtype=torch.int64)[None, :]
+    topk_ids = ((rows * 17 + cols * 7) % num_experts).to(torch.int16)
+
+    # Row zero includes duplicates and IDs on both sides of the 31/32 word
+    # boundary whenever those IDs are valid for the case.
+    edge_ids = [
+        0,
+        0,
+        min(30, num_experts - 1),
+        min(31, num_experts - 1),
+        min(32, num_experts - 1),
+        num_experts - 1,
+        num_experts - 1,
+    ]
+    prefix_len = min(topk, len(edge_ids))
+    topk_ids[0, :prefix_len] = torch.tensor(
+        edge_ids[:prefix_len], dtype=torch.int16
+    )
+    topk_ids[-1, 0] = num_experts - 1
+    return topk_ids.to(device)
+
+
 def run_compile():
     try:
         import ast
@@ -111,6 +147,24 @@ def run_correctness():
                 return False, f"Shape {i+1}: {diff_count} mismatched elements"
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, (n_rows, num_experts, topk) in enumerate(BOUNDARY_TEST_SHAPES):
+        try:
+            topk_ids = make_boundary_topk_ids(
+                n_rows, num_experts, topk, device
+            )
+
+            result = mod.pack_topk_to_bitmatrix(topk_ids, num_experts)
+            torch.cuda.synchronize()
+
+            ref = reference_pack_bitmatrix(topk_ids.cpu(), num_experts).to(device)
+            if not torch.equal(result, ref):
+                diff_count = (result != ref).sum().item()
+                return False, (
+                    f"Boundary shape {i+1}: {diff_count} mismatched elements"
+                )
+        except Exception as e:
+            return False, f"Boundary shape {i+1}: exception: {e}"
     return True, None
 
 
@@ -176,7 +230,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(BOUNDARY_TEST_SHAPES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_penalties/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_penalties/scripts/task_runner.py
@@ -32,6 +32,53 @@ TEST_SHAPES = [
     (32, 16384),
     (64, 32768),
 ]
+TARGETED_CORRECTNESS_CASES = [
+    {
+        "name": "small_vocab_speculative_mapped_penalties_fp16",
+        "vocab": 7,
+        "dtype": "float16",
+        "idx_mapping": [2, 2, 2, 0, 0, 0, 1, 1, 1, 3],
+        "token_ids": [6, 5, 5, 0, 2, 6, 4, 0, 0, 3],
+        "local_pos": [0, 1, 2, 0, 1, 2, 0, 1, 2, 0],
+        "num_speculative_tokens": 2,
+        # State 0: repetition only; state 1: frequency only;
+        # state 2: presence only; state 3: intentional no-op.
+        "penalties": [
+            (1.25, 0.0, 0.0),
+            (1.0, 0.5, 0.0),
+            (1.0, 0.0, 0.75),
+            (1.0, 0.0, 0.0),
+        ],
+        "prompt_tokens": [[0, 3, 6], [1], [2], [0, 6]],
+        "output_counts": [
+            (0, 1, 2), (0, 5, 1),
+            (1, 0, 3), (1, 6, 1),
+            (2, 2, 1),
+            (3, 4, 3),
+        ],
+    },
+    {
+        "name": "packed_mask_and_tile_tails_bf16",
+        "vocab": 8209,
+        "dtype": "bfloat16",
+        "idx_mapping": [1, 0, 1],
+        "token_ids": [8208, 8192, 31],
+        "local_pos": [0, 0, 0],
+        "num_speculative_tokens": 0,
+        "penalties": [
+            (1.2, 0.35, 0.15),
+            (1.3, 0.0, 0.0),
+        ],
+        "prompt_tokens": [
+            [0, 31, 32, 8191, 8192, 8208],
+            [1, 63, 8193, 8208],
+        ],
+        "output_counts": [
+            (0, 31, 1), (0, 8192, 2), (0, 8208, 3),
+            (1, 0, 1), (1, 8191, 4), (1, 8193, 2),
+        ],
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -104,6 +151,61 @@ def reference_apply_penalties(
 
     return out.to(logits.dtype)
 
+
+def run_targeted_correctness_case(mod, case, seed):
+    import torch
+
+    device = "cuda"
+    vocab = case["vocab"]
+    dtype = getattr(torch, case["dtype"])
+    idx_mapping = torch.tensor(case["idx_mapping"], dtype=torch.int32, device=device)
+    token_ids = torch.tensor(case["token_ids"], dtype=torch.int32, device=device)
+    local_pos = torch.tensor(case["local_pos"], dtype=torch.int32, device=device)
+    num_states = len(case["penalties"])
+
+    penalties = torch.tensor(case["penalties"], dtype=torch.float32, device=device)
+    rep_pen = penalties[:, 0].contiguous()
+    freq_pen = penalties[:, 1].contiguous()
+    pres_pen = penalties[:, 2].contiguous()
+
+    # Build in int64 so setting bit 31 is well-defined, then preserve the packed
+    # two's-complement representation expected by the int32 kernel input.
+    prompt_mask = torch.zeros(
+        num_states, (vocab + 31) // 32, dtype=torch.int64
+    )
+    for state_idx, prompt_tokens in enumerate(case["prompt_tokens"]):
+        for token_id in prompt_tokens:
+            prompt_mask[state_idx, token_id // 32] |= 1 << (token_id % 32)
+    prompt_mask = prompt_mask.to(dtype=torch.int32, device=device)
+
+    output_counts = torch.zeros(
+        num_states, vocab, dtype=torch.int32, device=device
+    )
+    for state_idx, token_id, count in case["output_counts"]:
+        output_counts[state_idx, token_id] = count
+
+    torch.manual_seed(seed)
+    logits = torch.randn(
+        len(case["idx_mapping"]), vocab, dtype=torch.float32, device=device
+    ).to(dtype)
+    # Guarantee both sign paths at the boundaries targeted by these cases.
+    logits[:, 0] = 2.0
+    logits[:, -1] = -2.0
+
+    ref = reference_apply_penalties(
+        logits, idx_mapping, token_ids, local_pos, rep_pen, freq_pen,
+        pres_pen, prompt_mask, output_counts, case["num_speculative_tokens"]
+    )
+    mod.apply_penalties(
+        logits, idx_mapping, token_ids, local_pos, rep_pen, freq_pen, pres_pen,
+        prompt_mask, output_counts, case["num_speculative_tokens"]
+    )
+    torch.cuda.synchronize()
+    if not torch.allclose(logits, ref, atol=1e-2, rtol=1e-2):
+        return False, (logits - ref).abs().max().item()
+    return True, None
+
+
 def run_correctness():
     import torch
     try: mod = load_module()
@@ -134,6 +236,13 @@ def run_correctness():
                 return False, f"Shape {i+1}: max diff = {(logits - ref).abs().max().item()}"
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+    for i, case in enumerate(TARGETED_CORRECTNESS_CASES):
+        try:
+            ok, max_diff = run_targeted_correctness_case(mod, case, 100 + i)
+            if not ok:
+                return False, f"Case {case['name']}: max diff = {max_diff}"
+        except Exception as e:
+            return False, f"Case {case['name']}: exception: {e}"
     return True, None
 
 def run_performance():
@@ -201,7 +310,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(TARGETED_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f: json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")
         if err: print(f"Error: {err}")

--- a/tasks/triton2triton/vllm/triton_prepare_mrope_positions/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_prepare_mrope_positions/scripts/task_runner.py
@@ -20,6 +20,29 @@ TEST_SHAPES = [
     (32, 256, 1024, True),
     (64, 16, 2048, False),
 ]
+TARGETED_CORRECTNESS_CASES = [
+    {
+        "name": "mixed_mapped_boundary_lengths",
+        "max_model_len": 64,
+        "idx_mapping": [6, 2, 7, 0, 5, 3],
+        "query_lens": [0, 1, 3, 1, 0, 7],
+        # Per-batch values are scattered through idx_mapping below. These cover
+        # zero, the final prefill position, and the exact decode boundary.
+        "prefill_lens": [5, 9, 12, 1, 4, 11],
+        "num_computed_tokens": [0, 8, 12, 1, 4, 4],
+    },
+    {
+        "name": "mixed_multi_tile_requests",
+        "max_model_len": 4096,
+        "idx_mapping": [3, 0],
+        "query_lens": [1025, 2051],
+        # Both requests cross the kernel's 1024-element tile. The prefill
+        # request ends at the last valid lookup entry; decode starts exactly at
+        # its prefill length and remains within max_model_len.
+        "prefill_lens": [4096, 2045],
+        "num_computed_tokens": [3071, 2045],
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -80,6 +103,110 @@ def reference_prepare_mrope(mrope_positions, prefill_mrope_positions, max_model_
     return mrope_positions
 
 
+def check_mrope_case(mod, case_name, mrope_positions, prefill_mrope_positions,
+                     max_model_len, prefill_mrope_delta, idx_mapping,
+                     query_start_loc, prefill_lens, num_computed_tokens):
+    import torch
+
+    ref = reference_prepare_mrope(
+        mrope_positions.cpu(), prefill_mrope_positions.cpu(), max_model_len,
+        prefill_mrope_delta.cpu(), idx_mapping.cpu(), query_start_loc.cpu(),
+        prefill_lens.cpu(), num_computed_tokens.cpu(),
+    )
+    mod.prepare_mrope_positions(
+        mrope_positions, prefill_mrope_positions, max_model_len,
+        prefill_mrope_delta, idx_mapping, query_start_loc, prefill_lens,
+        num_computed_tokens,
+    )
+    torch.cuda.synchronize()
+
+    actual = mrope_positions.cpu()
+    if torch.equal(actual, ref):
+        return True, None
+
+    first_diff = (actual != ref).nonzero()[0]
+    dim = first_diff[0].item()
+    token = first_diff[1].item()
+    return False, (
+        f"{case_name}: mismatch at [{dim},{token}] "
+        f"got {actual[dim, token].item()} expected {ref[dim, token].item()}"
+    )
+
+
+def run_targeted_correctness_case(mod, case, seed):
+    import torch
+
+    device = "cuda"
+    idx_mapping_values = case["idx_mapping"]
+    query_lens = case["query_lens"]
+    prefill_lens_by_batch = case["prefill_lens"]
+    num_computed_by_batch = case["num_computed_tokens"]
+    max_model_len = case["max_model_len"]
+    num_reqs = len(idx_mapping_values)
+
+    if not (
+        len(query_lens) == len(prefill_lens_by_batch)
+        == len(num_computed_by_batch) == num_reqs
+    ):
+        raise ValueError("targeted case arrays must have one entry per request")
+    if len(set(idx_mapping_values)) != num_reqs:
+        raise ValueError("targeted cases require unique request-state mappings")
+
+    max_num_reqs = max(num_reqs + 8, max(idx_mapping_values) + 1)
+    idx_mapping = torch.tensor(
+        idx_mapping_values, dtype=torch.int32, device=device
+    )
+    query_starts = [0]
+    for query_len in query_lens:
+        if query_len < 0:
+            raise ValueError("query lengths must be nonnegative")
+        query_starts.append(query_starts[-1] + query_len)
+    query_start_loc = torch.tensor(
+        query_starts, dtype=torch.int32, device=device
+    )
+
+    prefill_lens = torch.zeros(
+        max_num_reqs, dtype=torch.int32, device=device
+    )
+    num_computed_tokens = torch.zeros(
+        max_num_reqs, dtype=torch.int32, device=device
+    )
+    for batch_idx, req_state_idx in enumerate(idx_mapping_values):
+        prefill_len = prefill_lens_by_batch[batch_idx]
+        num_computed = num_computed_by_batch[batch_idx]
+        query_len = query_lens[batch_idx]
+        if not (0 <= prefill_len <= max_model_len):
+            raise ValueError("prefill length is outside max_model_len")
+        if not (0 <= num_computed <= max_model_len):
+            raise ValueError("num_computed is outside max_model_len")
+        if num_computed + query_len > max_model_len:
+            raise ValueError("request tokens exceed max_model_len")
+        if num_computed < prefill_len and num_computed + query_len > prefill_len:
+            raise ValueError("prefill query extends beyond its prefill length")
+        prefill_lens[req_state_idx] = prefill_len
+        num_computed_tokens[req_state_idx] = num_computed
+
+    torch.manual_seed(seed)
+    prefill_mrope_positions = torch.randint(
+        0, max_model_len, (max_num_reqs * 3, max_model_len),
+        dtype=torch.int32, device=device,
+    )
+    prefill_mrope_delta = torch.randint(
+        -10, 10, (max_num_reqs,), dtype=torch.int32, device=device
+    )
+    # The int64-only sentinel also verifies that empty requests and the output
+    # guard element remain untouched.
+    mrope_positions = torch.full(
+        (3, query_starts[-1] + 1), -(1 << 40),
+        dtype=torch.int64, device=device,
+    )
+    return check_mrope_case(
+        mod, case["name"], mrope_positions, prefill_mrope_positions,
+        max_model_len, prefill_mrope_delta, idx_mapping, query_start_loc,
+        prefill_lens, num_computed_tokens,
+    )
+
+
 def run_compile():
     try:
         import ast
@@ -129,29 +256,24 @@ def run_correctness():
             )
             mrope_positions = torch.zeros(3, total_tokens + 1, dtype=torch.int64, device=device)
 
-            mod.prepare_mrope_positions(
-                mrope_positions, prefill_mrope_positions, max_model_len,
-                prefill_mrope_delta, idx_mapping, query_start_loc,
-                prefill_lens, num_computed_tokens,
+            ok, err = check_mrope_case(
+                mod, f"Shape {i + 1}", mrope_positions,
+                prefill_mrope_positions, max_model_len, prefill_mrope_delta,
+                idx_mapping, query_start_loc, prefill_lens,
+                num_computed_tokens,
             )
-            torch.cuda.synchronize()
-
-            ref = reference_prepare_mrope(
-                torch.zeros(3, total_tokens + 1, dtype=torch.int64),
-                prefill_mrope_positions.cpu(), max_model_len,
-                prefill_mrope_delta.cpu(), idx_mapping.cpu(), query_start_loc.cpu(),
-                prefill_lens.cpu(), num_computed_tokens.cpu(),
-            )
-
-            if not torch.equal(mrope_positions.cpu()[:, :total_tokens], ref[:, :total_tokens]):
-                diff = (mrope_positions.cpu()[:, :total_tokens] != ref[:, :total_tokens])
-                first_diff = diff.nonzero()
-                if len(first_diff) > 0:
-                    fd = first_diff[0]
-                    return False, f"Shape {i+1}: mismatch at [{fd[0]},{fd[1]}] got {mrope_positions.cpu()[fd[0],fd[1]].item()} expected {ref[fd[0],fd[1]].item()}"
-                return False, f"Shape {i+1}: mismatch"
+            if not ok:
+                return False, err
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, case in enumerate(TARGETED_CORRECTNESS_CASES):
+        try:
+            ok, err = run_targeted_correctness_case(mod, case, 100 + i)
+            if not ok:
+                return False, err
+        except Exception as e:
+            return False, f"Case {case['name']}: exception: {e}"
 
     return True, None
 
@@ -177,8 +299,21 @@ def run_performance():
                 query_start_loc[r + 1] = query_start_loc[r] + query_len
             total_tokens = int(query_start_loc[-1].item())
 
-            prefill_lens = torch.full((max_num_reqs,), max_model_len, dtype=torch.int32, device=device)
-            num_computed_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+            if is_prefill:
+                prefill_lens = torch.full(
+                    (max_num_reqs,), max_model_len,
+                    dtype=torch.int32, device=device,
+                )
+                num_computed_tokens = torch.zeros(
+                    max_num_reqs, dtype=torch.int32, device=device
+                )
+            else:
+                prefill_lens = torch.full(
+                    (max_num_reqs,), 10, dtype=torch.int32, device=device
+                )
+                num_computed_tokens = torch.full(
+                    (max_num_reqs,), 50, dtype=torch.int32, device=device
+                )
             prefill_mrope_positions = torch.randint(
                 0, max_model_len, (max_num_reqs * 3, max_model_len),
                 dtype=torch.int32, device=device
@@ -243,7 +378,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(TARGETED_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_ranks/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_ranks/scripts/task_runner.py
@@ -32,6 +32,29 @@ TEST_SHAPES = [
     (32, 8192),
     (64, 32768),
 ]
+ADDITIONAL_CORRECTNESS_CASES = [
+    {
+        "name": "masked_tail",
+        "batch": 3,
+        "vocab": 8193,
+        "dtype": "float32",
+        "pattern": "all_ties",
+    },
+    {
+        "name": "above_32768",
+        "batch": 2,
+        "vocab": 40003,
+        "dtype": "float32",
+        "pattern": "high_tail",
+    },
+    {
+        "name": "large_batch_small_vocab_fp16_ties",
+        "batch": 65,
+        "vocab": 257,
+        "dtype": "float16",
+        "pattern": "repeated_values",
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -74,6 +97,43 @@ def run_correctness():
                 return False, f"Shape {i+1}: mismatch"
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, case in enumerate(ADDITIONAL_CORRECTNESS_CASES):
+        name = case["name"]
+        batch = case["batch"]
+        vocab = case["vocab"]
+        dtype = getattr(torch, case["dtype"])
+        try:
+            if case["pattern"] == "all_ties":
+                logits = torch.zeros(batch, vocab, device=device, dtype=dtype)
+                token_ids = torch.full(
+                    (batch,), vocab - 1, dtype=torch.int64, device=device
+                )
+            elif case["pattern"] == "high_tail":
+                logits = torch.zeros(batch, vocab, device=device, dtype=dtype)
+                logits[:, 32768:] = 1
+                token_ids = torch.tensor(
+                    [0, vocab - 1], dtype=torch.int64, device=device
+                )
+            else:
+                values = (torch.arange(vocab, device=device) % 7 - 3).to(dtype)
+                logits = values.unsqueeze(0).expand(batch, -1).contiguous()
+                token_ids = (
+                    torch.arange(batch, dtype=torch.int64, device=device) * 37
+                    + vocab
+                    - 1
+                ) % vocab
+
+            result = mod.compute_ranks(logits, token_ids)
+            torch.cuda.synchronize()
+            ref = torch.zeros(batch, dtype=torch.int64, device=device)
+            for b in range(batch):
+                x = logits[b, token_ids[b].item()]
+                ref[b] = (logits[b] >= x).sum().item()
+            if not torch.equal(result, ref):
+                return False, f"Additional case {name}: mismatch"
+        except Exception as e:
+            return False, f"Additional case {name}: exception: {e}"
     return True, None
 
 def run_performance():
@@ -132,7 +192,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(TEST_SHAPES) + len(ADDITIONAL_CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f: json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")
         if err: print(f"Error: {err}")

--- a/tasks/triton2triton/vllm/triton_sample_recovered_tokens/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_sample_recovered_tokens/scripts/task_runner.py
@@ -32,6 +32,11 @@ TEST_SHAPES = [
     (32, 6, 512),
     (64, 8, 1024),
 ]
+CORRECTNESS_EDGE_CASES = [
+    (1, 1, 3, [1]),
+    (5, 3, 511, [0, 1, 0, 3, 0]),
+]
+NUM_CORRECTNESS_CASES = len(TEST_SHAPES) + len(CORRECTNESS_EDGE_CASES) + 1
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -104,6 +109,92 @@ def run_correctness():
             assert result.min() >= 0 and result.max() < vocab_size
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
+
+    for i, (batch_size, max_draft, vocab_size, num_per_req) in enumerate(
+        CORRECTNESS_EDGE_CASES
+    ):
+        case_name = f"Edge shape {i+1}"
+        try:
+            torch.manual_seed(100 + i)
+            cu = torch.cumsum(
+                torch.tensor(num_per_req, dtype=torch.int32, device=device), dim=0
+            )
+            total = sum(num_per_req)
+            draft_ids = torch.randint(
+                0, vocab_size, (total,), dtype=torch.int32, device=device
+            )
+            draft_probs = torch.rand(total, vocab_size, device=device)
+            draft_probs = draft_probs / draft_probs.sum(-1, keepdim=True)
+            target_probs = torch.rand(total, vocab_size, device=device)
+            target_probs = target_probs / target_probs.sum(-1, keepdim=True)
+            q = torch.empty(batch_size, vocab_size, device=device).exponential_()
+
+            result = mod.sample_recovered_tokens(
+                cu, draft_ids, draft_probs, target_probs, q,
+                max_draft, vocab_size,
+            )
+            ref = reference_sample_recovered_tokens(
+                cu, draft_ids, draft_probs, target_probs, q, vocab_size
+            )
+            if not torch.equal(result, ref):
+                return False, f"{case_name}: mismatch with draft_probs path"
+
+            result_no_draft = mod.sample_recovered_tokens(
+                cu, draft_ids, None, target_probs, q, max_draft, vocab_size
+            )
+            ref_no_draft = reference_sample_recovered_tokens(
+                cu, draft_ids, None, target_probs, q, vocab_size
+            )
+            if not torch.equal(result_no_draft, ref_no_draft):
+                return False, f"{case_name}: mismatch with NO_DRAFT_PROBS path"
+            torch.cuda.synchronize()
+            assert result.shape == (total,), f"Wrong shape: {result.shape}"
+            assert result.min() >= 0 and result.max() < vocab_size
+        except Exception as e:
+            return False, f"{case_name}: exception: {e}"
+
+    # Use sparse, normalized distributions to make the expected argmax exact.
+    # Row 0 ties at tokens 1 and 3, row 1 has no positive adjusted probability,
+    # and row 2 selects the final valid token before power-of-two padding.
+    try:
+        batch_size, max_draft, vocab_size = 3, 2, 513
+        cu = torch.tensor([1, 1, 3], dtype=torch.int32, device=device)
+        draft_ids = torch.tensor([0, 5, 0], dtype=torch.int32, device=device)
+        draft_probs = torch.zeros(3, vocab_size, device=device)
+        target_probs = torch.zeros_like(draft_probs)
+        draft_probs[0, 0] = 1.0
+        target_probs[0, 1] = 0.5
+        target_probs[0, 3] = 0.5
+        draft_probs[1, 5] = 1.0
+        target_probs[1, 5] = 1.0
+        draft_probs[2, 0] = 1.0
+        target_probs[2, vocab_size - 1] = 1.0
+        q = torch.ones(batch_size, vocab_size, device=device)
+        expected = torch.tensor([1, 0, vocab_size - 1], dtype=torch.int32, device=device)
+
+        ref = reference_sample_recovered_tokens(
+            cu, draft_ids, draft_probs, target_probs, q, vocab_size
+        )
+        ref_no_draft = reference_sample_recovered_tokens(
+            cu, draft_ids, None, target_probs, q, vocab_size
+        )
+        if not torch.equal(ref, expected) or not torch.equal(ref_no_draft, expected):
+            return False, "Tie/padding case: reference did not produce expected tokens"
+
+        result = mod.sample_recovered_tokens(
+            cu, draft_ids, draft_probs, target_probs, q,
+            max_draft, vocab_size,
+        )
+        if not torch.equal(result, expected):
+            return False, "Tie/padding case: mismatch with draft_probs path"
+        result_no_draft = mod.sample_recovered_tokens(
+            cu, draft_ids, None, target_probs, q, max_draft, vocab_size
+        )
+        if not torch.equal(result_no_draft, expected):
+            return False, "Tie/padding case: mismatch with NO_DRAFT_PROBS path"
+        torch.cuda.synchronize()
+    except Exception as e:
+        return False, f"Tie/padding case: exception: {e}"
     return True, None
 
 def run_performance():
@@ -171,7 +262,7 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": NUM_CORRECTNESS_CASES}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f: json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")
         if err: print(f"Error: {err}")

--- a/tasks/triton2triton/vllm/triton_silu_mul_fp8_quant_dg/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_silu_mul_fp8_quant_dg/scripts/task_runner.py
@@ -15,6 +15,14 @@ TEST_SHAPES = [
     (8, 64, 1024, 128),
     (16, 64, 1024, 128),
 ]
+# (E, T, H, group_size, input_dtype, non_contiguous)
+# Keep performance shapes above unchanged; these additions exercise only correctness.
+CORRECTNESS_CASES = [
+    (*shape, "float16", False) for shape in TEST_SHAPES
+] + [
+    (4, 9, 320, 64, "bfloat16", True),
+    (4, 7, 768, 256, "float16", False),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -43,31 +51,40 @@ def load_module():
     return mod
 
 
-def reference_silu_mul_fp8(y, tokens_per_expert, group_size):
-    """CPU reference: silu(gate) * up with per-group scale."""
+def reference_silu_mul_fp8(y, tokens_per_expert, group_size, fp8_dtype):
+    """CPU reference for the activation, scales, and quantized output."""
     import torch
     E, T, H2 = y.shape
     H = H2 // 2
-    G = H // group_size
-
-    try:
-        fp8_dtype = torch.float8_e4m3fnuz
-        _ = torch.tensor([1.0]).to(fp8_dtype)
-    except (RuntimeError, AttributeError):
-        fp8_dtype = torch.float8_e4m3fn
+    G = (H + group_size - 1) // group_size
 
     fp8_max = torch.finfo(fp8_dtype).max
     results_float = torch.zeros(E, T, H, dtype=torch.float32)
+    results_q = torch.zeros(E, T, H, dtype=fp8_dtype)
+    results_s = torch.zeros(E, T, G, dtype=torch.float32)
 
     for e in range(E):
         nt = tokens_per_expert[e].item()
-        for t in range(nt):
-            gate = y[e, t, :H].float()
-            up = y[e, t, H:].float()
-            silu_gate = gate * torch.sigmoid(gate)
-            results_float[e, t] = silu_gate * up
+        if nt == 0:
+            continue
 
-    return results_float
+        gate = y[e, :nt, :H].float()
+        up = y[e, :nt, H:].float()
+        results_float[e, :nt] = gate * torch.sigmoid(gate) * up
+
+        for g in range(G):
+            start = g * group_size
+            end = min(start + group_size, H)
+            values = results_float[e, :nt, start:end]
+            scale = values.abs().amax(dim=-1).clamp_min(1e-10) / fp8_max
+            results_s[e, :nt, g] = scale
+            results_q[e, :nt, start:end] = torch.clamp(
+                values / scale[:, None],
+                torch.finfo(fp8_dtype).min,
+                fp8_max,
+            ).to(fp8_dtype)
+
+    return results_float, results_q, results_s
 
 
 def run_compile():
@@ -92,33 +109,89 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, (E, T, H, group_size) in enumerate(TEST_SHAPES):
+    try:
+        expected_fp8_dtype = torch.float8_e4m3fnuz
+        _ = torch.tensor([1.0]).to(expected_fp8_dtype)
+    except (RuntimeError, AttributeError):
+        expected_fp8_dtype = torch.float8_e4m3fn
+
+    for i, case in enumerate(CORRECTNESS_CASES):
+        E, T, H, group_size, dtype_name, non_contiguous = case
         try:
             torch.manual_seed(42 + i)
-            y = torch.randn(E, T, 2 * H, device=device, dtype=torch.float16) * 0.5
-            tokens_per_expert = torch.randint(1, T + 1, (E,), device=device, dtype=torch.int32)
+            input_dtype = getattr(torch, dtype_name)
+            if non_contiguous:
+                backing = torch.randn(
+                    T, E, 4 * H, device=device, dtype=input_dtype
+                ) * 0.5
+                y = backing.permute(1, 0, 2)[..., ::2]
+                if y.is_contiguous():
+                    return False, f"Shape {i+1}: input unexpectedly became contiguous"
+            else:
+                y = torch.randn(
+                    E, T, 2 * H, device=device, dtype=input_dtype
+                ) * 0.5
+
+            # Cover no work, the first-token boundary, a late boundary, and T.
+            boundary_counts = torch.tensor(
+                [0, 1, T - 1, T], device=device, dtype=torch.int32
+            )
+            tokens_per_expert = boundary_counts.repeat((E + 3) // 4)[:E]
 
             y_q, y_s = mod.silu_mul_fp8_quant(y, tokens_per_expert, group_size)
             torch.cuda.synchronize()
 
-            ref_float = reference_silu_mul_fp8(y.cpu(), tokens_per_expert.cpu(), group_size)
+            G = (H + group_size - 1) // group_size
+            if y_q.shape != (E, T, H) or y_s.shape != (E, T, G):
+                return False, (
+                    f"Shape {i+1}: output shapes are {tuple(y_q.shape)} and "
+                    f"{tuple(y_s.shape)}, expected {(E, T, H)} and {(E, T, G)}"
+                )
+            if y_q.dtype != expected_fp8_dtype:
+                return False, (
+                    f"Shape {i+1}: quantized dtype is {y_q.dtype}, "
+                    f"expected {expected_fp8_dtype}"
+                )
+            if y_s.dtype != torch.float32:
+                return False, (
+                    f"Shape {i+1}: scale dtype is {y_s.dtype}, "
+                    "expected torch.float32"
+                )
 
-            # Check that dequantized output is close to reference
-            y_q_float = y_q.float()
-            for e in range(E):
-                nt = tokens_per_expert[e].item()
-                if nt == 0:
-                    continue
-                for t in range(min(nt, 4)):  # spot-check
-                    for g in range(H // group_size):
-                        s = y_s[e, t, g].item()
-                        start = g * group_size
-                        end = start + group_size
-                        deq = y_q_float[e, t, start:end].cpu() * s
-                        ref_slice = ref_float[e, t, start:end]
-                        if not torch.allclose(deq, ref_slice, atol=0.5, rtol=0.2):
-                            max_diff = (deq - ref_slice).abs().max().item()
-                            return False, f"Shape {i+1}: e={e},t={t},g={g} max_diff={max_diff:.4f}"
+            ref_float, ref_q, ref_s = reference_silu_mul_fp8(
+                y.cpu(), tokens_per_expert.cpu(), group_size, expected_fp8_dtype
+            )
+            valid_tokens = (
+                torch.arange(T)[None, :] < tokens_per_expert.cpu()[:, None]
+            )
+
+            # Validate both complete outputs over their defined (valid-token) domain.
+            actual_q = y_q.float().cpu()[valid_tokens]
+            expected_q = ref_q.float()[valid_tokens]
+            q_mismatch = actual_q != expected_q
+            if torch.any(q_mismatch):
+                mismatch_count = q_mismatch.sum().item()
+                max_diff = (actual_q - expected_q).abs().max().item()
+                return False, (
+                    f"Shape {i+1}: y_q has {mismatch_count} mismatches "
+                    f"(max_diff={max_diff:.4f})"
+                )
+
+            actual_s = y_s.cpu()[valid_tokens]
+            expected_s = ref_s[valid_tokens]
+            if not torch.allclose(actual_s, expected_s, atol=1e-8, rtol=1e-5):
+                max_diff = (actual_s - expected_s).abs().max().item()
+                return False, f"Shape {i+1}: y_s max_diff={max_diff:.4e}"
+
+            expanded_s = y_s.cpu().repeat_interleave(group_size, dim=-1)[..., :H]
+            deq = y_q.float().cpu() * expanded_s
+            if not torch.allclose(
+                deq[valid_tokens], ref_float[valid_tokens], atol=0.5, rtol=0.2
+            ):
+                max_diff = (
+                    deq[valid_tokens] - ref_float[valid_tokens]
+                ).abs().max().item()
+                return False, f"Shape {i+1}: dequantized output max_diff={max_diff:.4f}"
         except Exception as e:
             return False, f"Shape {i+1}: exception: {e}"
     return True, None
@@ -189,7 +262,7 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(CORRECTNESS_CASES)}
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")

--- a/tasks/triton2triton/vllm/triton_silu_mul_fp8_quant_dg/source/triton_silu_mul_fp8_quant_dg.py
+++ b/tasks/triton2triton/vllm/triton_silu_mul_fp8_quant_dg/source/triton_silu_mul_fp8_quant_dg.py
@@ -46,46 +46,49 @@ def _silu_mul_fp8_quant_deep_gemm(
     Input layout: [..., 2*H] where first H elements are gate, second H are up.
     Output: fp8 quantized y = silu(gate) * up, with per-group scales.
 
-    Grid: (E * G,) where G = H // GROUP_SIZE
-    Each program handles one (expert, group) pair, iterating over tokens.
+    Grid: (G, T, E) where G = H // GROUP_SIZE.
+    Each program handles one (expert, token, group) tuple.  Keeping tokens in
+    the launch grid exposes enough independent wavefronts to occupy the GPU;
+    the former token loop left the MI355X severely under-subscribed.
     """
-    G = H // GROUP_SIZE
+    g = tl.program_id(0)
+    t = tl.program_id(1)
+    e = tl.program_id(2)
 
-    pid = tl.program_id(0)
-    e = pid // G
-    g = pid % G
+    n_tokens = tl.load(counts_ptr + e * stride_counts_e)
 
-    e = e.to(tl.int64)
-    g = g.to(tl.int64)
+    cols = tl.arange(0, BLOCK)
+    mask = (t < n_tokens) & (cols < GROUP_SIZE) & (g * GROUP_SIZE + cols < H)
 
-    n_tokens = tl.load(counts_ptr + e * stride_counts_e).to(tl.int64)
-
-    cols = tl.arange(0, BLOCK).to(tl.int64)
-    mask = cols < BLOCK
-
-    base_input_offset = e * stride_i_e + g * GROUP_SIZE * stride_i_h
+    base_input_offset = (
+        e * stride_i_e + t * stride_i_t + g * GROUP_SIZE * stride_i_h
+    )
     base_gate_offset = base_input_offset + cols * stride_i_h
     base_up_offset = base_input_offset + H * stride_i_h + cols * stride_i_h
-    base_yq_offset = e * stride_yq_e + g * GROUP_SIZE * stride_yq_h + cols * stride_yq_h
-    base_ys_offset = e * stride_ys_e + g * stride_ys_g
+    base_yq_offset = (
+        e * stride_yq_e
+        + t * stride_yq_t
+        + g * GROUP_SIZE * stride_yq_h
+        + cols * stride_yq_h
+    )
+    base_ys_offset = e * stride_ys_e + t * stride_ys_t + g * stride_ys_g
 
-    for t in tl.range(0, n_tokens, num_stages=NUM_STAGES):
-        gate = tl.load(
-            input_ptr + base_gate_offset + t * stride_i_t, mask=mask, other=0.0
-        ).to(tl.float32)
-        up = tl.load(input_ptr + base_up_offset + t * stride_i_t, mask=mask, other=0.0)
+    gate = tl.load(input_ptr + base_gate_offset, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    up = tl.load(input_ptr + base_up_offset, mask=mask, other=0.0)
 
-        gate = gate * (1.0 / (1.0 + tl.exp(-gate)))
-        y = gate * up
+    gate = gate * (1.0 / (1.0 + tl.exp(-gate)))
+    y = gate * up
 
-        y_s = tl.maximum(tl.max(tl.abs(y)), eps) / fp8_max
-        if ceil_ue8m0:
-            y_s = tl.exp2(tl.ceil(tl.log2(y_s)))
+    y_s = tl.maximum(tl.max(tl.abs(y)), eps) / fp8_max
+    if ceil_ue8m0:
+        y_s = tl.exp2(tl.ceil(tl.log2(y_s)))
 
-        y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+    y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
 
-        tl.store(y_q_ptr + base_yq_offset + t * stride_yq_t, y_q, mask=mask)
-        tl.store(y_s_ptr + base_ys_offset + t * stride_ys_t, y_s)
+    tl.store(y_q_ptr + base_yq_offset, y_q, mask=mask)
+    tl.store(y_s_ptr + base_ys_offset, y_s, mask=t < n_tokens)
 
 
 def silu_mul_fp8_quant(
@@ -138,7 +141,7 @@ def silu_mul_fp8_quant(
     stride_i_e, stride_i_t, stride_i_h = y.stride()
     stride_yq_e, stride_yq_t, stride_yq_h = y_q.stride()
 
-    grid = (E * G,)
+    grid = (G, T, E)
     _silu_mul_fp8_quant_deep_gemm[grid](
         y, y_q, y_s, tokens_per_expert,
         H, group_size,
@@ -149,7 +152,7 @@ def silu_mul_fp8_quant(
         eps, fp8_min, fp8_max,
         ceil_ue8m0=False,
         BLOCK=group_size,
-        NUM_STAGES=4,
+        NUM_STAGES=1,
         num_warps=1,
     )
     return y_q, y_s

--- a/tasks/triton2triton/vllm/triton_ssd_chunk_cumsum/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_ssd_chunk_cumsum/scripts/task_runner.py
@@ -15,6 +15,36 @@ TEST_SHAPES = [
     (256, 32, 64, True, True),
     (384, 16, 64, False, False),
 ]
+
+# Correctness-only cases that cover non-uniform chunk masks, non-power-of-two
+# dimensions, clamp limits, lower precision, and non-contiguous strides without
+# changing the performance workload.
+CORRECTNESS_EDGE_CASES = [
+    {
+        "name": "variable_chunks_odd_heads_clamped",
+        "seqlen": 121,
+        "nheads": 7,
+        "chunk_size": 48,
+        "cu_chunk_seqlens": (0, 48, 79, 121),
+        "has_bias": True,
+        "softplus": False,
+        "dt_limit": (0.01, 0.06),
+        "dtype": "float32",
+        "strided": False,
+    },
+    {
+        "name": "short_chunks_strided_float16",
+        "seqlen": 67,
+        "nheads": 5,
+        "chunk_size": 33,
+        "cu_chunk_seqlens": (0, 1, 34, 58, 67),
+        "has_bias": True,
+        "softplus": True,
+        "dt_limit": (0.0, float("inf")),
+        "dtype": "float16",
+        "strided": True,
+    },
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -48,7 +78,7 @@ def ref_softplus(x):
     return torch.where(x <= 20.0, torch.log1p(torch.exp(x)), x)
 
 
-def reference(dt, A, chunk_size, cu, dt_bias, softplus):
+def reference(dt, A, chunk_size, cu, dt_bias, softplus, dt_limit=(0.0, float("inf"))):
     import torch
     seqlen, nheads = dt.shape
     nchunks = len(cu) - 1
@@ -66,10 +96,10 @@ def reference(dt, A, chunk_size, cu, dt_bias, softplus):
                 dt_chunk += dt_bias.cpu().float()[h]
             if softplus:
                 dt_chunk = ref_softplus(dt_chunk)
-            dt_chunk = dt_chunk.clamp(min=0.0)
+            dt_chunk = dt_chunk.clamp(min=dt_limit[0], max=dt_limit[1])
             dt_out[h, c, :clen] = dt_chunk
-            dA = dt_chunk * A_f[h]
-            dA_cumsum[h, c, :clen] = torch.cumsum(dA, 0)
+            dA = dt_out[h, c] * A_f[h]
+            dA_cumsum[h, c] = torch.cumsum(dA, 0)
     return dA_cumsum, dt_out
 
 
@@ -93,26 +123,72 @@ def run_correctness():
     except Exception as e:
         return False, f"Load failed: {e}"
     device = "cuda"
+
+    cases = []
     for i, (seqlen, nheads, chunk_size, has_bias, softplus) in enumerate(TEST_SHAPES):
+        nchunks = seqlen // chunk_size
+        cases.append({
+            "name": f"baseline_{i}",
+            "seqlen": seqlen,
+            "nheads": nheads,
+            "chunk_size": chunk_size,
+            "cu_chunk_seqlens": tuple(j * chunk_size for j in range(nchunks + 1)),
+            "has_bias": has_bias,
+            "softplus": softplus,
+            "dt_limit": (0.0, float("inf")),
+            "dtype": "float32",
+            "strided": False,
+        })
+    cases.extend(CORRECTNESS_EDGE_CASES)
+
+    for i, case in enumerate(cases):
         try:
+            seqlen = case["seqlen"]
+            nheads = case["nheads"]
+            chunk_size = case["chunk_size"]
+            has_bias = case["has_bias"]
+            softplus = case["softplus"]
+            dt_limit = case["dt_limit"]
+            dtype = getattr(torch, case["dtype"])
             torch.manual_seed(42 + i)
-            nchunks = seqlen // chunk_size
-            dt = torch.randn(seqlen, nheads, device=device, dtype=torch.float32) * 0.1
-            A = -torch.rand(nheads, device=device, dtype=torch.float32) * 0.5
-            dt_bias = torch.randn(nheads, device=device, dtype=torch.float32) * 0.01 if has_bias else None
-            cu = torch.arange(0, nchunks + 1, device=device, dtype=torch.int32) * chunk_size
-            dA_cs, dt_out = mod.chunk_cumsum_fwd(dt, A, chunk_size, cu, dt_bias=dt_bias, dt_softplus=softplus)
-            ref_dA, ref_dt = reference(dt, A, chunk_size, cu, dt_bias, softplus)
+            if case["strided"]:
+                dt_storage = torch.randn(
+                    seqlen * 2, nheads * 2, device=device, dtype=dtype
+                ) * 0.1
+                dt = dt_storage[::2, ::2]
+                A_storage = -torch.rand(
+                    nheads * 2, device=device, dtype=torch.float32
+                ) * 0.5
+                A = A_storage[::2]
+                if has_bias:
+                    dt_bias_storage = torch.randn(
+                        nheads * 2, device=device, dtype=torch.float32
+                    ) * 0.01
+                    dt_bias = dt_bias_storage[::2]
+                else:
+                    dt_bias = None
+            else:
+                dt = torch.randn(seqlen, nheads, device=device, dtype=dtype) * 0.1
+                A = -torch.rand(nheads, device=device, dtype=torch.float32) * 0.5
+                dt_bias = torch.randn(nheads, device=device, dtype=torch.float32) * 0.01 if has_bias else None
+            cu = torch.tensor(case["cu_chunk_seqlens"], device=device, dtype=torch.int32)
+            dA_cs, dt_out = mod.chunk_cumsum_fwd(
+                dt, A, chunk_size, cu, dt_bias=dt_bias,
+                dt_softplus=softplus, dt_limit=dt_limit,
+            )
+            ref_dA, ref_dt = reference(
+                dt, A, chunk_size, cu, dt_bias, softplus, dt_limit,
+            )
             ref_dA = ref_dA.to(device)
             ref_dt = ref_dt.to(device)
             if not torch.allclose(dA_cs, ref_dA, atol=1e-3, rtol=1e-3):
                 diff = (dA_cs - ref_dA).abs().max().item()
-                return False, f"Shape {i} dA_cumsum: max diff={diff}"
+                return False, f"{case['name']} dA_cumsum: max diff={diff}"
             if not torch.allclose(dt_out, ref_dt, atol=1e-3, rtol=1e-3):
                 diff = (dt_out - ref_dt).abs().max().item()
-                return False, f"Shape {i} dt_out: max diff={diff}"
+                return False, f"{case['name']} dt_out: max diff={diff}"
         except Exception as e:
-            return False, f"Shape {i}: {e}"
+            return False, f"{case['name']}: {e}"
     return True, None
 
 

--- a/tasks/triton2triton/vllm/triton_update_eagle_inputs/scripts/task_runner.py
+++ b/tasks/triton2triton/vllm/triton_update_eagle_inputs/scripts/task_runner.py
@@ -15,6 +15,12 @@ TEST_SHAPES = [
     (32, 1024, 8192),
     (64, 2048, 8192),
 ]
+CORRECTNESS_CASES = [
+    *((shape, False) for shape in TEST_SHAPES),
+    # Exercise both transitions onto and attempts to advance past the clamp
+    # boundaries. 1536 also covers a masked second block above BLOCK_SIZE.
+    ((4, 1536, 2048), True),
+]
 WARMUP_ITERATIONS = 10
 BENCHMARK_ITERATIONS = 100
 
@@ -43,7 +49,9 @@ def load_module():
     return mod
 
 
-def make_inputs(num_reqs, hidden_size, max_model_len, device="cpu"):
+def make_inputs(
+    num_reqs, hidden_size, max_model_len, device="cpu", boundary_values=False
+):
     import torch
     torch.manual_seed(42)
     draft_tokens = torch.randint(0, 32000, (num_reqs,), dtype=torch.int64)
@@ -52,6 +60,18 @@ def make_inputs(num_reqs, hidden_size, max_model_len, device="cpu"):
     positions = torch.randint(0, max_model_len - 2, (num_reqs,), dtype=torch.int32)
     input_hs = torch.zeros(num_reqs, hidden_size, dtype=torch.float16)
     seq_lens = torch.randint(1, max_model_len - 1, (num_reqs,), dtype=torch.int32)
+
+    if boundary_values:
+        if num_reqs < 4:
+            raise ValueError("boundary cases require at least four requests")
+        positions[:4] = torch.tensor(
+            [max_model_len - 2, max_model_len - 1, 0, max_model_len - 3],
+            dtype=positions.dtype,
+        )
+        seq_lens[:4] = torch.tensor(
+            [max_model_len - 1, max_model_len, 1, max_model_len - 2],
+            dtype=seq_lens.dtype,
+        )
 
     if device != "cpu":
         draft_tokens = draft_tokens.to(device)
@@ -102,10 +122,10 @@ def run_correctness():
         return False, f"Failed to load module: {e}"
 
     device = "cuda"
-    for i, (nr, hs, mml) in enumerate(TEST_SHAPES):
+    for i, ((nr, hs, mml), boundary_values) in enumerate(CORRECTNESS_CASES):
         try:
-            gpu_inputs = make_inputs(nr, hs, mml, device)
-            cpu_inputs = make_inputs(nr, hs, mml, "cpu")
+            gpu_inputs = make_inputs(nr, hs, mml, device, boundary_values)
+            cpu_inputs = make_inputs(nr, hs, mml, "cpu", boundary_values)
 
             mod.update_eagle_inputs(
                 gpu_inputs[0], gpu_inputs[1], gpu_inputs[2],
@@ -198,7 +218,11 @@ def main():
         sys.exit(0 if ok else 1)
     elif args.mode == "correctness":
         ok, err = run_correctness()
-        report = {"status": "ok" if ok else "fail", "error": err, "num_shapes": len(TEST_SHAPES)}
+        report = {
+            "status": "ok" if ok else "fail",
+            "error": err,
+            "num_shapes": len(CORRECTNESS_CASES),
+        }
         with open(os.path.join(build_dir, "correctness_report.json"), "w") as f:
             json.dump(report, f, indent=2)
         print(f"Correctness: {'PASS' if ok else 'FAIL'}")


### PR DESCRIPTION
> **Superseded by [draft PR #105](https://github.com/AMD-AGI/AgentKernelArena/pull/105).** This PR is closed without merging. Review the consolidated robustness changes in #105 instead.

Retains the robustness changes across 18 tasks, including stricter top-k and non-finite logit checks. Restores the original silu_mul_fp8_quant_dg baseline while retaining the expanded harness.

The replacement also fixes quality-loop artifact filtering and commit-time checks to prevent recurrence. Its description records the curation decisions, historical MI355X run evidence, local CPU tests, and the lack of a fresh GPU run for the consolidated head. Generated experiment artifacts remain outside Git.

---

## Summary

- Audited tasks: 42
- Accepted task changes: 18
- Validator warnings recorded: 69
- Unresolved validation failures: 1
- Optimizer: Codex, exactly one iteration per task
- Easy-task threshold: reproducible 5.0x

## Changed tasks

- `triton2triton/geak_eval/L1/refk_fp8_blockwise_mm`
- `triton2triton/geak_eval/L2/topk`
- `triton2triton/geak_eval/L3/fused_qkv_rope`
- `triton2triton/rocmbench/hard/triton_multreduce_matmul_kernel`
- `triton2triton/vllm/triton_apply_write`
- `triton2triton/vllm/triton_compute_identity`
- `triton2triton/vllm/triton_decode_attn_stage2`
- `triton2triton/vllm/triton_ep_scatter_1`
- `triton2triton/vllm/triton_fused_moe_lora`
- `triton2triton/vllm/triton_logit_bias`
- `triton2triton/vllm/triton_pack_bitmatrix`
- `triton2triton/vllm/triton_penalties`
- `triton2triton/vllm/triton_prepare_mrope_positions`
- `triton2triton/vllm/triton_ranks`
- `triton2triton/vllm/triton_sample_recovered_tokens`
- `triton2triton/vllm/triton_silu_mul_fp8_quant_dg`
- `triton2triton/vllm/triton_ssd_chunk_cumsum`
- `triton2triton/vllm/triton_update_eagle_inputs`

## Unresolved validation failures

- `triton2triton/vllm/triton_kda_recompute_wu`

The full machine-readable report is stored in the local run artifact
`quality_loop_runs/20260909_ql_triton_s0/audit_report.yaml`. Every promoted baseline and case change passed the fail-closed
dual correctness gate against the pre-audit kernel.
